### PR TITLE
feature request: in MMM, sort credentials by modified date feature request good first issue help wanted #207 

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -224,5 +224,14 @@ Q_DECLARE_METATYPE(Common::MPHwVersion)
                             "background-color: #237C95;" \
                         "}"
 
+#define CSS_CREDVIEW_HEADER "QHeaderView::section {" \
+                                "background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,"\
+                                        "stop:0 #F1F1F1, stop: 0.5 #E0E0E0,"\
+                                        "stop: 0.6 #D3D3D3, stop:1 #F5F5F5);"\
+                                "color: black;"\
+                                "padding-left: 4px;"\
+                                "border: 1px solid #FcFcFc;"\
+                            "}"
+
 #endif // COMMON_H
 

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -35,12 +35,20 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
     // Cast to login item
     LoginItem *pLoginItem = getLoginItemByIndex(idx);
 
-    if (role == Qt::DisplayRole)
-        return pItem->name();
+    if (role == Qt::DisplayRole && idx.column() == 0)
+        return  pItem->name();
+    if (role == Qt::DisplayRole && idx.column() == 1)
+    {
+        if (pLoginItem != nullptr)
+            return pLoginItem->updatedDate();
+        else
+             return  QVariant(" ");
+    }
+
 
     if (role == Qt::ForegroundRole)
     {
-        if (pLoginItem != nullptr)
+        if (pLoginItem != nullptr && idx.column() == 0)
             return QColor("#3D96AF");
     }
 
@@ -54,7 +62,7 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
             return font;
         }
         else
-        if (pLoginItem != nullptr)
+        if (pLoginItem != nullptr && idx.column() == 0)
         {
             QFont font = qApp->font();
             font.setBold(true);
@@ -66,10 +74,27 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
     }
 
     if (role == Qt::DecorationRole) {
-        if (pLoginItem != nullptr)
+        if (pLoginItem != nullptr && idx.column() == 0)
             return loginItemIcon;
     }
 
+    return QVariant();
+}
+
+QVariant CredentialModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (Qt::DisplayRole == role && orientation == Qt::Horizontal)
+    {
+        switch (section)
+        {
+        case 0:
+            return QString("Service or website");
+        case 1:
+            return QString("modified date");
+        default:
+            return QVariant();
+        }
+    }
     return QVariant();
 }
 
@@ -131,7 +156,7 @@ int CredentialModel::rowCount(const QModelIndex &parent) const
 int CredentialModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 1;
+    return 2;
 }
 
 TreeItem *CredentialModel::getItemByIndex(const QModelIndex &idx) const

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -75,6 +75,15 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
         }
         return qApp->font();
     }
+
+    if (Qt::TextAlignmentRole == role)
+    {
+        if (pLoginItem != nullptr && idx.column() == 1)
+        {
+            return Qt::AlignHCenter;
+        }
+    }
+
     return QVariant();
 }
 
@@ -92,6 +101,15 @@ QVariant CredentialModel::headerData(int section, Qt::Orientation orientation, i
             return QVariant();
         }
     }
+
+    if (Qt::TextAlignmentRole == role)
+    {
+        if (section == 1)
+        {
+            return Qt::AlignHCenter;
+        }
+    }
+
     return QVariant();
 }
 

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -4,6 +4,7 @@
 #include <QColor>
 #include <QFont>
 #include <QApplication>
+#include <QBrush>
 
 // Application
 #include "CredentialModel.h"
@@ -76,6 +77,26 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
     if (role == Qt::DecorationRole) {
         if (pLoginItem != nullptr && idx.column() == 0)
             return loginItemIcon;
+    }
+
+    if (role == Qt::BackgroundRole)
+    {
+        QColor bkgColor("white");
+        if (pServiceItem != nullptr)
+        {
+            if (idx.row()%2 == 0)
+                bkgColor.setNamedColor("#eef7fa");
+            else
+                bkgColor.setNamedColor("white");
+        }
+        else if (pLoginItem != nullptr)
+        {
+            if (parent(idx).row()%2 == 0)
+                bkgColor.setNamedColor("#eef7fa");
+            else
+                bkgColor.setNamedColor("white");
+        }
+        return QBrush(bkgColor);
     }
 
     return QVariant();

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -38,21 +38,13 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
 
     if (role == Qt::DisplayRole && idx.column() == 0)
     {
-        if (pLoginItem != nullptr)
-            return  "         " + pItem->name();
-        else if (pServiceItem != nullptr)
+       if (pServiceItem != nullptr)
             return  pItem->name();
     }
-    if (role == Qt::DisplayRole && idx.column() == 1)
+    else if (role == Qt::DisplayRole && idx.column() == 1)
     {
         if (pLoginItem != nullptr)
             return  pItem->updatedDate();
-    }
-
-    if (role == Qt::ForegroundRole)
-    {
-        if (pLoginItem != nullptr && idx.column() == 0)
-            return QColor("#3D96AF");
     }
 
     if (role == Qt::FontRole)
@@ -64,15 +56,7 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
             font.setPointSize(10);
             return font;
         }
-        else
-        if (pLoginItem != nullptr && idx.column() == 0)
-        {
-            QFont font = qApp->font();
-            font.setBold(true);
-            font.setItalic(true);
-            font.setPointSize(10);
-            return font;
-        }
+
         return qApp->font();
     }
 
@@ -287,11 +271,6 @@ LoginItem *CredentialModel::getLoginItemByIndex(const QModelIndex &idx) const
 ServiceItem *CredentialModel::getServiceItemByIndex(const QModelIndex &idx) const
 {
     return dynamic_cast<ServiceItem *>(getItemByIndex(idx));
-}
-
-void CredentialModel::setLoginItemIcon(const QIcon &icon)
-{
-    loginItemIcon = icon;
 }
 
 void CredentialModel::updateLoginItem(const QModelIndex &idx, const QString &sPassword, const QString &sDescription, const QString &sName)

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -37,15 +37,17 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
     LoginItem *pLoginItem = getLoginItemByIndex(idx);
 
     if (role == Qt::DisplayRole && idx.column() == 0)
-        return  pItem->name();
+    {
+        if (pLoginItem != nullptr)
+            return  "         " + pItem->name();
+        else if (pServiceItem != nullptr)
+            return  pItem->name();
+    }
     if (role == Qt::DisplayRole && idx.column() == 1)
     {
         if (pLoginItem != nullptr)
-            return pLoginItem->updatedDate();
-        else
-             return  QVariant(" ");
+            return  pItem->updatedDate();
     }
-
 
     if (role == Qt::ForegroundRole)
     {
@@ -73,32 +75,6 @@ QVariant CredentialModel::data(const QModelIndex &idx, int role) const
         }
         return qApp->font();
     }
-
-    if (role == Qt::DecorationRole) {
-        if (pLoginItem != nullptr && idx.column() == 0)
-            return loginItemIcon;
-    }
-
-    if (role == Qt::BackgroundRole)
-    {
-        QColor bkgColor("white");
-        if (pServiceItem != nullptr)
-        {
-            if (idx.row()%2 == 0)
-                bkgColor.setNamedColor("#eef7fa");
-            else
-                bkgColor.setNamedColor("white");
-        }
-        else if (pLoginItem != nullptr)
-        {
-            if (parent(idx).row()%2 == 0)
-                bkgColor.setNamedColor("#eef7fa");
-            else
-                bkgColor.setNamedColor("white");
-        }
-        return QBrush(bkgColor);
-    }
-
     return QVariant();
 }
 
