### PR TITLE
Issue 199

### DIFF
--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -3,6 +3,7 @@
 #include <QJsonObject>
 #include <QColor>
 #include <QFont>
+#include <QApplication>
 
 // Application
 #include "CredentialModel.h"
@@ -10,7 +11,6 @@
 #include "ServiceItem.h"
 #include "LoginItem.h"
 #include "TreeItem.h"
-#include "AppGui.h"
 
 CredentialModel::CredentialModel(QObject *parent) : QAbstractItemModel(parent)
 {
@@ -67,9 +67,7 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
 
     if (role == Qt::DecorationRole) {
         if (pLoginItem != nullptr)
-            return AppGui::qtAwesome()->icon(fa::arrowcircleright, {{ "color", QColor("#0097a7") },
-                                                                    { "color-selected", QColor("#0097a7") },
-                                                                    { "color-active", QColor("#0097a7") }});
+            return loginItemIcon;
     }
 
     return QVariant();
@@ -249,6 +247,11 @@ LoginItem *CredentialModel::getLoginItemByIndex(const QModelIndex &idx) const
 ServiceItem *CredentialModel::getServiceItemByIndex(const QModelIndex &idx) const
 {
     return dynamic_cast<ServiceItem *>(getItemByIndex(idx));
+}
+
+void CredentialModel::setLoginItemIcon(const QIcon &icon)
+{
+    loginItemIcon = icon;
 }
 
 void CredentialModel::updateLoginItem(const QModelIndex &idx, const QString &sPassword, const QString &sDescription, const QString &sName)

--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -6,6 +6,7 @@
 #include <QJsonArray>
 #include <QDate>
 #include <QTimer>
+#include <QIcon>
 
 // Application
 #include "Common.h"
@@ -50,11 +51,13 @@ public:
     LoginItem *getLoginItemByIndex(const QModelIndex &idx) const;
     ServiceItem *getServiceItemByIndex(const QModelIndex &idx) const;
 
+    void setLoginItemIcon(const QIcon &icon);
 private:
     ServiceItem *addService(const QString &sServiceName);
 
 private:
     RootItem *m_pRootItem;
+    QIcon loginItemIcon;
 
 signals:
     void modelLoaded(bool bClearLoginDescription);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -70,6 +70,11 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->pushButtonFavorite->setMenu(&m_favMenu);
 
     m_pCredModel = new CredentialModel(this);
+    const QIcon i = AppGui::qtAwesome()->icon(fa::arrowcircleright, {{ "color", QColor("#0097a7") },
+                                                                     { "color-selected", QColor("#0097a7") },
+                                                                     { "color-active", QColor("#0097a7") }});
+    m_pCredModel->setLoginItemIcon(i);
+
     m_pCredModelFilter = new CredentialModelFilter(this);
     m_pCredModelFilter->setSourceModel(m_pCredModel);
     ui->credentialTreeView->setModel(m_pCredModelFilter);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -92,6 +92,7 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     connect(ui->credDisplayPasswordInput, &LockedPasswordLineEdit::unlockRequested, this, &CredentialsManagement::requestPasswordForSelectedItem);
     connect(ui->pushButtonConfirm, &QPushButton::clicked, [this](bool)
     {
+        // Save selected credential
         saveSelectedCredential();
     });
 
@@ -193,9 +194,8 @@ void CredentialsManagement::onButtonDiscard_confirmed()
 
 void CredentialsManagement::on_buttonSaveChanges_clicked()
 {
-    saveSelectedCredential({});
+    saveSelectedCredential();
 
-    qDebug() << m_pCredModel->getJsonChanges();
     wsClient->sendCredentialsMM(m_pCredModel->getJsonChanges());
     emit wantSaveMemMode(); //waits for the daemon to process the data
     m_pCredModel->clear();
@@ -293,20 +293,9 @@ void CredentialsManagement::onCredentialUpdated(const QString & service, const Q
     }
 }
 
-void CredentialsManagement::saveSelectedCredential(const QModelIndex &proxyIndex)
+void CredentialsManagement::saveCredential(const QModelIndex currentSelectionIndex)
 {
-    // Retrieve selection model
-    QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
-
-    // Retrieve src index
-    QModelIndex srcIndex = getSourceIndexFromProxyIndex(proxyIndex);
-    if (!srcIndex.isValid())
-    {
-        QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-        if (lIndexes.size() != 1)
-            return;
-        srcIndex = getSourceIndexFromProxyIndex(lIndexes.first());
-    }
+    QModelIndex srcIndex = getSourceIndexFromProxyIndex(currentSelectionIndex);
 
     // Do we have a login item?
     LoginItem *pLoginItem = m_pCredModel->getLoginItemByIndex(srcIndex);
@@ -314,6 +303,15 @@ void CredentialsManagement::saveSelectedCredential(const QModelIndex &proxyIndex
         m_pCredModel->updateLoginItem(srcIndex, ui->credDisplayPasswordInput->text(), ui->credDisplayDescriptionInput->text(), ui->credDisplayLoginInput->text());
         ui->credentialTreeView->refreshLoginItem(srcIndex);
     }
+}
+
+void CredentialsManagement::saveSelectedCredential()
+{
+    const QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
+    const QModelIndex currentSelectionIndex = pSelectionModel->currentIndex();
+
+    if (currentSelectionIndex.isValid())
+        saveCredential(currentSelectionIndex);
 }
 
 bool CredentialsManagement::confirmDiscardUneditedCredentialChanges(const QModelIndex &proxyIndex)
@@ -364,7 +362,7 @@ bool CredentialsManagement::confirmDiscardUneditedCredentialChanges(const QModel
                     return true;
                 if (btn == QMessageBox::Save)
                 {
-                    saveSelectedCredential(proxyIndex);
+                    saveCredential(proxyIndex);
                     return true;
                 }
             }
@@ -376,16 +374,7 @@ bool CredentialsManagement::confirmDiscardUneditedCredentialChanges(const QModel
 
 void CredentialsManagement::on_pushButtonConfirm_clicked()
 {
-    // Retrieve selection model
-    QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
-    QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-    if (lIndexes.size() != 1)
-        return;
-
-    // Save selected credential
-    saveSelectedCredential(lIndexes.first());
-
-    // Update save discard state
+    saveSelectedCredential();
     updateSaveDiscardState();
 }
 
@@ -511,11 +500,6 @@ void CredentialsManagement::on_pushButtonDelete_clicked()
     TreeItem *pParentItem = pLoginItem->parentItem();
     if ((pLoginItem != nullptr) && (pParentItem != nullptr))
     {
-        // Get service index
-        QModelIndex serviceIndex = m_pCredModel->getServiceIndexByName(pLoginItem->parentItem()->name());
-        QModelIndex serviceProxyIndex = m_pCredModelFilter->mapFromSource(serviceIndex);
-        int iServiceRow = serviceProxyIndex.row();
-
         // Retrieve parent item
         auto btn = QMessageBox::question(this,
                                          tr("Delete?"),
@@ -525,33 +509,17 @@ void CredentialsManagement::on_pushButtonDelete_clicked()
                                          QMessageBox::Yes);
         if (btn == QMessageBox::Yes)
         {
-            m_selectionCanceled = true;
-            ui->credDisplayPasswordInput->setText("");
-            ui->credDisplayDescriptionInput->setText("");
-            ui->credDisplayLoginInput->setText("");
+            ui->credDisplayFrame->setEnabled(false);
+            clearLoginDescription();
 
-            bool bSelectNextAvailableLogin = m_pCredModel->removeCredential(srcIndex);
-            if (bSelectNextAvailableLogin)
-            {
-                int nVisibleChilds = m_pCredModelFilter->rowCount(QModelIndex());
-                if (nVisibleChilds > 0)
-                {
-                    if (iServiceRow > (nVisibleChilds-1))
-                        iServiceRow = nVisibleChilds-1;
-                    serviceIndex = m_pCredModelFilter->index(iServiceRow, 0, QModelIndex());
-
-                    QModelIndex firstLoginIndex = serviceIndex.child(0, 0);
-                    if (firstLoginIndex.isValid())
-                        ui->credentialTreeView->setCurrentIndex(firstLoginIndex);
-                }
-            }
+            m_pCredModel->removeCredential(srcIndex);
         }
     }
 }
 
-void CredentialsManagement::onCredentialSelected(const QModelIndex &proxyIndex, const QModelIndex &previous)
+void CredentialsManagement::onCredentialSelected(const QModelIndex &current, const QModelIndex &previous)
 {
-    if (m_selectionCanceled || !previous.isValid() || proxyIndex == previous)
+    if (m_selectionCanceled || !previous.isValid() || current == previous)
     {
         m_selectionCanceled = false;
         return;
@@ -565,18 +533,23 @@ void CredentialsManagement::onCredentialSelected(const QModelIndex &proxyIndex, 
         return;
     }
 
-    QModelIndex srcIndex = getSourceIndexFromProxyIndex(proxyIndex);
-    if (srcIndex.isValid())
+    // Don't trust in the "current" value it's wrong when a sourceModel item is deleted.
+    const QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
+    const QModelIndex realCurrent = pSelectionModel->currentIndex();
+
+    if (realCurrent.isValid())
     {
-        ServiceItem *pServiceItem = m_pCredModel->getServiceItemByIndex(srcIndex);
-        LoginItem *pLoginItem = m_pCredModel->getLoginItemByIndex(srcIndex);
+        auto sourceIndex = getSourceIndexFromProxyIndex(realCurrent);
+        auto pLoginItem  = m_pCredModel->getLoginItemByIndex(sourceIndex);
+        auto pServiceItem = m_pCredModel->getServiceItemByIndex(sourceIndex);
         if (pLoginItem != nullptr)
-            emit loginSelected(srcIndex);
+            emit loginSelected(sourceIndex);
         else
-        if (pServiceItem != nullptr)
-            emit serviceSelected(srcIndex);
-        updateSaveDiscardState(proxyIndex);
+            if (pServiceItem != nullptr)
+                emit serviceSelected(sourceIndex);
+        updateSaveDiscardState(realCurrent);
     }
+
 }
 
 void CredentialsManagement::onLoginSelected(const QModelIndex &srcIndex)

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -53,7 +53,7 @@ private slots:
     void updateSaveDiscardState(const QModelIndex &proxyIndex=QModelIndex());
     void onPasswordUnlocked(const QString &service, const QString &login, const QString &password, bool success);
     void onCredentialUpdated(const QString &service, const QString &login, const QString &description, bool success);
-    void saveSelectedCredential(const QModelIndex &proxyIndex=QModelIndex());
+    void saveSelectedCredential();
     void on_pushButtonEnterMMM_clicked();
     void on_buttonDiscard_pressed();
     void onButtonDiscard_confirmed();
@@ -95,6 +95,8 @@ private:
     QMenu m_favMenu;
     QJsonArray m_loadedModelSerialiation;
     bool m_selectionCanceled;
+
+    void saveCredential(const QModelIndex currentSelectionIndex);
 
 signals:
     void wantEnterMemMode();

--- a/tests/FilesCacheTests.cpp
+++ b/tests/FilesCacheTests.cpp
@@ -1,4 +1,5 @@
 #include "FilesCacheTests.h"
+#include "../src/TreeItem.h"
 
 FilesCacheTests::FilesCacheTests()
 {

--- a/tests/TestCredentialModel.cpp
+++ b/tests/TestCredentialModel.cpp
@@ -10,31 +10,36 @@ TestCredentialModel::TestCredentialModel(QObject *parent) : QObject(parent)
 
 }
 
+CredentialModel *TestCredentialModel::createCredentialModelWithThreeLogins()
+{
+    CredentialModel *model = new CredentialModel();
+    QJsonArray array = QJsonDocument::fromJson(emptyLoginTestJson).array();
+    model->load(array);
+
+    return model;
+}
+
 void TestCredentialModel::noChanges()
 {
-    CredentialModel model(this);
-    QJsonArray array = QJsonDocument::fromJson(emptyLoginTestJson).array();
-    model.load(array);
+    CredentialModel *model = createCredentialModelWithThreeLogins();
 
-    Q_ASSERT(model.rowCount());
-    Q_ASSERT(!model.getJsonChanges().isEmpty());
+    Q_ASSERT(model->rowCount());
+    Q_ASSERT(!model->getJsonChanges().isEmpty());
 }
 
 void TestCredentialModel::oneCredentialRemoved()
 {
-    CredentialModel model(this);
-    QJsonArray array = QJsonDocument::fromJson(emptyLoginTestJson).array();
-    model.load(array);
+    CredentialModel *model = createCredentialModelWithThreeLogins();
 
     QString loginName = "";
     QString serviceName = "service.io";
 
-    QModelIndex requiredIdx = findLoginIndex(loginName, serviceName, &model);
+    QModelIndex requiredIdx = findLoginIndex(loginName, serviceName, model);
     Q_ASSERT(requiredIdx.isValid());
 
-    model.removeCredential(requiredIdx);
+    model->removeCredential(requiredIdx);
 
-    QJsonArray result = model.getJsonChanges();
+    QJsonArray result = model->getJsonChanges();
     Q_ASSERT(result.count() == 2);
 
     QJsonObject l1 = result.at(0).toObject();

--- a/tests/TestCredentialModel.cpp
+++ b/tests/TestCredentialModel.cpp
@@ -1,0 +1,68 @@
+#include "TestCredentialModel.h"
+
+#include <QJsonDocument>
+#include <QJsonArray>
+
+#include "../src/CredentialModel.h"
+
+TestCredentialModel::TestCredentialModel(QObject *parent) : QObject(parent)
+{
+
+}
+
+void TestCredentialModel::noChanges()
+{
+    CredentialModel model(this);
+    QJsonArray array = QJsonDocument::fromJson(emptyLoginTestJson).array();
+    model.load(array);
+
+    Q_ASSERT(model.rowCount());
+    Q_ASSERT(!model.getJsonChanges().isEmpty());
+}
+
+void TestCredentialModel::oneCredentialRemoved()
+{
+    CredentialModel model(this);
+    QJsonArray array = QJsonDocument::fromJson(emptyLoginTestJson).array();
+    model.load(array);
+
+    QString loginName = "";
+    QString serviceName = "service.io";
+
+    QModelIndex requiredIdx = findLoginIndex(loginName, serviceName, &model);
+    Q_ASSERT(requiredIdx.isValid());
+
+    model.removeCredential(requiredIdx);
+
+    QJsonArray result = model.getJsonChanges();
+    Q_ASSERT(result.count() == 2);
+
+    QJsonObject l1 = result.at(0).toObject();
+    QJsonObject l2 = result.at(1).toObject();
+
+    Q_ASSERT(l1.value("login").toString().compare("loginA") == 0);
+    Q_ASSERT(l2.value("login").toString().compare("loginB") == 0);
+}
+
+QModelIndex TestCredentialModel::findLoginIndex(QString loginName, QString serviceName, QAbstractItemModel *model)
+{
+    bool found = false;
+    QModelIndex requiredIdx;
+
+    for (int r = 0; r < model->rowCount() && !found; r++) {
+        const QModelIndex sIdx = model->index(r, 0);
+        const QString sItemName = sIdx.data(Qt::DisplayRole).toString();
+        if (serviceName.compare(sItemName) == 0) {
+            for (int sr = 0; sr < model->rowCount(sIdx) && !found; sr ++) {
+                const QModelIndex lIdx = model->index(r, 0, sIdx);
+                const QString lItemName = lIdx.data(Qt::DisplayRole).toString();
+                if (loginName.compare(lItemName) == 0) {
+                    requiredIdx = lIdx;
+                    found = true;
+                }
+            }
+        }
+    }
+
+    return requiredIdx;
+}

--- a/tests/TestCredentialModel.h
+++ b/tests/TestCredentialModel.h
@@ -1,0 +1,24 @@
+#ifndef TESTCREDENTIALSMODEL_H
+#define TESTCREDENTIALSMODEL_H
+
+#include <QObject>
+#include <QByteArray>
+#include <QModelIndex>
+#include <QAbstractItemModel>
+
+class TestCredentialModel : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TestCredentialModel(QObject *parent = nullptr);
+
+private Q_SLOTS:
+    void noChanges();
+    void oneCredentialRemoved();
+
+private:
+    QByteArray emptyLoginTestJson = R"([{"childs":[{"address":[-71,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"","password_enc":[205,246,128,228,207,183,151,121,154,164,68,227,85,34,65,36,54,46,44,211,209,114,140,34,194,235,32,43,138,2,2,97]},{"address":[-64,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginA","password_enc":[9,17,87,15,205,141,137,165,134,141,88,96,145,42,191,140,151,19,34,223,86,147,125,167,136,239,47,87,31,102,74,2]},{"address":[16,14],"date_created":"","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginB","password_enc":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"service":"service.io"}])";
+    QModelIndex findLoginIndex(QString loginName, QString serviceName, QAbstractItemModel* model);
+};
+
+#endif // TESTCREDENTIALSMODEL_H

