### PR TITLE
fix appearing of monitored backup save requests

### DIFF
--- a/gui.pro
+++ b/gui.pro
@@ -49,7 +49,8 @@ SOURCES += src/main_gui.cpp \
     src/PromptWidget.cpp \
     src/DbExportsRegistry.cpp \
     src/DbExportsRegistryController.cpp \
-    src/DbBackupChangeNumbersComparator.cpp
+    src/DbBackupChangeNumbersComparator.cpp \
+    src/DbMasterController.cpp
 
 HEADERS  += src/MainWindow.h \
     src/Common.h \
@@ -85,7 +86,8 @@ HEADERS  += src/MainWindow.h \
     src/PromptWidget.h \
     src/DbExportsRegistry.h \
     src/DbExportsRegistryController.h \
-    src/DbBackupChangeNumbersComparator.h
+    src/DbBackupChangeNumbersComparator.h \
+    src/DbMasterController.h
 
 mac {
     HEADERS += src/MacUtils.h

--- a/src/AppGui.h
+++ b/src/AppGui.h
@@ -32,7 +32,7 @@
 #include "DaemonMenuAction.h"
 #include <QtAwesome.h>
 
-class DbExportsRegistryController;
+class DbMasterController;
 class AppGui : public QApplication
 {
     Q_OBJECT
@@ -100,8 +100,7 @@ private:
      void startSSHAgent();
      void createMainWindow();
 
-     DbExportsRegistryController *dbExportsRegistryController;
-     void initializeDbExportsRegitry();
+     DbMasterController *dbMasterController;
 };
 
 #endif // APPGUI_H

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -99,6 +99,7 @@ Common::MPStatus Common::statusFromString(const QString &st)
             return it.key();
     }
 