@@ -109,7 +85,7 @@ QVariant CredentialModel::headerData(int section, Qt::Orientation orientation, i
         switch (section)
         {
         case 0:
-            return QString("Service or Website");
+            return QString("   Service or Website");
         case 1:
             return QString("Modified Date");
         default:

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -88,9 +88,9 @@ QVariant CredentialModel::headerData(int section, Qt::Orientation orientation, i
         switch (section)
         {
         case 0:
-            return QString("Service or website");
+            return QString("Service or Website");
         case 1:
-            return QString("modified date");
+            return QString("Modified Date");
         default:
             return QVariant();
         }

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -255,9 +255,9 @@ ServiceItem *CredentialModel::addService(const QString &sServiceName)
     return new ServiceItem(sServiceName);
 }
 
-QModelIndex CredentialModel::getServiceIndexByName(const QString &sServiceName) const
+QModelIndex CredentialModel::getServiceIndexByName(const QString &sServiceName, int column) const
 {
-    QModelIndexList lMatches = match(index(0, 0, QModelIndex()), Qt::DisplayRole, sServiceName, 1);
+    QModelIndexList lMatches = match(index(0, column, QModelIndex()), Qt::DisplayRole, sServiceName, 1);
     if (!lMatches.isEmpty())
         return lMatches.first();
 

--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -33,6 +33,7 @@ public:
     CredentialModel(QObject *parent=nullptr);
     ~CredentialModel();
     virtual QVariant data(const QModelIndex &idx, int role) const;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     virtual Qt::ItemFlags flags(const QModelIndex &idx) const;
     virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     virtual QModelIndex parent(const QModelIndex &idx) const;

--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -48,7 +48,7 @@ public:
     void updateLoginItem(const QModelIndex &idx, const QString &sPassword, const QString &sDescription, const QString &sName);
     void updateLoginItem(const QModelIndex &idx, const ItemRole &role, const QVariant &vValue);
     void clear();
-    QModelIndex getServiceIndexByName(const QString &sServiceName) const;
+    QModelIndex getServiceIndexByName(const QString &sServiceName, int column = 0) const;
     LoginItem *getLoginItemByIndex(const QModelIndex &idx) const;
     ServiceItem *getServiceItemByIndex(const QModelIndex &idx) const;
 

--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -52,13 +52,11 @@ public:
     LoginItem *getLoginItemByIndex(const QModelIndex &idx) const;
     ServiceItem *getServiceItemByIndex(const QModelIndex &idx) const;
 
-    void setLoginItemIcon(const QIcon &icon);
 private:
     ServiceItem *addService(const QString &sServiceName);
 
 private:
     RootItem *m_pRootItem;
-    QIcon loginItemIcon;
 
 signals:
     void modelLoaded(bool bClearLoginDescription);

--- a/src/CredentialModelFilter.cpp
+++ b/src/CredentialModelFilter.cpp
@@ -71,8 +71,8 @@ QModelIndexList CredentialModelFilter::getNextRow(const QModelIndex& rowIdx)
         else if (parent.row() > 0)
         {
             QModelIndex prevousParent = index(parent.row()-1, 0, parent.parent());
-            nextRow << index(0, 0, prevousParent);
-            nextRow << index(0, 1, prevousParent);
+            nextRow << index(rowCount(prevousParent)-1, 0, prevousParent);
+            nextRow << index(rowCount(prevousParent)-1, 1, prevousParent);
         }
     }
 

--- a/src/CredentialModelFilter.cpp
+++ b/src/CredentialModelFilter.cpp
@@ -42,6 +42,43 @@ void CredentialModelFilter::sort(int column, Qt::SortOrder order)
     return QSortFilterProxyModel::sort(column, order);
 }
 
+QModelIndexList CredentialModelFilter::getNextRow(const QModelIndex& rowIdx)
+{
+    QModelIndexList nextRow;
+    QModelIndex parent = rowIdx.parent();
+    if (!rowIdx.isValid())
+        return nextRow;
+
+    if (rowCount(parent) > rowIdx.row()+1)
+    {
+        nextRow << index(rowIdx.row()+1, 0, parent);
+        nextRow << index(rowIdx.row()+1, 1, parent);
+    }
+    else if (parent.isValid())
+    {
+        if  (rowCount(parent.parent()) > parent.row()+1)
+        {
+            QModelIndex nextParent = index(parent.row()+1, 0, parent.parent());
+            nextRow << index(0, 0, nextParent);
+            nextRow << index(0, 1, nextParent);
+        }
+        else if (rowIdx.row() > 0)
+        {
+            nextRow << index(rowIdx.row()-1, 0, parent);
+            nextRow << index(rowIdx.row()-1, 1, parent);
+
+        }
+        else if (parent.row() > 0)
+        {
+            QModelIndex prevousParent = index(parent.row()-1, 0, parent.parent());
+            nextRow << index(0, 0, prevousParent);
+            nextRow << index(0, 1, prevousParent);
+        }
+    }
+
+    return nextRow;
+}
+
 bool CredentialModelFilter::filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const
 {
     // Get source index

--- a/src/CredentialModelFilter.cpp
+++ b/src/CredentialModelFilter.cpp
@@ -135,3 +135,25 @@ QModelIndex CredentialModelFilter::getProxyIndexFromItem(TreeItem *pItem, int co
     {
         QModelIndex serviceIndex = pCredModel->getServiceIndexByName(pItem->name(), column);
         return mapFromSource(serviceIndex);
+    }
+    case TreeItem::TreeType::Login:
+    {
+        QModelIndex parentIndex = getProxyIndexFromItem(pItem->parentItem());
+
+        for (int i = 0; i < rowCount(parentIndex); i ++)
+        {
+            QModelIndex loginIndex = index(i, column, parentIndex);
+            if (loginIndex.isValid())
+            {
+                TreeItem *pLoginItem = getItemByProxyIndex(loginIndex);
+                if (pLoginItem->name() == pItem->name())
+                    return loginIndex;
+            }
+        }
+        return QModelIndex();
+    }
+    case TreeItem::TreeType::Root:
+    default:
+        return QModelIndex();
+    }
+}

--- a/src/CredentialModelFilter.cpp
+++ b/src/CredentialModelFilter.cpp
@@ -126,3 +126,12 @@ bool CredentialModelFilter::lessThan(const QModelIndex &srcLeft, const QModelInd
     return false;
 }
 
+QModelIndex CredentialModelFilter::getProxyIndexFromItem(TreeItem *pItem, int column)
+{
+    CredentialModel *pCredModel = dynamic_cast<CredentialModel *>(sourceModel());
+    switch (pItem->treeType())
+    {
+    case TreeItem::TreeType::Service:
+    {
+        QModelIndex serviceIndex = pCredModel->getServiceIndexByName(pItem->name(), column);
+        return mapFromSource(serviceIndex);

--- a/src/CredentialModelFilter.cpp
+++ b/src/CredentialModelFilter.cpp
@@ -7,7 +7,6 @@
 CredentialModelFilter::CredentialModelFilter(QObject *parent) : QSortFilterProxyModel(parent)
 {
     setDynamicSortFilter(true);
-    sort(0);
 }
 
 CredentialModelFilter::~CredentialModelFilter()
@@ -33,6 +32,14 @@ const TreeItem *CredentialModelFilter::getItemByProxyIndex(const QModelIndex &pr
     QModelIndex srcIndex = mapToSource(proxyIndex);
     CredentialModel *pSrcModel = dynamic_cast<CredentialModel *>(sourceModel());
     return pSrcModel->getItemByIndex(srcIndex);
+}
+
+void CredentialModelFilter::sort(int column, Qt::SortOrder order)
+{
+    // sort order is not passed as a parameter to lessThan so need
+    // to save sort order globally.
+    tempSortOrder = order;
+    return QSortFilterProxyModel::sort(column, order);
 }
 
 bool CredentialModelFilter::filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const
@@ -103,7 +110,18 @@ bool CredentialModelFilter::lessThan(const QModelIndex &srcLeft, const QModelInd
     TreeItem *pRightItem = pSrcModel->getItemByIndex(srcRight);
 
     if ((pLeftItem != nullptr) && (pRightItem != nullptr))
-        return pLeftItem->name() < pRightItem->name();
+    {
+        if (srcLeft.column() == 0 && srcRight.column() == 0)
+        {
+            return pLeftItem->name() < pRightItem->name();
+        }
+
+        if ((srcLeft.column() == 1 && srcRight.column() == 1))
+        {
+            return pLeftItem->bestUpdateDate(tempSortOrder)
+                        < pRightItem->bestUpdateDate(tempSortOrder);
+        }
+    }
 
     return false;
 }

--- a/src/CredentialModelFilter.h
+++ b/src/CredentialModelFilter.h
@@ -17,6 +17,7 @@ public:
     void setFilter(const QString &sFilter);
     TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex);
     const TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex) const;
+    QModelIndex getProxyIndexFromItem(TreeItem* pItem, int column = 0);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) Q_DECL_OVERRIDE;
 
 protected:

--- a/src/CredentialModelFilter.h
+++ b/src/CredentialModelFilter.h
@@ -19,6 +19,7 @@ public:
     const TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex) const;
     QModelIndex getProxyIndexFromItem(TreeItem* pItem, int column = 0);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) Q_DECL_OVERRIDE;