--- a/tests/TestCredentialModel.h
+++ b/tests/TestCredentialModel.h
@@ -6,19 +6,21 @@
 #include <QModelIndex>
 #include <QAbstractItemModel>
 
+class CredentialModel;
 class TestCredentialModel : public QObject
 {
     Q_OBJECT
 public:
     explicit TestCredentialModel(QObject *parent = nullptr);
 
+    static CredentialModel* createCredentialModelWithThreeLogins();
+    static QModelIndex findLoginIndex(QString loginName, QString serviceName, QAbstractItemModel* model);
+
+    static constexpr const char* emptyLoginTestJson = R"([{"childs":[{"address":[-71,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"","password_enc":[205,246,128,228,207,183,151,121,154,164,68,227,85,34,65,36,54,46,44,211,209,114,140,34,194,235,32,43,138,2,2,97]},{"address":[-64,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginA","password_enc":[9,17,87,15,205,141,137,165,134,141,88,96,145,42,191,140,151,19,34,223,86,147,125,167,136,239,47,87,31,102,74,2]},{"address":[16,14],"date_created":"","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginB","password_enc":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"service":"service.io"}])";
 private Q_SLOTS:
     void noChanges();
     void oneCredentialRemoved();
 
-private:
-    QByteArray emptyLoginTestJson = R"([{"childs":[{"address":[-71,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"","password_enc":[205,246,128,228,207,183,151,121,154,164,68,227,85,34,65,36,54,46,44,211,209,114,140,34,194,235,32,43,138,2,2,97]},{"address":[-64,12],"date_created":"2018-01-28","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginA","password_enc":[9,17,87,15,205,141,137,165,134,141,88,96,145,42,191,140,151,19,34,223,86,147,125,167,136,239,47,87,31,102,74,2]},{"address":[16,14],"date_created":"","date_last_used":"2018-01-28","description":"","favorite":-1,"login":"loginB","password_enc":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"service":"service.io"}])";
-    QModelIndex findLoginIndex(QString loginName, QString serviceName, QAbstractItemModel* model);
 };
 
 #endif // TESTCREDENTIALSMODEL_H