+    qWarning() << "Unable to find value from enum for status" << st;
     return Common::UnknownStatus;
 }
 

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -40,12 +40,6 @@ DbBackupsTrackerController::DbBackupsTrackerController(MainWindow *window, WSCli
 
     connect(wsClient, &WSClient::fwVersionChanged,
             this, &DbBackupsTrackerController::handleFirmwareVersionChange);
-    connect(wsClient, &WSClient::cardDbMetadataChanged,
-            this, &DbBackupsTrackerController::handleCardDbMetadataChanged);
-    connect(wsClient, &WSClient::statusChanged,
-            this, &DbBackupsTrackerController::handleDeviceStatusChanged);
-    connect(wsClient, &WSClient::connectedChanged,
-            this, &DbBackupsTrackerController::handleDeviceConnectedChanged);
 
     handleFirmwareVersionChange(wsClient->get_fwVersion());
     handleDeviceStatusChanged(wsClient->get_status());
@@ -166,9 +160,6 @@ void DbBackupsTrackerController::askForExportBackup()
 
 void DbBackupsTrackerController::exportDbBackup()
 {
-    connect(wsClient, &WSClient::dbExported, this,
-            &DbBackupsTrackerController::handleExportDbResult);
-
     QString format;
     try
     {

--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -21,6 +21,12 @@ public:
 
     QString getBackupFilePath();
 
+    // they are not slots anymore. Will be called by dbMasterController.
+    void handleCardDbMetadataChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
+    void handleExportDbResult(const QByteArray &d, bool success);
+    void handleDeviceStatusChanged(const Common::MPStatus &status);
+    void handleDeviceConnectedChanged(const bool &connected);
+
 signals:
     void backupFilePathChanged(const QString &path);
 
@@ -28,15 +34,10 @@ public slots:
     void setBackupFilePath(const QString &path);
 
 protected slots:
-    void handleCardDbMetadataChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
     void handleGreaterDbBackupChangeNumber();
     void handleLowerDbBackupChangeNumber();
-    void handleExportDbResult(const QByteArray &d, bool success);
     void handleNewTrack(const QString &cardId, const QString &path);
-    void handleDeviceStatusChanged(const Common::MPStatus &status);
-    void handleDeviceConnectedChanged(const bool &connected);
     void handleFirmwareVersionChange(const QString &version);
-
 
 private:
     DbBackupsTracker dbBackupsTracker;

--- a/src/DbExportsRegistryController.h
+++ b/src/DbExportsRegistryController.h
@@ -14,26 +14,27 @@ class DbExportsRegistryController : public QObject
     MainWindow *window;
     WSClient *wsClient;
     bool wasDbExportRecommendedWithoutMainWindow;
+    bool handleExportResultEnabled = false;
 public:
     explicit DbExportsRegistryController(const QString &settingsFilePath, QObject *parent = nullptr);
     virtual ~DbExportsRegistryController();
 
     void setMainWindow(MainWindow *window);
     void setWSClient(WSClient *wsClient);
-    void writeDbToFile(const QByteArray &d, QString fname);
 
-signals:
-
-public slots:
+    // they are not slots anymore to prevent any attempts of connection to wsClient.
+    // they will be called by DbMasterController when no monitored backup is active.
     void handleCardIdChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
+    void handleDeviceStatusChanged(const Common::MPStatus &status);
+    void handleDeviceConnectedChanged(const bool &);
     void registerDbExported(const QByteArray &, bool success);
+    void handleExportDbResult(const QByteArray &d, bool success);
 
 protected slots:
     void handleDbExportRecommended();
-    void handleExportDbResult(const QByteArray &d, bool success);
-    void handleDeviceStatusChanged(const Common::MPStatus &status);
-    void handleDeviceConnectedChanged(const bool &);
+
 private:
+    void writeDbToFile(const QByteArray &d, QString fname);
     void exportDbBackup();
     void hidePrompt();
 };

--- a/src/DbMasterController.cpp
+++ b/src/DbMasterController.cpp
@@ -1,0 +1,99 @@
+#include "DbMasterController.h"
+#include "AppGui.h"
+
+#include "DbBackupsTrackerController.h"
+#include "DbExportsRegistryController.h"
+
+
+DbMasterController::DbMasterController(QObject *parent)
+    : QObject(parent)
+{
+    QString regitryFile = AppGui::getDataDirPath() + "/dbExportsRegistry.ini";
+    dbExportsRegistryController = new DbExportsRegistryController(regitryFile, this);
+}
+
+void DbMasterController::setMainWindow(MainWindow *window)
+{
+    dbExportsRegistryController->setMainWindow(window);
+
+    if (! dbBackupsTrackerController && window && wsClient)
+    {
+        dbBackupsTrackerController = new DbBackupsTrackerController(window, wsClient,
+                                                                    AppGui::getDataDirPath() + "/dbBackupTracks.ini", this);
+        connect(dbBackupsTrackerController, SIGNAL(backupFilePathChanged(QString)),
+                this, SIGNAL(backupFilePathChanged(QString)));
+    }
+}
+
+void DbMasterController::setWSClient(WSClient *client)
+{
+    Q_ASSERT(client);
+
+    wsClient = client;
+
+    connect(wsClient, &WSClient::cardDbMetadataChanged, this, &DbMasterController::handleCardIdChanged);
+    connect(wsClient, &WSClient::statusChanged, this, &DbMasterController::handleDeviceStatusChanged);
+    connect(wsClient, &WSClient::connectedChanged, this, &DbMasterController::handleDeviceConnectedChanged);
+    connect(wsClient, &WSClient::dbExported, this, &DbMasterController::registerDbExported);
+
+    dbExportsRegistryController->setWSClient(wsClient);
+}
+
+void DbMasterController::setBackupFilePath(const QString &path)
+{
+    Q_ASSERT(dbBackupsTrackerController);
+    dbBackupsTrackerController->setBackupFilePath(path);
+}
+
+QString DbMasterController::getBackupFilePath()
+{
+    if (! dbBackupsTrackerController)
+        return "";
+
+    return dbBackupsTrackerController->getBackupFilePath();
+}
+
+void DbMasterController::handleCardIdChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber)
+{
+    if (dbBackupsTrackerController) {
+        dbBackupsTrackerController->handleCardDbMetadataChanged(cardId, credentialsDbChangeNumber, dataDbChangeNumber);
+        if (! dbBackupsTrackerController->getBackupFilePath().isEmpty())
+            return; // monitored backup is active, no need of 'export registry' functionality
+    }
+
+    dbExportsRegistryController->handleCardIdChanged(cardId, credentialsDbChangeNumber, dataDbChangeNumber);
+}
+
+void DbMasterController::handleDeviceStatusChanged(const Common::MPStatus &status)
+{
+    if (dbBackupsTrackerController) {
+        dbBackupsTrackerController->handleDeviceStatusChanged(status);
+        if (! dbBackupsTrackerController->getBackupFilePath().isEmpty())
+            return;
+    }
+
+    dbExportsRegistryController->handleDeviceStatusChanged(status);
+}
+
+void DbMasterController::handleDeviceConnectedChanged(const bool &connected)
+{
+    if (dbBackupsTrackerController) {
+        dbBackupsTrackerController->handleDeviceConnectedChanged(connected);
+        if (! dbBackupsTrackerController->getBackupFilePath().isEmpty())
+            return;
+    }
+
+    dbExportsRegistryController->handleDeviceConnectedChanged(connected);
+}
+
+void DbMasterController::registerDbExported(const QByteArray &data, bool success)
+{
+    if (dbBackupsTrackerController) {
+        dbBackupsTrackerController->handleExportDbResult(data, success);
+        if (! dbBackupsTrackerController->getBackupFilePath().isEmpty())
+            return;
+    }
+
+    dbExportsRegistryController->registerDbExported(data, success);
+    dbExportsRegistryController->handleExportDbResult(data, success);
+}

--- a/src/DbMasterController.h
+++ b/src/DbMasterController.h
@@ -1,0 +1,57 @@
+#ifndef DBMASTERCONTROLLER_H
+#define DBMASTERCONTROLLER_H
+
+#include <QObject>
+#include "Common.h"
+
+class DbExportsRegistryController;
+class DbBackupsTrackerController;
+class MainWindow;
+class WSClient;
+
+
+/**
+ * This class is a coordinator for DbBackupsTrackerController and DbExportsRegistryController.
+ *
+ * That classes were created without any knowledge about each other.
+ * But we need to disable DbExportsRegistryController (periodical backup creation)
+ * in a case if monitored backup is configured (done by DbBackupsTrackerController).
+ *
+ * So the aim of this class is following:
+ * to receive all related signals from WSClient and pass them to
+ * DbBackupsTrackerController first, then, if a monitored backup is not configured
+ * for current CardId, to DbExportsRegistryController.
+ *
+ * This way we will avoid simultaniously and uncoordinated use of promptWidget in MainWindow.
+ */
+class DbMasterController : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DbMasterController(QObject *parent = nullptr);
+
+    void setMainWindow(MainWindow *window);
+    void setWSClient(WSClient *client);
+
+    void setBackupFilePath(const QString &path);
+    QString getBackupFilePath();
+
+
+signals:
+    void backupFilePathChanged(const QString &path);
+
+private slots:
+    void handleCardIdChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
+    void handleDeviceStatusChanged(const Common::MPStatus &status);
+    void handleDeviceConnectedChanged(const bool &connected);
+    void registerDbExported(const QByteArray &data, bool success);
+
+private:
+    MainWindow *window = nullptr;
+    WSClient *wsClient = nullptr;
+
+    DbExportsRegistryController *dbExportsRegistryController = nullptr;
+    DbBackupsTrackerController *dbBackupsTrackerController = nullptr;
+};
+
+#endif // DBMASTERCONTROLLER_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -74,7 +74,7 @@ void MainWindow::initHelpLabels()
     ui->label_ExportCSVHelp->setToolTip(tr("Export unencrypted passwords to comma-separated values text file."));
 }
 