+    QModelIndexList getNextRow(const QModelIndex &rowIdx);
 
 protected:
     virtual bool filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const;

--- a/src/CredentialModelFilter.h
+++ b/src/CredentialModelFilter.h
@@ -17,6 +17,7 @@ public:
     void setFilter(const QString &sFilter);
     TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex);
     const TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex) const;
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) Q_DECL_OVERRIDE;
 
 protected:
     virtual bool filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const;
@@ -28,6 +29,7 @@ private:
 
 private:
     QString m_sFilter;
+    Qt::SortOrder tempSortOrder;
 };
 
 #endif // CREDENTIALMODELFILTER_H

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -52,7 +52,9 @@ void CredentialView::onModelLoaded(bool bClearLoginDescription)
 {
     Q_UNUSED(bClearLoginDescription)
     CredentialModelFilter *pCredModelFilter = dynamic_cast<CredentialModelFilter *>(model());
+
     pCredModelFilter->sort(0, Qt::AscendingOrder);
+    header()->setSortIndicator(0, Qt::AscendingOrder);
 
     QModelIndex firstServiceIndex = model()->index(0, 0, QModelIndex());
     if (firstServiceIndex.isValid())

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -24,14 +24,13 @@ CredentialView::CredentialView(QWidget *parent) : QTreeView(parent)
     m_tSelectionTimer.setInterval(50);
     m_tSelectionTimer.setSingleShot(true);
     connect(&m_tSelectionTimer, &QTimer::timeout, this, &CredentialView::onSelectionTimerTimeOut);
-
+    setIndentation(10);
     setSortingEnabled(true);
     m_pItemDelegate = new ItemDelegate(this);
     setItemDelegateForColumn(0, m_pItemDelegate);
     setMinimumWidth(430);
     connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState);
-    header()->setStyleSheet("QHeaderView::section{ background-color: #D5D5D5; }");
-
+    header()->setStyleSheet(CSS_CREDVIEW_HEADER);
 }
 
 CredentialView::~CredentialView()
@@ -52,6 +51,7 @@ void CredentialView::onModelLoaded(bool bClearLoginDescription)
 {
     Q_UNUSED(bClearLoginDescription)
     CredentialModelFilter *pCredModelFilter = dynamic_cast<CredentialModelFilter *>(model());
+    pCredModelFilter->sort(0, Qt::AscendingOrder);
 
     QModelIndex firstServiceIndex = model()->index(0, 0, QModelIndex());
     if (firstServiceIndex.isValid())
@@ -71,16 +71,26 @@ void CredentialView::onModelLoaded(bool bClearLoginDescription)
                 {
                     expand(serviceIndex);
                     expand(itemIndex);
-                    wasAnyItemFavoriteExpanded = true;
+                    if (!wasAnyItemFavoriteExpanded)
+                    {
+                        selectionModel()->setCurrentIndex(itemIndex
+                                , QItemSelectionModel::ClearAndSelect
+                                | QItemSelectionModel::Rows);
+                        wasAnyItemFavoriteExpanded = true;
+                    }
+
                 }
             }
         }
 
         if (!wasAnyItemFavoriteExpanded) {
-            selectionModel()->setCurrentIndex(firstServiceIndex, QItemSelectionModel::ClearAndSelect);
+            selectionModel()->setCurrentIndex(firstServiceIndex,
+                  QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
             onToggleExpandedState(firstServiceIndex);
         }
     }
+
+
 }
 
 void CredentialView::onToggleExpandedState(const QModelIndex &proxyIndex)
@@ -212,7 +222,8 @@ void CredentialView::resetCurrentIndex()
                 if (loginIndex.isValid())
                 {
                     setExpanded(serviceIndex, true);
-                    selectionModel()->setCurrentIndex(loginIndex, QItemSelectionModel::ClearAndSelect);
+                    selectionModel()->setCurrentIndex(loginIndex
+                        , QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
                     return;
                 }
             }
@@ -220,7 +231,8 @@ void CredentialView::resetCurrentIndex()
             if (pCredModelFilter->rowCount(serviceIndex) > 0)
             {
                 setExpanded(serviceIndex, false);
-                selectionModel()->setCurrentIndex(serviceIndex, QItemSelectionModel::ClearAndSelect);
+                selectionModel()->setCurrentIndex(serviceIndex
+                     , QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
                 return;
             }
         }

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -28,10 +28,9 @@ CredentialView::CredentialView(QWidget *parent)
     m_pItemDelegate = new ItemDelegate(this);
     setItemDelegateForColumn(0, m_pItemDelegate);
     setMinimumWidth(430);
-    connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState, Qt::DirectConnection);
+    connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState);
 
     header()->setStyleSheet("QHeaderView::section{ background-color: #D5D5D5; }");
-    setColumnWidth(0, 300);
 }
 
 CredentialView::~CredentialView()
@@ -175,12 +174,11 @@ void CredentialView::setModel(QAbstractItemModel *model)
     connect(model, &QAbstractItemModel::layoutChanged, this, &CredentialView::onLayoutChanged);
 }
 
-
 void CredentialView::onLayoutChanged(const QList<QPersistentModelIndex> &parents
                                      , QAbstractItemModel::LayoutChangeHint hint)
 {
     Q_UNUSED(parents)
-    if (QAbstractItemModel::VerticalSortHint == hint && tempTreeItem)
+    if (QAbstractItemModel::VerticalSortHint == hint)
     {
         onSelectionTimerTimeOut();
     }

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -19,6 +19,7 @@ CredentialView::CredentialView(QWidget *parent) : QTreeView(parent)
   , m_pItemDelegate(nullptr)
   , tempCurrentServiceItem(nullptr)
   , tempCurrentLoginItem(nullptr)
+  , columnBreakRatio(0.75)
 {
     m_tSelectionTimer.setInterval(50);
     m_tSelectionTimer.setSingleShot(true);
@@ -139,11 +140,18 @@ void CredentialView::onSelectionTimerTimeOut()
 void CredentialView::setModel(QAbstractItemModel *model)
 {
     QTreeView::setModel(model);
-    setColumnWidth(0, 300);
+
+    setColumnWidth(0, geometry().width()*columnBreakRatio);
     connect(model, &QAbstractItemModel::layoutAboutToBeChanged
             , this, &CredentialView::onLayoutAboutToBeChanged);
     connect(model, &QAbstractItemModel::layoutChanged, this
             , &CredentialView::onLayoutChanged);
+}
+
+void CredentialView::resizeEvent(QResizeEvent *event)
+{
+    QTreeView::resizeEvent(event);
+    setColumnWidth(0, geometry().width()*columnBreakRatio);
 }
 
 void CredentialView::onLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -1,7 +1,8 @@
-// Qt
+ // Qt
 #include <QDateTime>
 #include <QMouseEvent>
 #include <QDebug>
+#include <QHeaderView>
 
 // Application
 #include "CredentialView.h"
@@ -12,18 +13,25 @@
 #include "TreeItem.h"
 #include "LoginItem.h"
 
-CredentialView::CredentialView(QWidget *parent) : QTreeView(parent),
-    m_bIsFullyExpanded(false), m_pCurrentServiceItem(nullptr), m_pItemDelegate(nullptr)
+CredentialView::CredentialView(QWidget *parent)
+    : QTreeView(parent)
+  , m_bIsFullyExpanded(false)
+  , m_pCurrentServiceItem(nullptr)
+  , m_pCurrentLoginItem(nullptr)
+  , m_pItemDelegate(nullptr)
 {
     m_tSelectionTimer.setInterval(50);
     m_tSelectionTimer.setSingleShot(true);
     connect(&m_tSelectionTimer, &QTimer::timeout, this, &CredentialView::onSelectionTimerTimeOut);
 
-    setHeaderHidden(true);
+    setSortingEnabled(true);
     m_pItemDelegate = new ItemDelegate(this);
     setItemDelegateForColumn(0, m_pItemDelegate);
     setMinimumWidth(430);
-    connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState);
+    connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState, Qt::DirectConnection);
+
+    header()->setStyleSheet("QHeaderView::section{ background-color: #D5D5D5; }");
+    setColumnWidth(0, 300);
 }
 
 CredentialView::~CredentialView()