--- a/tests/TestCredentialModelFilter.cpp
+++ b/tests/TestCredentialModelFilter.cpp
@@ -1,0 +1,47 @@
+#include "TestCredentialModelFilter.h"
+
+#include <QJsonObject>
+
+#include "../src/TreeItem.h"
+#include "../src/LoginItem.h"
+#include "../src/CredentialModel.h"
+#include "../src/CredentialModelFilter.h"
+#include "TestCredentialModel.h"
+
+TestCredentialModelFilter::TestCredentialModelFilter(QObject *parent) : QObject(parent)
+{
+
+}
+
+void TestCredentialModelFilter::findAndRemoveCredentialFromSourceModel()
+{
+    CredentialModel *sourceModel = TestCredentialModel::createCredentialModelWithThreeLogins();
+    CredentialModelFilter *filter = new CredentialModelFilter();
+    filter->setSourceModel(sourceModel);
+
+    QModelIndex idx = TestCredentialModel::findLoginIndex("", "service.io", filter);
+    Q_ASSERT(idx.isValid());
+
+    QModelIndex srcIdx = filter->mapToSource(idx);
+
+    LoginItem *loginItem = sourceModel->getLoginItemByIndex(srcIdx);
+    Q_ASSERT(loginItem != nullptr);
+
+    QJsonObject o = loginItem->toJson();
+    Q_ASSERT(o.value("login").toString().compare("") == 0);
+    Q_ASSERT(o.value("service").toString().compare("service.io") == 0);
+
+    sourceModel->removeCredential(srcIdx);
+
+    QJsonArray result = sourceModel->getJsonChanges();
+    Q_ASSERT(result.count() == 2);
+
+    QJsonObject l1 = result.at(0).toObject();
+    QJsonObject l2 = result.at(1).toObject();
+
+    Q_ASSERT(l1.value("login").toString().compare("loginA") == 0);
+    Q_ASSERT(l2.value("login").toString().compare("loginB") == 0);
+
+    filter->deleteLater();
+    sourceModel->deleteLater();
+}

