### PR TITLE
Correct minimum firmware version number to show the import dialog.

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -235,7 +235,7 @@ void DbBackupsTrackerController::handleDeviceConnectedChanged(const bool &)
 
 void DbBackupsTrackerController::handleFirmwareVersionChange(const QString &version)
 {
-    if (version >= "1.2")
+    if (version >= "v1.2")
     {
         window->showDbBackTrackingControls(true);
         connectDbBackupsTracker();


### PR DESCRIPTION
Fix #160
there was an error in the version number that i was using as base to show the import dialog.
The "v" was missing.
Please notice that this is a lexicographical comparison.