### PR TITLE
Hide backup import and export messages 

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -31,7 +31,8 @@ DbBackupsTrackerController::DbBackupsTrackerController(MainWindow *window, WSCli
 
 void DbBackupsTrackerController::setBackupFilePath(const QString &path)
 {
-    window->hidePrompt();
+    hideExportRequestIfVisible();
+    hideExportImportIfVisible();
     try
     {
         dbBackupsTracker.track(path);
@@ -153,7 +154,7 @@ void DbBackupsTrackerController::writeDbBackup(QString file, const QByteArray& d
 }
 
 void DbBackupsTrackerController::clearTrackerCardInfo()
- {
+{
     dbBackupsTracker.setCardId("");
     dbBackupsTracker.setDataDbChangeNumber(0);
     dbBackupsTracker.setCredentialsDbChangeNumber(0);
@@ -180,17 +181,8 @@ void DbBackupsTrackerController::handleNewTrack(const QString &cardId, const QSt
     QString currentCardId = dbBackupsTracker.getCardId();
     if (currentCardId.compare(cardId) == 0)
         emit backupFilePathChanged(path);
-
-    hideExportRequestIfVisible();
-    hideExportImportIfVisible();
-}
-
-void DbBackupsTrackerController::handleDeviceConnectedChanged(const bool &)
-{
-    clearTrackerCardInfo();
-
-    hideExportRequestIfVisible();
-    hideExportImportIfVisible();
+    else
+        emit backupFilePathChanged(QString());
 }
 
 void DbBackupsTrackerController::handleDeviceStatusChanged(const Common::MPStatus &status)
@@ -202,6 +194,14 @@ void DbBackupsTrackerController::handleDeviceStatusChanged(const Common::MPStatu
         hideExportRequestIfVisible();
         hideExportImportIfVisible();
     }
+}
+
+void DbBackupsTrackerController::handleDeviceConnectedChanged(const bool &)
+{
+    clearTrackerCardInfo();
+
+    hideExportRequestIfVisible();
+    hideExportImportIfVisible();
 }
 
 void DbBackupsTrackerController::hideExportRequestIfVisible()

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -102,7 +102,11 @@ void DbBackupsTrackerController::handleGreaterDbBackupChangeNumber()
 
 void DbBackupsTrackerController::askForExportBackup()
 {
-    std::function<void()> onAccept = [this]() { exportDbBackup(); };
+    std::function<void()> onAccept = [this]()
+    {
+        exportDbBackup();
+        isExportRequestMessageVisible = false;
+    };
 
     std::function<void()> onReject = [this]()
     {
@@ -110,14 +114,19 @@ void DbBackupsTrackerController::askForExportBackup()
                     window, tr("Be careful"),
                     tr("By denying you can loose your changes. Do you want to continue?"),
                     QMessageBox::Yes | QMessageBox::No);
+
         if (btn == QMessageBox::Yes)
+        {
             window->hidePrompt();
+            isExportRequestMessageVisible = false;
+        }
     };
 
     PromptMessage *message = new PromptMessage(tr("Credentials on the device are more recent. "
                                                   "Do you want export credentials to backup file?"),
                                                onAccept, onReject);
     window->showPrompt(message);
+    isExportRequestMessageVisible = true;
 }
 
 void DbBackupsTrackerController::exportDbBackup()

--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -8,6 +8,7 @@
 
 class WSClient;
 class MainWindow;
+class QMessageBox;
 
 class DbBackupsTrackerController : public QObject
 {
@@ -32,18 +33,25 @@ protected slots:
     void handleExportDbResult(const QByteArray &d, bool success);
     void handleNewTrack(const QString &cardId, const QString &path);
     void handleDeviceStatusChanged(const Common::MPStatus &status);
+    void handleDeviceConnectedChanged(const bool &connected);
+
 
 private:
     DbBackupsTracker dbBackupsTracker;
     MainWindow *window;
     WSClient *wsClient;
+    bool isExportRequestMessageVisible;
+    QMessageBox *askImportMessage;
 
     void askForImportBackup();
     void askForExportBackup();
+    void hideExportRequestIfVisible();
+    void hideExportImportIfVisible();
     QString readDbBackupFile();
     void importDbBackup(QString data);
     void exportDbBackup();
     void writeDbBackup(QString file, const QByteArray &d);
+    void clearTrackerCardInfo();
 };
 
 #endif // DBBACKUPSTRACKERCONTROLLER_H


### PR DESCRIPTION
Hide import and export messages when:
 - the device is disconnected, 
 - the card is removed or
 - the current db backup file being track is changed.