--- a/tests/TestCredentialModelFilter.h
+++ b/tests/TestCredentialModelFilter.h
@@ -1,0 +1,16 @@
+#ifndef TESTCREDENTIALMODELFILTER_H
+#define TESTCREDENTIALMODELFILTER_H
+
+#include <QObject>
+
+class TestCredentialModelFilter : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TestCredentialModelFilter(QObject *parent = nullptr);
+
+private slots:
+    void findAndRemoveCredentialFromSourceModel();
+};
+
+#endif // TESTCREDENTIALMODELFILTER_H

--- a/tests/TestTreeItem.cpp
+++ b/tests/TestTreeItem.cpp
@@ -1,0 +1,84 @@
+#include "TestTreeItem.h"
+#include "../src/TreeItem.h"
+
+
+
+TestTreeItem::TestTreeItem(QObject *parent) : QObject(parent)
+{
+
+}
+
+void TestTreeItem::createTreeItem()
+{
+    BaseTreeItem *i = createBaseTreeItem();
+
+    Q_ASSERT(i->name() == baseItemName);
+    Q_ASSERT(i->accessedDate() == accessDate);
+    Q_ASSERT(i->updatedDate() == updateDate);
+    Q_ASSERT(i->description() == baseItemDescription);
+
+    delete i;
+}
+
+BaseTreeItem * TestTreeItem::createBaseTreeItem()
+{
+    BaseTreeItem *i = new BaseTreeItem(baseItemName, updateDate, accessDate, baseItemDescription);
+
+    return i;
+}
+
+QList<BaseTreeItem *> TestTreeItem::addChildsTo(BaseTreeItem *b)
+{
+    QList<BaseTreeItem*> childs;
+
+    QString nameTemplate = "child_%1";
+    BaseTreeItem *c = new BaseTreeItem();
+
+    childs.append(c);
+    b->addChild(c);
+
+    for (int i = 0; i < 3; i++) {
+        c = new BaseTreeItem(nameTemplate.arg(i));
+        childs.append(c);
+        b->addChild(c);
+    }
+
+    return childs;
+}
+
+void TestTreeItem::assertChilds(BaseTreeItem *b, QList<BaseTreeItem*> childs)
+{
+    for (TreeItem *c: b->childs()) {
+        BaseTreeItem *cc = dynamic_cast<BaseTreeItem*>(c);
+        Q_ASSERT(childs.contains(cc));
+    }
+}
+
+void TestTreeItem::addChild()
+{
+    BaseTreeItem *b = createBaseTreeItem();
+    QList<BaseTreeItem*> childs = addChildsTo(b);
+
+    Q_ASSERT(b->childCount() == childs.size());
+
+    assertChilds(b, childs);
+
+    delete b;
+}
+
+void TestTreeItem::removeChild()
+{
+    BaseTreeItem *b = createBaseTreeItem();
+    QList<BaseTreeItem*> childs = addChildsTo(b);
+
+    BaseTreeItem* k = childs.first();
+    childs.removeOne(k);
+    b->removeOne(k);
+
+    Q_ASSERT(b->childCount() == childs.size());
+
+    assertChilds(b, childs);
+
+    delete k;
+    delete b;
+}