@@ -79,8 +87,13 @@ void CredentialView::onToggleExpandedState(const QModelIndex &proxyIndex)
 {
     CredentialModelFilter *pCredModelFilter = dynamic_cast<CredentialModelFilter *>(model());
     TreeItem *pItem = pCredModelFilter->getItemByProxyIndex(proxyIndex);
+
     ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pItem);
+    LoginItem* ploginItem = dynamic_cast<LoginItem *>(pItem);    
+    Q_ASSERT((pServiceItem != nullptr || ploginItem != nullptr));
+
     m_pCurrentServiceItem = nullptr;
+    m_pCurrentLoginItem = nullptr;
     if (pServiceItem != nullptr)
     {
         m_pCurrentServiceItem = pServiceItem;
@@ -91,7 +104,18 @@ void CredentialView::onToggleExpandedState(const QModelIndex &proxyIndex)
                 m_tSelectionTimer.start();
         }
         else
+        {
             collapse(proxyIndex);
+        }
+    }
+    else if (ploginItem != nullptr)
+    {
+        QModelIndex proxyParent = proxyIndex.parent();
+        Q_ASSERT(proxyParent.isValid());
+        TreeItem *pParent = pCredModelFilter->getItemByProxyIndex(proxyParent);
+        ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pParent);
+        m_pCurrentServiceItem = pServiceItem;
+        m_pCurrentLoginItem = ploginItem;       
     }
 }
 
@@ -107,24 +131,68 @@ void CredentialView::onChangeExpandedState()
 
 void CredentialView::onSelectionTimerTimeOut()
 {
-    if ((m_pCurrentServiceItem != nullptr) && (m_pCurrentServiceItem->isExpanded()))
+    if ((m_pCurrentServiceItem != nullptr))
     {
         CredentialModelFilter *pCredModelFilter = dynamic_cast<CredentialModelFilter *>(model());
         CredentialModel *pCredModel = dynamic_cast<CredentialModel *>(pCredModelFilter->sourceModel());
         QModelIndex serviceIndex = pCredModel->getServiceIndexByName(m_pCurrentServiceItem->name());
         if (serviceIndex.isValid())
         {
-            QModelIndex proxyIndex = pCredModelFilter->mapFromSource(serviceIndex);
-            if (proxyIndex.isValid())
+            QModelIndex proxyServiceIndex = pCredModelFilter->mapFromSource(serviceIndex);
+            if (proxyServiceIndex.isValid())
             {
-                int nVisibleChilds = pCredModelFilter->rowCount(proxyIndex);
-                if (nVisibleChilds > 0)
+                if (m_pCurrentServiceItem->isExpanded())
                 {
-                    QModelIndex firstLoginIndex = proxyIndex.child(0, 0);
-                    if (firstLoginIndex.isValid())
-                        setCurrentIndex(firstLoginIndex);
+                    int nVisibleChilds = pCredModelFilter->rowCount(proxyServiceIndex);
+                    if (nVisibleChilds > 0)
+                    {
+                        QModelIndex firstLoginIndex = proxyServiceIndex.child(0, 0);
+                        if (firstLoginIndex.isValid())
+                        {
+                            setCurrentIndex(firstLoginIndex);
+
+                            TreeItem *pItem = pCredModelFilter->getItemByProxyIndex(firstLoginIndex);
+                            LoginItem* ploginItem = dynamic_cast<LoginItem *>(pItem);
+                            m_pCurrentLoginItem = ploginItem;
+                        }
+                    }
                 }
+                else
+                {
+                    m_pCurrentLoginItem = nullptr;
+                    setCurrentIndex(proxyServiceIndex);
+                }
+
             }
         }
     }
 }
+
+void CredentialView::setModel(QAbstractItemModel *model)
+{
+    QTreeView::setModel(model);
+    setColumnWidth(0, 300);
+    connect(model, &QAbstractItemModel::layoutChanged, this, &CredentialView::onLayoutChanged);
+}
+
+
+void CredentialView::onLayoutChanged(const QList<QPersistentModelIndex> &parents
+                                     , QAbstractItemModel::LayoutChangeHint hint)
+{
+    Q_UNUSED(parents)
+    if (QAbstractItemModel::VerticalSortHint == hint && tempTreeItem)
+    {
+        onSelectionTimerTimeOut();
+    }
+}
+
+void CredentialView::dumpCurrentItem(const QString& intro)
+{
+    CredentialModelFilter *pCredModelFilter = dynamic_cast<CredentialModelFilter *>(model());
+    TreeItem* currentItem = pCredModelFilter->getItemByProxyIndex(currentIndex());
+    qDebug() << intro
+             << "\tService\t" << (m_pCurrentServiceItem ? m_pCurrentServiceItem->name() : "none")
+             << "\tLogin\t" << (m_pCurrentLoginItem ? m_pCurrentLoginItem->name() : "none")
+             << "\tcurrent\t" << (currentItem ? currentItem->name() : "none");
+}
+

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -32,6 +32,7 @@ CredentialView::CredentialView(QWidget *parent) : QTreeView(parent)
     setMinimumWidth(430);
     connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState);
     header()->setStyleSheet(CSS_CREDVIEW_HEADER);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 
 CredentialView::~CredentialView()

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -28,6 +28,7 @@ CredentialView::CredentialView(QWidget *parent) : QTreeView(parent)
     setSortingEnabled(true);
     m_pItemDelegate = new ItemDelegate(this);
     setItemDelegateForColumn(0, m_pItemDelegate);
+    setItemDelegateForColumn(1, m_pItemDelegate);
     setMinimumWidth(430);
     connect(this, &CredentialView::clicked, this, &CredentialView::onToggleExpandedState);
     header()->setStyleSheet(CSS_CREDVIEW_HEADER);

--- a/src/CredentialView.h
+++ b/src/CredentialView.h
@@ -7,8 +7,10 @@
 
 // Application
 class ServiceItem;
+class LoginItem;
 class ItemDelegate;
-
+class QAbstractItemModel;
+class TreeItem;
 class CredentialView : public QTreeView
 {
     Q_OBJECT
@@ -20,15 +22,28 @@ public:
 
 public slots:
     void onModelLoaded(bool bClearLoginDescription);
+
     void onToggleExpandedState(const QModelIndex &proxyIndex);
     void onChangeExpandedState();
     void onSelectionTimerTimeOut();
 
+    virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
+
+private slots:
+    void onLayoutChanged(const QList<QPersistentModelIndex> &parents
+                            , QAbstractItemModel::LayoutChangeHint hint);
+
 private:
+    void dumpCurrentItem(const QString &intro);
+
     bool m_bIsFullyExpanded;
     QTimer m_tSelectionTimer;
     ServiceItem *m_pCurrentServiceItem;
+    LoginItem *m_pCurrentLoginItem;
     ItemDelegate *m_pItemDelegate;
+
+    TreeItem* tempTreeItem;
+    QPersistentModelIndex tempPIndex;
 
 signals:
     void expandedStateChanged(bool bIsExpanded);

--- a/src/CredentialView.h
+++ b/src/CredentialView.h
@@ -28,8 +28,6 @@ public slots:
     void onSelectionTimerTimeOut();
 
     virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
-
-private slots:
     void onLayoutChanged(const QList<QPersistentModelIndex> &parents
                             , QAbstractItemModel::LayoutChangeHint hint);
 
@@ -41,9 +39,6 @@ private:
     ServiceItem *m_pCurrentServiceItem;
     LoginItem *m_pCurrentLoginItem;
     ItemDelegate *m_pItemDelegate;
-
-    TreeItem* tempTreeItem;
-    QPersistentModelIndex tempPIndex;
 
 signals:
     void expandedStateChanged(bool bIsExpanded);

--- a/src/CredentialView.h
+++ b/src/CredentialView.h
@@ -21,24 +21,28 @@ public:
     void refreshLoginItem(const QModelIndex &srcIndex, bool bIsFavorite=false);
 
 public slots:
-    void onModelLoaded(bool bClearLoginDescription);
+    void onModelLoaded(bool bClearLoginDescription = false);
 
     void onToggleExpandedState(const QModelIndex &proxyIndex);
     void onChangeExpandedState();
     void onSelectionTimerTimeOut();
 
     virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
+    void onLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents
+                                , QAbstractItemModel::LayoutChangeHint hint);
     void onLayoutChanged(const QList<QPersistentModelIndex> &parents
                             , QAbstractItemModel::LayoutChangeHint hint);
 
 private:
