### PR TITLE
fix for problem with sizeof(MPCmd::Command) #192

### DIFF
--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -40,7 +40,7 @@ class MPCmd: public QObject
     Q_OBJECT
 public:
 
-    enum Command
+    enum Command: unsigned char
     {
         EXPORT_FLASH_START    = 0x8A,
         EXPORT_FLASH          = 0x8B,


### PR DESCRIPTION
Fix for the issue #192 