--- a/tests/TestTreeItem.h
+++ b/tests/TestTreeItem.h
@@ -1,0 +1,42 @@
+#ifndef TESTTREEITEM_H
+#define TESTTREEITEM_H
+
+#include <QObject>
+#include "../src/TreeItem.h"
+
+class BaseTreeItem : public TreeItem {
+public:
+    explicit BaseTreeItem(const QString &sName = "",
+                          const QDate &dCreatedDate = QDate::currentDate(),
+                          const QDate &dUpdatedDate = QDate::currentDate(),
+                          const QString &setDescription = "") :
+        TreeItem(sName, dCreatedDate, dUpdatedDate, setDescription) {
+    }
+
+    ~BaseTreeItem() {
+    }
+};
+
+class TestTreeItem : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TestTreeItem(QObject *parent = nullptr);
+
+    BaseTreeItem * createBaseTreeItem();
+
+    void assertChilds(BaseTreeItem *b, QList<BaseTreeItem*> childs);
+
+private Q_SLOTS:
+    void createTreeItem();
+    void addChild();
+    void removeChild();
+private:
+    QString baseItemName = "base";
+    QString baseItemDescription = "base item";
+    QDate accessDate = QDate(2018,1, 28);
+    QDate updateDate = QDate(2018,1, 1);
+    QList<BaseTreeItem *> addChildsTo(BaseTreeItem *b);
+};
+
+#endif // TESTTREEITEM_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -5,6 +5,7 @@
 #include "DbBackupsTrackerTests.h"
 #include "TestTreeItem.h"
 #include "TestCredentialModel.h"