-    void dumpCurrentItem(const QString &intro);
+    void resetCurrentIndex();
 
     bool m_bIsFullyExpanded;
     QTimer m_tSelectionTimer;
     ServiceItem *m_pCurrentServiceItem;
-    LoginItem *m_pCurrentLoginItem;
     ItemDelegate *m_pItemDelegate;
+
+    ServiceItem *tempCurrentServiceItem;
+    LoginItem *tempCurrentLoginItem;
 
 signals:
     void expandedStateChanged(bool bIsExpanded);

--- a/src/CredentialView.h
+++ b/src/CredentialView.h
@@ -19,7 +19,8 @@ public:
     explicit CredentialView(QWidget *parent = nullptr);
     ~CredentialView();
     void refreshLoginItem(const QModelIndex &srcIndex, bool bIsFavorite=false);
-
+    virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
+    virtual void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
 public slots:
     void onModelLoaded(bool bClearLoginDescription = false);
 
@@ -27,7 +28,7 @@ public slots:
     void onChangeExpandedState();
     void onSelectionTimerTimeOut();
 
-    virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
+
     void onLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents
                                 , QAbstractItemModel::LayoutChangeHint hint);
     void onLayoutChanged(const QList<QPersistentModelIndex> &parents
@@ -43,6 +44,8 @@ private:
 
     ServiceItem *tempCurrentServiceItem;
     LoginItem *tempCurrentLoginItem;
+
+    const float columnBreakRatio;
 
 signals:
     void expandedStateChanged(bool bIsExpanded);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -530,9 +530,11 @@ void CredentialsManagement::on_pushButtonDelete_clicked()
             QModelIndexList nextRow = m_pCredModelFilter->getNextRow(lIndexes.at(0));
             auto selectionModel = ui->credentialTreeView->selectionModel();
             if (nextRow.size()>0 && nextRow.at(0).isValid())
-                selectionModel->setCurrentIndex(nextRow.at(0), QItemSelectionModel::ClearAndSelect);
+                selectionModel->setCurrentIndex(nextRow.at(0)
+                    , QItemSelectionModel::ClearAndSelect  | QItemSelectionModel::Rows);
             else
-                selectionModel->setCurrentIndex(QModelIndex(), QItemSelectionModel::ClearAndSelect);
+                selectionModel->setCurrentIndex(QModelIndex()
+                    , QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 
             m_pCredModel->removeCredential(srcIndex);
         }
@@ -563,7 +565,8 @@ void CredentialsManagement::onCredentialSelected(const QModelIndex &current, con
         {
             m_selectionCanceled = true;
             auto selectionModel = ui->credentialTreeView->selectionModel();
-            selectionModel->setCurrentIndex(previous, QItemSelectionModel::ClearAndSelect);
+            selectionModel->setCurrentIndex(previous,
+                 QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
             return;
         }
     }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -74,10 +74,6 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->pushButtonFavorite->setMenu(&m_favMenu);
 
     m_pCredModel = new CredentialModel(this);
-    const QIcon i = AppGui::qtAwesome()->icon(fa::arrowcircleright, {{ "color", QColor("#0097a7") },
-                                                                     { "color-selected", QColor("#0097a7") },
-                                                                     { "color-active", QColor("#0097a7") }});
-    m_pCredModel->setLoginItemIcon(i);
 
     m_pCredModelFilter = new CredentialModelFilter(this);
     m_pCredModelFilter->setSourceModel(m_pCredModel);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -209,7 +209,7 @@ void CredentialsManagement::requestPasswordForSelectedItem()
     // Get selection model
     QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
     QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-    if (lIndexes.size() != 1)
+    if (lIndexes.size() != 2)
         return;
 
     // Retrieve src index
@@ -325,7 +325,7 @@ bool CredentialsManagement::confirmDiscardUneditedCredentialChanges(const QModel
     {
         QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
         QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-        if (lIndexes.size() != 1)
+        if (lIndexes.size() != 2)
             return true;
 
         srcIndex = getSourceIndexFromProxyIndex(lIndexes.first());
@@ -385,7 +385,7 @@ void CredentialsManagement::on_pushButtonCancel_clicked()
 
     // Retrieve selected indexes
     QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-    if (lIndexes.size() != 1)
+    if (lIndexes.size() != 2)
         return;
 
     // Retrieve src index
@@ -410,7 +410,7 @@ void CredentialsManagement::updateSaveDiscardState(const QModelIndex &proxyIndex
     {
         QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
         QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-        if (lIndexes.size() != 1)
+        if (lIndexes.size() != 2)
         {
             ui->pushButtonCancel->hide();
             ui->pushButtonConfirm->hide();
@@ -464,7 +464,7 @@ void CredentialsManagement::changeCurrentFavorite(int iFavorite)
 
     // Retrieve selected indexes
     QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-    if (lIndexes.size() != 1)
+    if (lIndexes.size() != 2)
         return;
 
     // Retrieve src index
@@ -487,7 +487,7 @@ void CredentialsManagement::on_pushButtonDelete_clicked()
 
     // Retrieve selected indexes
     QModelIndexList lIndexes = pSelectionModel->selectedIndexes();
-    if (lIndexes.size() != 1)
+    if (lIndexes.size() != 2)
         return;
 
     // Retrieve src index
@@ -511,6 +511,9 @@ void CredentialsManagement::on_pushButtonDelete_clicked()
         {
             ui->credDisplayFrame->setEnabled(false);
             clearLoginDescription();
+
+            auto selectionModel = ui->credentialTreeView->selectionModel();
+            selectionModel->setCurrentIndex(QModelIndex(), QItemSelectionModel::ClearAndSelect);
 
             m_pCredModel->removeCredential(srcIndex);
         }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -85,8 +85,7 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     connect(m_pCredModel, &CredentialModel::modelLoaded, ui->credentialTreeView, &CredentialView::onModelLoaded);
     connect(m_pCredModel, &CredentialModel::modelLoaded, this, &CredentialsManagement::onModelLoaded);
     connect(ui->credentialTreeView->selectionModel(), &QItemSelectionModel::currentChanged,
-            this, &CredentialsManagement::onCredentialSelected,
-            Qt::QueuedConnection);
+            this, &CredentialsManagement::onCredentialSelected);
     connect(this, &CredentialsManagement::loginSelected, this, &CredentialsManagement::onLoginSelected);
     connect(this, &CredentialsManagement::serviceSelected, this, &CredentialsManagement::onServiceSelected);
     connect(ui->credDisplayPasswordInput, &LockedPasswordLineEdit::unlockRequested, this, &CredentialsManagement::requestPasswordForSelectedItem);

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -30,14 +30,38 @@ QSize ItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelInd
     return defaultSize;
 }
 
+void ItemDelegate::paintServiceItem(QPainter *painter, const QStyleOptionViewItem &option, const ServiceItem *pServiceItem) const
+{
+    if (pServiceItem != nullptr)
+    {
+        QPen pen;
+        QString sLogins = pServiceItem->logins();
+
+        qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
+        painter->setRenderHint(QPainter::Antialiasing, true);
+
+        QFont f = loginFont();
+
+        if (!pServiceItem->isExpanded())
+        {
+            pen.setColor(QColor("#666666"));
+            painter->setFont(f);
+            painter->setPen(pen);
+            painter->drawText(option.rect, Qt::AlignRight, sLogins);
+        }
+    }
+}
+
 void ItemDelegate::paintFavorite(QPainter *painter, const QStyleOptionViewItem &option, int iFavorite) const
 {
     QFont f = loginFont();
-
+    int optionrecheight = option.rect.height();
+    QPoint topleft = option.rect.topLeft();
     QIcon star = AppGui::qtAwesome()->icon(fa::star);
-    QSize iconSz = QSize(option.rect.height(), option.rect.height()); //QSize(serviceMetrics.height(), serviceMetrics.height());
-    QPoint pos = option.rect.topRight() - QPoint(iconSz.width(), -(option.rect.height()-iconSz.height())/2);
+    QSize iconSz = QSize(option.rect.height(), option.rect.height());
+    QPoint pos = option.rect.topLeft() + QPoint(0, -(option.rect.height()-iconSz.height())/2);
     QRect iconRect(pos, iconSz);
+
     if (iFavorite != Common::FAV_NOT_SET)
         star.paint(painter, iconRect);
 
@@ -50,60 +74,52 @@ void ItemDelegate::paintFavorite(QPainter *painter, const QStyleOptionViewItem &
     painter->setPen(pen);
 
     if (iFavorite != Common::FAV_NOT_SET)
-        painter->drawText(iconRect, Qt::AlignCenter, sFavNumber);
+        painter->drawText(iconRect, Qt::AlignCenter , sFavNumber);
 }
 
-void ItemDelegate::paintServiceItem(QPainter *painter, const QStyleOptionViewItem &option, const ServiceItem *pServiceItem) const
+void ItemDelegate::paintArrow(QPainter *painter
+                              , const QStyleOptionViewItem &option
+                              , int iFavorite) const
 {
-    if (pServiceItem != nullptr)
-    {
-        QPen pen;
-        QString sLogins = pServiceItem->logins();
+    QIcon arrow = AppGui::qtAwesome()->icon(fa::arrowcircleright
+                                    , {{ "color", QColor("#0097a7") }
+                                    , { "color-selected", QColor("#0097a7") }
+                                    , { "color-active", QColor("#0097a7") }});
 
-        qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
-        painter->setRenderHint(QPainter::Antialiasing, true);
-
-        QFont f = loginFont();
-        const QFontMetrics serviceMetrics = QFontMetrics{f};
-
-        QRect dstRect = option.rect;
-        if (!pServiceItem->isExpanded())
-        {
-            QRect otherRect(dstRect.width() - serviceMetrics.width(sLogins),
-                            dstRect.y() + (dstRect.height() - serviceMetrics.height()) / 2,
-                            serviceMetrics.width(sLogins),
-                            dstRect.height());
-            pen.setColor(QColor("#666666"));
-            painter->setFont(f);
-            painter->setPen(pen);
-            painter->drawText(otherRect, Qt::AlignRight, sLogins);
-        }
-    }
+    QPoint arrowPos(option.rect.topLeft() + QPoint(option.rect.height()*1/2, 0));
+    QSize arrowSz(QSize(option.rect.height(), option.rect.height()));
+    QRect arrowRec(arrowPos, arrowSz);
+    arrow.paint(painter, arrowRec);
 }
 
-void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const
+void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option,  const LoginItem *pLoginItem) const
 {
     if (pLoginItem != nullptr)
     {
         ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
-
         if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
         {
-            QPen pen;
-            QString sDisplayedData = pLoginItem->updatedDate().toString(Qt::DefaultLocaleShortDate);
-
-            qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
-            painter->setRenderHint(QPainter::Antialiasing, true);
-
-            QFont f = loginFont();
-            QRect dstRect = option.rect;
-            pen.setColor(QColor("#666666"));
-            painter->setFont(f);
-            painter->setPen(pen);
-            painter->drawText(dstRect, sDisplayedData);
-            paintFavorite(painter, option, pLoginItem->favorite());
+            if (pLoginItem->favorite() == Common::FAV_NOT_SET)
+                paintArrow(painter, option, pLoginItem->favorite());
+            else
+                paintFavorite(painter, option, pLoginItem->favorite());
         }
     }
+}
+
+void ItemDelegate::paintDate(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const
+{
+    QPen pen;
+    QString sDisplayedData = pLoginItem->updatedDate().toString(Qt::DefaultLocaleShortDate);
+
+    qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    QFont f = loginFont();
+    pen.setColor(QColor("#666666"));
+    painter->setFont(f);
+    painter->setPen(pen);
+    painter->drawText(option.rect, Qt::AlignVCenter, sDisplayedData);
 }
 
 void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -112,13 +128,40 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
     {
         const CredentialModelFilter *pProxyModel = dynamic_cast<const CredentialModelFilter *>(index.model());
         const TreeItem *pItem = pProxyModel->getItemByProxyIndex(index);
+        const LoginItem *pLoginItem = dynamic_cast<const LoginItem *>(pItem);
         const ServiceItem *pServiceItem = dynamic_cast<const ServiceItem *>(pItem);
 
         painter->save();
-        painter->fillRect(option.rect, painter->background());
 
-        if ((pServiceItem != nullptr) && (!pServiceItem->isExpanded()))
+        QColor bkgColor("white");
+        if (pServiceItem != nullptr)
+        {
+            if (index.row()%2 == 0)
+                bkgColor.setNamedColor("#eef7fa");
+            else
+                bkgColor.setNamedColor("white");
+        }
+        else if (pLoginItem != nullptr)
+        {
+            if (index.parent().row()%2 == 0)
+                bkgColor.setNamedColor("#eef7fa");
+            else
+                bkgColor.setNamedColor("white");
+        }
+        painter->fillRect(option.rect, bkgColor);
+
+        if ((pServiceItem != nullptr)
+                && (!pServiceItem->isExpanded())
+                && index.column() == 0)
             paintServiceItem(painter, option, pServiceItem);
+        else if (pLoginItem != nullptr && index.column() == 1)
+        {
+            ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
+            if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
+                paintDate(painter, option, pLoginItem);
+        }
+        else if (pLoginItem != nullptr && index.column() == 0)
+            paintLoginItem(painter, option, pLoginItem);
 
         painter->restore();
     }

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -76,8 +76,7 @@ void ItemDelegate::paintFavorite(QPainter *painter, const QStyleOptionViewItem &
         painter->drawText(iconRect, Qt::AlignCenter , sFavNumber);
 }
 
-void ItemDelegate::paintArrow(QPainter *painter
-                              , const QStyleOptionViewItem &option) const
+void ItemDelegate::paintArrow(QPainter *painter, const QStyleOptionViewItem &option) const
 {
     QIcon arrow = AppGui::qtAwesome()->icon(fa::arrowcircleright
                                     , {{ "color", QColor("#0097a7") }
@@ -90,9 +89,7 @@ void ItemDelegate::paintArrow(QPainter *painter
     arrow.paint(painter, arrowRec);
 }
 
-void ItemDelegate::paintLoginItem(QPainter *painter
-                                  , const QStyleOptionViewItem &option
-                                  ,  const LoginItem *pLoginItem) const
+void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option,  const LoginItem *pLoginItem) const
 {
     if (pLoginItem != nullptr)
     {
@@ -113,8 +110,17 @@ void ItemDelegate::paintLoginItem(QPainter *painter
             font.setPointSize(10);
             painter->setFont(font);
 
-            QString indent(8, ' ');
-            painter->drawText(option.rect, Qt::AlignVCenter, indent + pLoginItem->name());
+            int indent = 0;
+            if (pLoginItem->favorite() == Common::FAV_NOT_SET)
+                indent += option.rect.height() * 2;
+            else
+                indent += option.rect.height();
+            QRect loginRect(option.rect.x() + indent,
+                            option.rect.y(),
+                            option.rect.width() - indent,
+                            option.rect.height());
+
+            painter->drawText(loginRect, Qt::AlignVCenter, pLoginItem->name());
         }
     }
 }

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -102,24 +102,6 @@ void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem 
             painter->setPen(pen);
             painter->drawText(dstRect, sDisplayedData);
             paintFavorite(painter, option, pLoginItem->favorite());
-
-/*
-            QFont f = loginFont();
-            const QFontMetrics serviceMetrics = QFontMetrics{f};
-
-            QRect dstRect = option.rect;
-            int delta = 4;
-            QRect otherRect(dstRect.width() - serviceMetrics.width(sDisplayedData) - delta,
-                            dstRect.y() + (dstRect.height() - serviceMetrics.height()) / 2,
-                            serviceMetrics.width(sDisplayedData) + delta,
-                            dstRect.height());
-
-            pen.setColor(QColor("#666666"));
-            painter->setFont(f);
-            painter->setPen(pen);
-            painter->drawText(otherRect, sDisplayedData);
-
-            paintFavorite(painter, option, pLoginItem->favorite());*/
         }
     }
 }
@@ -155,12 +137,7 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
 
         if ((pServiceItem != nullptr) && (!pServiceItem->isExpanded()))
             paintServiceItem(painter, option, pServiceItem);
-        else if (pLoginItem != nullptr)
-        {
-            ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
-           // if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
-           //     paintLoginItem(painter, option, pLoginItem);
-        }
+
         painter->restore();
     }
 

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -112,28 +112,10 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
     {
         const CredentialModelFilter *pProxyModel = dynamic_cast<const CredentialModelFilter *>(index.model());
         const TreeItem *pItem = pProxyModel->getItemByProxyIndex(index);
-        const LoginItem *pLoginItem = dynamic_cast<const LoginItem *>(pItem);
         const ServiceItem *pServiceItem = dynamic_cast<const ServiceItem *>(pItem);
 
         painter->save();
-
-        QColor bkgColor("white");
-        if (pServiceItem != nullptr)
-        {
-            if (index.row()%2 == 0)
-                bkgColor.setNamedColor("#eef7fa");
-            else
-                bkgColor.setNamedColor("white");
-        }
-        else if (pLoginItem != nullptr)
-        {
-            if (index.parent().row()%2 == 0)
-                bkgColor.setNamedColor("#eef7fa");
-            else
-                bkgColor.setNamedColor("white");
-        }
-
-        painter->fillRect(option.rect, bkgColor);
+        painter->fillRect(option.rect, painter->background());
 
         if ((pServiceItem != nullptr) && (!pServiceItem->isExpanded()))
             paintServiceItem(painter, option, pServiceItem);

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -55,8 +55,7 @@ void ItemDelegate::paintServiceItem(QPainter *painter, const QStyleOptionViewIte
 void ItemDelegate::paintFavorite(QPainter *painter, const QStyleOptionViewItem &option, int iFavorite) const
 {
     QFont f = loginFont();
-    int optionrecheight = option.rect.height();
-    QPoint topleft = option.rect.topLeft();
+
     QIcon star = AppGui::qtAwesome()->icon(fa::star);
     QSize iconSz = QSize(option.rect.height(), option.rect.height());
     QPoint pos = option.rect.topLeft() + QPoint(0, -(option.rect.height()-iconSz.height())/2);
@@ -78,8 +77,7 @@ void ItemDelegate::paintFavorite(QPainter *painter, const QStyleOptionViewItem &
 }
 
 void ItemDelegate::paintArrow(QPainter *painter
-                              , const QStyleOptionViewItem &option
-                              , int iFavorite) const
+                              , const QStyleOptionViewItem &option) const
 {
     QIcon arrow = AppGui::qtAwesome()->icon(fa::arrowcircleright
                                     , {{ "color", QColor("#0097a7") }
@@ -92,7 +90,9 @@ void ItemDelegate::paintArrow(QPainter *painter
     arrow.paint(painter, arrowRec);
 }
 
-void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option,  const LoginItem *pLoginItem) const
+void ItemDelegate::paintLoginItem(QPainter *painter
+                                  , const QStyleOptionViewItem &option
+                                  ,  const LoginItem *pLoginItem) const
 {
     if (pLoginItem != nullptr)
     {
@@ -100,7 +100,7 @@ void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem 
         if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
         {
             if (pLoginItem->favorite() == Common::FAV_NOT_SET)
-                paintArrow(painter, option, pLoginItem->favorite());
+                paintArrow(painter, option);
             else
                 paintFavorite(painter, option, pLoginItem->favorite());
         }
@@ -153,13 +153,15 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
         if ((pServiceItem != nullptr)
                 && (!pServiceItem->isExpanded())
                 && index.column() == 0)
-            paintServiceItem(painter, option, pServiceItem);
-        else if (pLoginItem != nullptr && index.column() == 1)
         {
-            ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
-            if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
-                paintDate(painter, option, pLoginItem);
+            paintServiceItem(painter, option, pServiceItem);
         }
+        //else if (pLoginItem != nullptr && index.column() == 1)
+        //{
+        //    ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
+        //    if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
+        //        paintDate(painter, option, pLoginItem);
+        //}
         else if (pLoginItem != nullptr && index.column() == 0)
             paintLoginItem(painter, option, pLoginItem);
 

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -103,23 +103,20 @@ void ItemDelegate::paintLoginItem(QPainter *painter
                 paintArrow(painter, option);
             else
                 paintFavorite(painter, option, pLoginItem->favorite());
+
+            QPen pen;
+            pen.setColor(QColor("#3D96AF"));
+            painter->setPen(pen);
+            QFont font = qApp->font();
+            font.setBold(true);
+            font.setItalic(true);
+            font.setPointSize(10);
+            painter->setFont(font);
+
+            QString indent(8, ' ');
+            painter->drawText(option.rect, Qt::AlignVCenter, indent + pLoginItem->name());
         }
     }
-}
-
-void ItemDelegate::paintDate(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const
-{
-    QPen pen;
-    QString sDisplayedData = pLoginItem->updatedDate().toString(Qt::DefaultLocaleShortDate);
-
-    qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
-    painter->setRenderHint(QPainter::Antialiasing, true);
-
-    QFont f = loginFont();
-    pen.setColor(QColor("#666666"));
-    painter->setFont(f);
-    painter->setPen(pen);
-    painter->drawText(option.rect, Qt::AlignVCenter, sDisplayedData);
 }
 
 void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -156,12 +153,6 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
         {
             paintServiceItem(painter, option, pServiceItem);
         }
-        //else if (pLoginItem != nullptr && index.column() == 1)
-        //{
-        //    ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
-        //    if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
-        //        paintDate(painter, option, pLoginItem);
-        //}
         else if (pLoginItem != nullptr && index.column() == 0)
             paintLoginItem(painter, option, pLoginItem);
 

--- a/src/ItemDelegate.cpp
+++ b/src/ItemDelegate.cpp
@@ -96,6 +96,15 @@ void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem 
             painter->setRenderHint(QPainter::Antialiasing, true);
 
             QFont f = loginFont();
+            QRect dstRect = option.rect;
+            pen.setColor(QColor("#666666"));
+            painter->setFont(f);
+            painter->setPen(pen);
+            painter->drawText(dstRect, sDisplayedData);
+            paintFavorite(painter, option, pLoginItem->favorite());
+
+/*
+            QFont f = loginFont();
             const QFontMetrics serviceMetrics = QFontMetrics{f};
 
             QRect dstRect = option.rect;
@@ -110,7 +119,7 @@ void ItemDelegate::paintLoginItem(QPainter *painter, const QStyleOptionViewItem 
             painter->setPen(pen);
             painter->drawText(otherRect, sDisplayedData);
 
-            paintFavorite(painter, option, pLoginItem->favorite());
+            paintFavorite(painter, option, pLoginItem->favorite());*/
         }
     }
 }
@@ -149,8 +158,8 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
         else if (pLoginItem != nullptr)
         {
             ServiceItem *pServiceItem = dynamic_cast<ServiceItem *>(pLoginItem->parentItem());
-            if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
-                paintLoginItem(painter, option, pLoginItem);
+           // if ((pServiceItem != nullptr) && (pServiceItem->isExpanded()))
+           //     paintLoginItem(painter, option, pLoginItem);
         }
         painter->restore();
     }

--- a/src/ItemDelegate.h
+++ b/src/ItemDelegate.h
@@ -24,9 +24,7 @@ private:
     void paintFavorite(QPainter *painter
                        , const QStyleOptionViewItem &option
                        , int iFavorite) const;
-    void paintArrow(QPainter *painter
-                    , const QStyleOptionViewItem &option
-                    , int iFavorite) const;
+    void paintArrow(QPainter *painter, const QStyleOptionViewItem &option) const;
     QFont loginFont() const;
     QFont favFont() const;
 };

--- a/src/ItemDelegate.h
+++ b/src/ItemDelegate.h
@@ -20,7 +20,13 @@ public:
 private:
     void paintServiceItem(QPainter *painter, const QStyleOptionViewItem &option, const ServiceItem *pServiceItem) const;
     void paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const;
-    void paintFavorite(QPainter *painter, const QStyleOptionViewItem &option, int iFavorite) const;
+    void paintDate(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const;
+    void paintFavorite(QPainter *painter
+                       , const QStyleOptionViewItem &option
+                       , int iFavorite) const;
+    void paintArrow(QPainter *painter
+                    , const QStyleOptionViewItem &option
+                    , int iFavorite) const;
     QFont loginFont() const;
     QFont favFont() const;
 };

--- a/src/ItemDelegate.h
+++ b/src/ItemDelegate.h
@@ -20,10 +20,7 @@ public:
 private:
     void paintServiceItem(QPainter *painter, const QStyleOptionViewItem &option, const ServiceItem *pServiceItem) const;
     void paintLoginItem(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const;
-    void paintDate(QPainter *painter, const QStyleOptionViewItem &option, const LoginItem *pLoginItem) const;
-    void paintFavorite(QPainter *painter
-                       , const QStyleOptionViewItem &option
-                       , int iFavorite) const;
+    void paintFavorite(QPainter *painter, const QStyleOptionViewItem &option, int iFavorite) const;
     void paintArrow(QPainter *painter, const QStyleOptionViewItem &option) const;
     QFont loginFont() const;
     QFont favFont() const;

--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -99,3 +99,8 @@ bool LoginItem::passwordLocked() const
 {
     return m_bPasswordLocked;
 }
+
+TreeItem::TreeType LoginItem::treeType() const
+{
+    return Login;
+}

--- a/src/LoginItem.h
+++ b/src/LoginItem.h
@@ -26,7 +26,7 @@ public:
     QString itemLabel() const;
     void setPasswordLocked(bool bVisible);
     bool passwordLocked() const;
-
+    virtual TreeType treeType()  const Q_DECL_OVERRIDE;
 private:    
     QByteArray m_bAddress;
     qint8 m_iFavorite;

--- a/src/RootItem.cpp
+++ b/src/RootItem.cpp
@@ -59,3 +59,8 @@ void RootItem::removeUnusedItems()
         }
     }
 }
+
+TreeItem::TreeType RootItem::treeType() const
+{
+    return Root;
+}

--- a/src/RootItem.h
+++ b/src/RootItem.h
@@ -15,6 +15,8 @@ public:
     ServiceItem *findServiceByName(const QString &sServiceName);
     void setItemsStatus(const Status &eStatus);
     void removeUnusedItems();
+
+    virtual TreeType treeType()  const Q_DECL_OVERRIDE;
 };
 
 #endif // ROOTITEM_H

--- a/src/ServiceItem.cpp
+++ b/src/ServiceItem.cpp
@@ -112,4 +112,9 @@ QDate ServiceItem::bestUpdateDate(Qt::SortOrder order) const
     return bestDate;
 }
 
