### PR TITLE
db backups traking  only in firmwares equal or greater than 1.2

### DIFF
--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -34,6 +34,7 @@ protected slots:
     void handleNewTrack(const QString &cardId, const QString &path);
     void handleDeviceStatusChanged(const Common::MPStatus &status);
     void handleDeviceConnectedChanged(const bool &connected);
+    void handleFirmwareVersionChange(const QString &version);
 
 
 private:
@@ -52,6 +53,8 @@ private:
     void exportDbBackup();
     void writeDbBackup(QString file, const QByteArray &d);
     void clearTrackerCardInfo();
+    void connectDbBackupsTracker();
+    void disconnectDbBackupsTracker();
 };
 
 #endif // DBBACKUPSTRACKERCONTROLLER_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -41,6 +41,7 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
     wsClient(client),
     bSSHKeyTabVisible(false),
     bAdvancedTabVisible(false),
+    dbBackupTrakingControlsVisible(false),
     previousWidget(nullptr),
     m_passwordProfilesModel(new PasswordProfilesModel(this)),
     dbBackupsTrackerController(this, client, this)
@@ -495,6 +496,15 @@ void MainWindow::changeEvent(QEvent *event)
     QMainWindow::changeEvent(event);
 }
 
+void MainWindow::updateBackupControlsVisibility()
+{
+    ui->label_backupControlsTitle->setVisible(dbBackupTrakingControlsVisible);
+    ui->label_backupControlsDescription->setVisible(dbBackupTrakingControlsVisible);
+    ui->lineEdit_dbBackupFilePath->setVisible(dbBackupTrakingControlsVisible);
+    ui->toolButton_clearBackupFilePath->setVisible(dbBackupTrakingControlsVisible);
+    ui->toolButton_setBackupFilePath->setVisible(dbBackupTrakingControlsVisible);
+}
+
 void MainWindow::updatePage()
 {
     bool isCardUnknown = wsClient->get_status() == Common::UnkownSmartcad;
@@ -551,6 +561,7 @@ void MainWindow::updatePage()
         ui->stackedWidget->setCurrentWidget(ui->pageSSH);
 
     updateTabButtons();
+    updateBackupControlsVisibility();
 }
 
 void MainWindow::enableKnockSettings(bool enable)
@@ -868,6 +879,11 @@ void MainWindow::showPrompt(PromptMessage * message)
 void MainWindow::hidePrompt()
 {
     ui->promptWidget->hide();
+}
+
+void MainWindow::showDbBackTrackingControls(const bool &show)
+{
+    dbBackupTrakingControlsVisible = show;
 }
 
 void MainWindow::wantExitFilesManagement()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -44,6 +44,8 @@ public:
 
     bool isHttpDebugChecked();
 
+    void updateBackupControlsVisibility();
+
 signals:
     void windowCloseRequested();
 
@@ -54,6 +56,7 @@ public slots:
     void handleBackupImported();
     void showPrompt(PromptMessage * message);
     void hidePrompt();
+    void showDbBackTrackingControls(const bool &show);
 
 private slots:
     void enableCredentialsManagement(bool enable);
@@ -119,7 +122,7 @@ private:
 
     void retranslateUi();
 
-    Ui::MainWindow *ui;
+    Ui::MainWindow *ui = NULL;
     QtAwesome* awesome;
 
     WSClient *wsClient;
@@ -133,6 +136,7 @@ private:
     bool bSSHKeyTabVisible;
     bool bAdvancedTabVisible;
     bool bSSHKeysTabVisibleOnDemand;
+    bool dbBackupTrakingControlsVisible;
 
     QShortcut *m_FilesAndSSHKeysTabsShortcut;
     QShortcut *m_advancedTabShortcut;

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1382,12 +1382,12 @@ QWidget {background-color: #EFEFEF;}</string>
            </widget>
           </item>
           <item row="3" column="0">
-           <layout class="QVBoxLayout" name="verticalLayout_27" stretch="0,0,0">
+           <layout class="QVBoxLayout" name="verticalLayout_backupControls" stretch="0,0,0">
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
             <item>
-             <widget class="QLabel" name="label_10">
+             <widget class="QLabel" name="label_backupControlsTitle">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -1407,7 +1407,7 @@ QWidget {background-color: #EFEFEF;}</string>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_11">
+             <widget class="QLabel" name="label_backupControlsDescription">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                 <horstretch>0</horstretch>


### PR DESCRIPTION
Backups tracking controls are hidden for devices with firmwares lower that "1.2"
An alphanumeric comparison is performed as the version number is an string.

Please check