+#include "TestCredentialModelFilter.h"
 
 // Note: This is equivalent to QTEST_APPLESS_MAIN for multiple test classes.
 int main(int argc, char** argv)
@@ -24,6 +25,11 @@ int main(int argc, char** argv)
    {
        TestCredentialModel testCredentialsModel;
        QTest::qExec(&testCredentialsModel);
+   }
+
+   {
+       TestCredentialModelFilter testCredentialsModelFilter;
+       QTest::qExec(&testCredentialsModelFilter);
    }
 
 //   TEST_CLASS(FilesCache, status);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -4,6 +4,7 @@
 #include "UpdaterTests.h"
 #include "DbBackupsTrackerTests.h"
 #include "TestTreeItem.h"
+#include "TestCredentialModel.h"
 
 // Note: This is equivalent to QTEST_APPLESS_MAIN for multiple test classes.
 int main(int argc, char** argv)
@@ -15,9 +16,16 @@ int main(int argc, char** argv)
 
 //   DbBackupsTrackerTests dbBackupsTrackerTests;
 //   QTest::qExec(&dbBackupsTrackerTests);
+   {
+       TestTreeItem testTreeItem;
+       QTest::qExec(&testTreeItem);
+   }
 
-   TestTreeItem testTreeItem;
-   QTest::qExec(&testTreeItem);
+   {
+       TestCredentialModel testCredentialsModel;
+       QTest::qExec(&testCredentialsModel);
+   }
+
 //   TEST_CLASS(FilesCache, status);
 //   TEST_CLASS(UpdaterTests, status);
 //   TEST_CLASS(DbBackupsTrackerTests, status);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -3,6 +3,7 @@
 #include "FilesCacheTests.h"
 #include "UpdaterTests.h"
 #include "DbBackupsTrackerTests.h"