+TreeItem::TreeType ServiceItem::treeType() const
+{
+    return Service;
+}
+
 

--- a/src/ServiceItem.cpp
+++ b/src/ServiceItem.cpp
@@ -88,4 +88,28 @@ QString ServiceItem::logins() const
     return sLogins;
 }
 
+QDate ServiceItem::bestUpdateDate(Qt::SortOrder order) const
+{
+    QDate bestDate = m_dUpdatedDate;
+    if (m_vChilds.length() > 0)
+    {
+        bestDate = m_vChilds[0]->updatedDate();
+        for ( int i=1 ; i < m_vChilds.length() ; i++ )
+        {
+            if (order == Qt::AscendingOrder)
+            {
+                if (m_vChilds[i]->updatedDate() > bestDate)
+                    bestDate = m_vChilds[i]->updatedDate();
+            }
+            else
+            {
+                if (m_vChilds[i]->updatedDate() < bestDate)
+                    bestDate = m_vChilds[i]->updatedDate();
+            }
+        }
+    }
+
+    return bestDate;
+}
+
 

--- a/src/ServiceItem.cpp
+++ b/src/ServiceItem.cpp
@@ -98,12 +98,12 @@ QDate ServiceItem::bestUpdateDate(Qt::SortOrder order) const
         {
             if (order == Qt::AscendingOrder)
             {
-                if (m_vChilds[i]->updatedDate() > bestDate)
+                if (m_vChilds[i]->updatedDate() < bestDate)
                     bestDate = m_vChilds[i]->updatedDate();
             }
             else
             {
-                if (m_vChilds[i]->updatedDate() < bestDate)
+                if (m_vChilds[i]->updatedDate() > bestDate)
                     bestDate = m_vChilds[i]->updatedDate();
             }
         }

