### PR TITLE
Appimage wrapper

### DIFF
--- a/data/moolticute.desktop
+++ b/data/moolticute.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name=Moolticute
 Comment=Start Moolticute daemon and App
 Exec=/usr/bin/moolticute
 Icon=moolticute
 Terminal=false
-Categories=Utility
+Categories=Utility;

--- a/data/moolticute.sh
+++ b/data/moolticute.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
-
+##
+# Wrapper for the moolticute AppImage
+##
 me="Moolticute.AppImage"
+UDEV_RULES_FILE_PATH="/etc/udev/rules.d/50-mooltipass.rules"
+
 help_msg="Moolticute for linux
 Usage:
 $me <arg>
 
 Arguments:
--d --daemon        Runs daemon only mode.
--i --install       Install moolticute as a systemd service
--u --uninstall     Uninstall moolticute as a systemd service
--h --help          This help
+-d --daemon         Runs daemon only mode.
+-i --install        Install moolticute UDev rules
+-c --check          Check moolticute UDev rules
+-u --uninstall      Uninstall moolticute UDev rules
+-h --help           This help
 
 Example:
 Run Moolticute normaly
@@ -22,6 +27,7 @@ Run only the moolticuted daemon
 DAEMON_ONLY=0
 INSTALL=0
 UNINSTALL=0
+CHECK=0
 
 
 case "$1" in
@@ -31,6 +37,10 @@ case "$1" in
         ;;
     -i|--install)
         INSTALL=1
+        shift
+    ;;
+        -c|--check)
+        CHECK=1
         shift
     ;;
     -u|--uninstall)
@@ -52,13 +62,23 @@ if (( $DAEMON_ONLY == 1 )) ;
 then
     echo "Running daemon only"
     moolticuted
-elif (( $INSTALL == 0 )) && (( $UNINSTALL == 0 ));
+elif (( $INSTALL == 0 )) && (( $UNINSTALL == 0 )) && (( $CHECK == 0 ));
 then
     moolticute
 elif (( $INSTALL == 1 ));
 then
-    echo "Installing moolticuted as service"
+    echo "Installing moolticute UDEV rules"
+elif (( $CHECK == 1 ));
+then
+    if [ -s $UDEV_RULES_FILE_PATH ];
+    then
+        echo "Moolticute Udev rules are NOT installed."
+        exit 1;
+    else
+        echo "Moolticute Udev rules are installed."
+        exit 0;
+    fi
 elif (( $UNINSTALL == 1 ));
 then
-    echo "Uninstalling moolticuted as service"
+    echo "Uninstalling moolticuted UDEV rules"
 fi

--- a/data/moolticute.sh
+++ b/data/moolticute.sh
@@ -68,6 +68,8 @@ then
 elif (( $INSTALL == 1 ));
 then
     echo "Installing moolticute UDEV rules"
+    echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", SYMLINK+="mooltipass" TAG+="uaccess", TAG+="udev-acl"' | sudo tee /etc/udev/rules.d/50-mooltipass.rules
+    sudo udevadm control --reload-rules
 elif (( $CHECK == 1 ));
 then
     if [ -s $UDEV_RULES_FILE_PATH ];
@@ -81,4 +83,6 @@ then
 elif (( $UNINSTALL == 1 ));
 then
     echo "Uninstalling moolticuted UDEV rules"
+    sudo rm /etc/udev/rules.d/50-mooltipass.rules
+    sudo udevadm control --reload-rules
 fi

--- a/data/moolticute.sh
+++ b/data/moolticute.sh
@@ -26,7 +26,7 @@ Run only the moolticuted daemon
 ./$me --daemon
 ";
 
-SUDO_MSG="Allow Mooltipas Udev rules to be applied in your system?"
+SUDO_MSG="Allow Mooltipass Udev rules to be applied in your system?"
 
 DAEMON_ONLY=0
 INSTALL=0

--- a/data/moolticute.sh
+++ b/data/moolticute.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+me="Moolticute.AppImage"
+help_msg="Moolticute for linux
+Usage:
+$me <arg>
+
+Arguments:
+-d --daemon        Runs daemon only mode.
+-i --install       Install moolticute as a systemd service
+-u --uninstall     Uninstall moolticute as a systemd service
+-h --help          This help
+
+Example:
+Run Moolticute normaly
+./$me
+
+Run only the moolticuted daemon
+./$me --daemon
+";
+
+DAEMON_ONLY=0
+INSTALL=0
+UNINSTALL=0
+
+
+case "$1" in
+    -d|--daemon)
+        DAEMON_ONLY=1
+        shift
+        ;;
+    -i|--install)
+        INSTALL=1
+        shift
+    ;;
+    -u|--uninstall)
+        UNINSTALL=1
+        shift
+    ;;
+    -h|-\?|--help)
+        printf "$help_msg"
+        exit
+    ;;
+    -?*)
+        printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+        exit 1
+    ;;
+
+esac
+
+if (( $DAEMON_ONLY == 1 )) ;
+then
+    echo "Running daemon only"
+    moolticuted
+elif (( $INSTALL == 0 )) && (( $UNINSTALL == 0 ));
+then
+    moolticute
+elif (( $INSTALL == 1 ));
+then
+    echo "Installing moolticuted as service"
+elif (( $UNINSTALL == 1 ));
+then
+    echo "Uninstalling moolticuted as service"
+fi

--- a/scripts/ci/linux/appimage.sh
+++ b/scripts/ci/linux/appimage.sh
@@ -28,20 +28,12 @@ source $SCRIPTDIR/../funcs.sh
 ########################################################################
 cp ./debian/moolticute/usr/* $TARGET_DIR -r
 
-########################################################################
-# Generate .desketop file and icon
-########################################################################
-
-echo "[Desktop Entry]
-Version=1.0
-Type=Application
-Name=Moolticute
-Comment=Moolticute allows your browser extensions to talk with the Mooltipass.
-TryExec=moolticute
-Exec=moolticute %F
-Icon=moolticute" > $BASE_PATH/$APP/$APP.AppDir/moolticute.desktop
-
+cp ./data/moolticute.desktop $BASE_PATH/$APP/$APP.AppDir
 cp ./img/AppIcon.svg $BASE_PATH/$APP/$APP.AppDir/moolticute.svg
+cp ./data/moolticute.sh $BASE_PATH/$APP/$APP.AppDir/usr/bin/
+
+# Use the wrapper instead of the 
+sed -i 's/Exec=\/usr\/bin\/moolticute/Exec=moolticute.sh/g' /$BASE_PATH/$APP/$APP.AppDir/moolticute.desktop 
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up


### PR DESCRIPTION
Add a wrapper script to install Udev rules if they don't exists.
Also allows uninstall, check rules, and run as daemon.