+#include "TestTreeItem.h"
 
 // Note: This is equivalent to QTEST_APPLESS_MAIN for multiple test classes.
 int main(int argc, char** argv)
@@ -12,8 +13,11 @@ int main(int argc, char** argv)
 
    int status = 0;
 
-   DbBackupsTrackerTests dbBackupsTrackerTests;
-   QTest::qExec(&dbBackupsTrackerTests);
+//   DbBackupsTrackerTests dbBackupsTrackerTests;
+//   QTest::qExec(&dbBackupsTrackerTests);
+
+   TestTreeItem testTreeItem;
+   QTest::qExec(&testTreeItem);
 //   TEST_CLASS(FilesCache, status);
 //   TEST_CLASS(UpdaterTests, status);
 //   TEST_CLASS(DbBackupsTrackerTests, status);

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -34,20 +34,30 @@ SOURCES += \
     ../src/FilesCache.cpp \
     ../src/DbBackupsTracker.cpp \
     ../src/TreeItem.cpp \
+    ../src/RootItem.cpp \
+    ../src/LoginItem.cpp \
+    ../src/ServiceItem.cpp \
+    ../src/CredentialModel.cpp \
     main.cpp \
     FilesCacheTests.cpp \
     UpdaterTests.cpp \
     DbBackupsTrackerTests.cpp \
