### PR TITLE
Hide Generate MooltiApp Compatible File checkbox for unknown cards.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -513,6 +513,7 @@ void MainWindow::updatePage()
 
     ui->label_13->setVisible(!isCardUnknown);
     ui->label_14->setVisible(!isCardUnknown);
+    ui->checkBoxExport->setVisible(!isCardUnknown);
     ui->pushButtonExportFile->setVisible(!isCardUnknown);
 
     ui->label_27->setVisible(!isCardUnknown);


### PR DESCRIPTION
Fix #175 