### PR TITLE
Lock mmm screen when the save button is clicked

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -207,6 +207,7 @@ void CredentialsManagement::on_buttonSaveChanges_clicked()
 {
     saveSelectedCredential();
 
+    ui->stackedWidget->setCurrentWidget(ui->pageLocked);
     wsClient->sendCredentialsMM(m_pCredModel->getJsonChanges());
     emit wantSaveMemMode(); //waits for the daemon to process the data
     m_pCredModel->clear();


### PR DESCRIPTION
The locked view is being set only when the memMgmtModeChanged is triggered. This sometimes happens after the progress view is hidden.
So we set the lock screen view in the CredentialsManagement.ui after the save button is clicked.