### PR TITLE
Use the appimage executable path for creating the autostart file when…

### DIFF
--- a/Moolticute.pro
+++ b/Moolticute.pro
@@ -1,7 +1,6 @@
 TEMPLATE = subdirs
 SUBDIRS = daemon gui \
     tests
-
 daemon.file = daemon.pro
 gui.file = gui.pro
 

--- a/src/AutoStartup.cpp
+++ b/src/AutoStartup.cpp
@@ -43,6 +43,10 @@ void AutoStartup::enableAutoStartup(bool en)
         settings.sync();
     }
 #elif defined(Q_OS_LINUX)
+    QString applicationFilePath = qgetenv("APPIMAGE");
+    if (applicationFilePath.isEmpty())
+        applicationFilePath= qApp->applicationFilePath();
+
     QString desktopFile = QString("[Desktop Entry]\n"
                                           "Name=Moolticute\n"
                                           "Comment=Mooltipass companion\n"
@@ -52,7 +56,7 @@ void AutoStartup::enableAutoStartup(bool en)
                                           "Hidden=false\n"
                                           "NoDisplay=false\n"
                                           "X-GNOME-Autostart-enabled=true\n")
-                                  .arg(qApp->applicationFilePath());
+                                  .arg(applicationFilePath);
 
     QString autostartLocation;
     char *xgdConfigHome = getenv("XDG_CONFIG_HOME");


### PR DESCRIPTION
… the application is packed as an appimage.
issue #149 