-MainWindow::MainWindow(WSClient *client, QWidget *parent) :
+MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow),
     wsClient(client),
@@ -82,7 +82,8 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
     bAdvancedTabVisible(false),
     dbBackupTrakingControlsVisible(false),
     previousWidget(nullptr),
-    m_passwordProfilesModel(new PasswordProfilesModel(this))
+    m_passwordProfilesModel(new PasswordProfilesModel(this)),
+    dbMasterController(mc)
 {
     QSettings s;
     bSSHKeysTabVisibleOnDemand = s.value("settings/SSHKeysTabsVisibleOnDemand", true).toBool();
@@ -93,9 +94,6 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
 
     ui->setupUi(this);
     refreshAppLangCb();
-
-    dbBackupsTrackerController = new DbBackupsTrackerController(this, client,
-                                                                AppGui::getDataDirPath() + "/dbBackupTracks.ini", this);
 
     ui->checkBoxLongPress->setChecked(s.value("settings/long_press_cancel", true).toBool());
     connect(ui->checkBoxLongPress, &QCheckBox::toggled, [this](bool checked)
@@ -213,8 +211,8 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
     // DB Backups UI
     ui->toolButton_clearBackupFilePath->setIcon(AppGui::qtAwesome()->icon(fa::remove));
     ui->toolButton_setBackupFilePath->setIcon(AppGui::qtAwesome()->icon(fa::foldero));
-    ui->lineEdit_dbBackupFilePath->setText(dbBackupsTrackerController->getBackupFilePath());
-    connect(dbBackupsTrackerController, &DbBackupsTrackerController::backupFilePathChanged, [=] (const QString &path)
+    ui->lineEdit_dbBackupFilePath->setText(dbMasterController->getBackupFilePath());
+    connect(dbMasterController, &DbMasterController::backupFilePathChanged, [=] (const QString &path)
     {
         ui->lineEdit_dbBackupFilePath->setText(path);
     });
@@ -1375,7 +1373,7 @@ void MainWindow::retranslateUi()
 void MainWindow::on_toolButton_clearBackupFilePath_released()
 {
     ui->lineEdit_dbBackupFilePath->clear();
-    dbBackupsTrackerController->setBackupFilePath("");
+    dbMasterController->setBackupFilePath("");
 }
 
 void MainWindow::on_toolButton_setBackupFilePath_released()
@@ -1389,7 +1387,7 @@ void MainWindow::on_toolButton_setBackupFilePath_released()
     {
         QStringList fileNames = dialog.selectedFiles();
         ui->lineEdit_dbBackupFilePath->setText(fileNames.first());
-        dbBackupsTrackerController->setBackupFilePath(fileNames.first());
+        dbMasterController->setBackupFilePath(fileNames.first());
     }
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -22,7 +22,7 @@
 #include <QtWidgets>
 #include "WSClient.h"
 #include <QtAwesome.h>
-#include "DbExportsRegistry.h"
+#include "DbMasterController.h"
 #include "WindowLog.h"
 
 #include <DbBackupsTrackerController.h>
@@ -38,7 +38,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(WSClient *client, QWidget *parent = 0);
+    explicit MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent = 0);
     ~MainWindow();
 
     void daemonLogAppend(const QByteArray &logdata);
@@ -151,7 +151,7 @@ private:
     QMap<QWidget *, QPushButton *> m_tabMap;
     QWidget *previousWidget;
     PasswordProfilesModel *m_passwordProfilesModel;
-    DbBackupsTrackerController *dbBackupsTrackerController;
+    DbMasterController *dbMasterController;
     void initHelpLabels();
 };
 


### PR DESCRIPTION
Introduce DbMasterController  which is a coordinator for DbExportsRegistryController and DbBackupsTrackerController as they both tried to use the same MainWindow::promptWidget.
This class prevents situations when one class shows prompt for backup a database
and another immediately hides it.