--- a/src/ServiceItem.h
+++ b/src/ServiceItem.h
@@ -18,7 +18,7 @@ public:
     QString logins() const;
 
     virtual QDate bestUpdateDate(Qt::SortOrder order) const Q_DECL_OVERRIDE;
-
+    virtual TreeType treeType()  const Q_DECL_OVERRIDE;
 private:
     bool m_bIsExpanded;
 };

--- a/src/ServiceItem.h
+++ b/src/ServiceItem.h
@@ -17,6 +17,8 @@ public:
     void setExpanded(bool bExpanded);
     QString logins() const;
 
+    virtual QDate bestUpdateDate(Qt::SortOrder order) const Q_DECL_OVERRIDE;
+
 private:
     bool m_bIsExpanded;
 };

--- a/src/TreeItem.cpp
+++ b/src/TreeItem.cpp
@@ -45,7 +45,7 @@ int TreeItem::childCount() const
 int TreeItem::row() const
 {
     if (m_pParentItem)
-        return childs().indexOf(const_cast<TreeItem*>(this));
+        return m_pParentItem->childs().indexOf(const_cast<TreeItem*>(this));
 
     return 0;
 }

--- a/src/TreeItem.cpp
+++ b/src/TreeItem.cpp
@@ -75,6 +75,11 @@ const QDate &TreeItem::updatedDate() const
     return m_dUpdatedDate;
 }
 
