### PR TITLE
Hide previous import backup message before showing a new one.

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -52,7 +52,7 @@ DbBackupsTrackerController::DbBackupsTrackerController(MainWindow *window, WSCli
 void DbBackupsTrackerController::setBackupFilePath(const QString &path)
 {
     hideExportRequestIfVisible();
-    hideExportImportIfVisible();
+    hideImportRequestIfVisible();
     try
     {
         dbBackupsTracker.track(path);
@@ -117,6 +117,8 @@ void DbBackupsTrackerController::importDbBackup(QString data)
 
 void DbBackupsTrackerController::handleGreaterDbBackupChangeNumber()
 {
+    hideExportRequestIfVisible();
+    hideImportRequestIfVisible();
     askForImportBackup();
 }
 
@@ -171,6 +173,8 @@ void DbBackupsTrackerController::exportDbBackup()
 
 void DbBackupsTrackerController::handleLowerDbBackupChangeNumber()
 {
+    hideImportRequestIfVisible();
+    hideExportRequestIfVisible();
     askForExportBackup();
 }
 
@@ -221,7 +225,7 @@ void DbBackupsTrackerController::handleDeviceStatusChanged(const Common::MPStatu
         clearTrackerCardInfo();
 
         hideExportRequestIfVisible();
-        hideExportImportIfVisible();
+        hideImportRequestIfVisible();
     }
 }
 
@@ -230,7 +234,7 @@ void DbBackupsTrackerController::handleDeviceConnectedChanged(const bool &)
     clearTrackerCardInfo();
 
     hideExportRequestIfVisible();
-    hideExportImportIfVisible();
+    hideImportRequestIfVisible();
 }
 
 void DbBackupsTrackerController::handleFirmwareVersionChange(const QString &version)
@@ -256,7 +260,7 @@ void DbBackupsTrackerController::hideExportRequestIfVisible()
     }
 }
 
-void DbBackupsTrackerController::hideExportImportIfVisible()
+void DbBackupsTrackerController::hideImportRequestIfVisible()
 {
     if (askImportMessage != nullptr)
         askImportMessage->reject();

--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -47,7 +47,7 @@ private:
     void askForImportBackup();
     void askForExportBackup();
     void hideExportRequestIfVisible();
-    void hideExportImportIfVisible();
+    void hideImportRequestIfVisible();
     QString readDbBackupFile();
     void importDbBackup(QString data);
     void exportDbBackup();


### PR DESCRIPTION
fix #166

The requests are shown every time a change is made credentials change numbers.