-    TestTreeItem.cpp
+    TestTreeItem.cpp \
+    TestCredentialModel.cpp
 
 HEADERS += \
     ../src/SimpleCrypt/SimpleCrypt.h \
     ../src/FilesCache.h \
     ../src/DbBackupsTracker.h\
     ../src/TreeItem.h \
+    ../src/RootItem.h \
+    ../src/LoginItem.h \
+    ../src/ServiceItem.h \
+    ../src/CredentialModel.h \
     UpdaterTests.h \
     FilesCacheTests.h \
     DbBackupsTrackerTests.h \
-    TestTreeItem.h
+    TestTreeItem.h \
+    TestCredentialModel.h
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -38,12 +38,14 @@ SOURCES += \
     ../src/LoginItem.cpp \
     ../src/ServiceItem.cpp \
     ../src/CredentialModel.cpp \
+    ../src/CredentialModelFilter.cpp \
     main.cpp \
     FilesCacheTests.cpp \
     UpdaterTests.cpp \
     DbBackupsTrackerTests.cpp \
     TestTreeItem.cpp \
-    TestCredentialModel.cpp
+    TestCredentialModel.cpp \
+    TestCredentialModelFilter.cpp
 
 HEADERS += \
     ../src/SimpleCrypt/SimpleCrypt.h \
@@ -54,10 +56,12 @@ HEADERS += \
     ../src/LoginItem.h \
     ../src/ServiceItem.h \
     ../src/CredentialModel.h \
+    ../src/CredentialModelFilter.h \
     UpdaterTests.h \
     FilesCacheTests.h \
     DbBackupsTrackerTests.h \
     TestTreeItem.h \
-    TestCredentialModel.h
+    TestCredentialModel.h \
+    TestCredentialModelFilter.h
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -33,17 +33,21 @@ SOURCES += \
     ../src/SimpleCrypt/SimpleCrypt.cpp \
     ../src/FilesCache.cpp \
     ../src/DbBackupsTracker.cpp \
+    ../src/TreeItem.cpp \
     main.cpp \
     FilesCacheTests.cpp \
     UpdaterTests.cpp \
-    DbBackupsTrackerTests.cpp
+    DbBackupsTrackerTests.cpp \
+    TestTreeItem.cpp
 
 HEADERS += \
     ../src/SimpleCrypt/SimpleCrypt.h \
     ../src/FilesCache.h \
     ../src/DbBackupsTracker.h\
+    ../src/TreeItem.h \
     UpdaterTests.h \
     FilesCacheTests.h \
-    DbBackupsTrackerTests.h
+    DbBackupsTrackerTests.h \
+    TestTreeItem.h
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"


### PR DESCRIPTION
Update credential selection properly. Fix #199 
Bug description:
When an item is deleted the selection is changed to the next available item.
But the Login details fields are not being updated with the new selected item details.

So when save changes is clicked the saveSelectedCredentials defaults to the first selected item overriding it's data erroneously. 
Finally the changes json also wrong, that's why the save fails.