+QDate TreeItem::bestUpdateDate(Qt::SortOrder) const
+{
+    return m_dUpdatedDate;
+}
+
 void TreeItem::setUpdatedDate(const QDate &dDate)
 {
     m_dUpdatedDate = dDate;

--- a/src/TreeItem.cpp
+++ b/src/TreeItem.cpp
@@ -145,3 +145,8 @@ void TreeItem::clear()
     qDeleteAll(m_vChilds);
     m_vChilds.clear();
 }
+
+TreeItem::TreeType TreeItem::treeType() const
+{
+    return Base;
+}

--- a/src/TreeItem.h
+++ b/src/TreeItem.h
@@ -20,6 +20,7 @@ public:
     const Status &status() const;
     void setStatus(const Status &eStatus);
     const QDate &updatedDate() const;
+    virtual QDate bestUpdateDate(Qt::SortOrder order) const;
     void setUpdatedDate(const QDate &dDate);
     const QDate &accessedDate() const;
     void setAccessedDate(const QDate &dDate);

--- a/src/TreeItem.h
+++ b/src/TreeItem.h
@@ -11,6 +11,7 @@ class TreeItem
 {
 public:
     enum Status {USED=0, UNUSED};
+    enum TreeType {Root = 0, Service, Login, Base};
     virtual ~TreeItem();
 
     const QString &name() const;
@@ -36,6 +37,7 @@ public:
     void addChild(TreeItem *pItem);
     bool removeOne(TreeItem *pItem);
     void clear();
+    virtual TreeType treeType()  const;
 
 protected:
     explicit TreeItem(const QString &sName = "",


### PR DESCRIPTION
Fix for 207.
In debug mode it will eventually assert in QAbstractItemModelPrivate::removePersistentIndexData, while deleting a QPersistentModelIndex. This occurs while handling a mouse click immediately following a sort, in QItemSelectionModel::setCurrentIndex while a copy of the previous index is being deleted.

CredentialView :
Add code so view knows the current login item. 
Handle layoutchanged signal after sorting, so the current item can be reset to the previous value.
Show header and enable sorting. Activating old sort by name code and new sort by date code.

CredentialModelFilter:
Add sort by date to lessThan. 
Override sort virtual function to remember sort order for lessThan.

CredentialModel:
Change number of columns to 2.
Modify data to return update date for new column row, and check column for other roles.
Add headerData function to return header text.

ItemDelegate:
Change so does not display date for login items.

TreeItem:
ServiceItem:
Add bestUpdateDate function to return the latest or earliest update date for item and/or subitems, dependant on sort order.