### PR TITLE
Fix warnings

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -139,6 +139,7 @@ bool AppGui::initialize()
                 mainWindowHide();
         }
 #else
+        Q_UNUSED(this)
         Q_UNUSED(reason)
 #endif
     });

--- a/src/CredentialModelFilter.h
+++ b/src/CredentialModelFilter.h
@@ -22,8 +22,8 @@ public:
     QModelIndexList getNextRow(const QModelIndex &rowIdx);
 
 protected:
-    virtual bool filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const;
-    virtual bool lessThan(const QModelIndex &srcLeft, const QModelIndex &srcRight) const;
+    virtual bool filterAcceptsRow(int iSrcRow, const QModelIndex &srcParent) const override;
+    virtual bool lessThan(const QModelIndex &srcLeft, const QModelIndex &srcRight) const override;
 
 private:
     bool acceptRow(int iSrcRow, const QModelIndex &srcParent) const;

--- a/src/ItemDelegate.h
+++ b/src/ItemDelegate.h
@@ -12,7 +12,8 @@ class ItemDelegate : public QStyledItemDelegate
 {
 public:
     explicit ItemDelegate(QWidget* parent = nullptr);
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option,
+                           const QModelIndex &index) const override;
     virtual void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;
     void emitSizeHintChanged(const QModelIndex &index);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -96,7 +96,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     refreshAppLangCb();
 
     ui->checkBoxLongPress->setChecked(s.value("settings/long_press_cancel", true).toBool());
-    connect(ui->checkBoxLongPress, &QCheckBox::toggled, [this](bool checked)
+    connect(ui->checkBoxLongPress, &QCheckBox::toggled, [](bool checked)
     {
         QSettings settings;
         settings.setValue("settings/long_press_cancel", checked);


### PR DESCRIPTION
Fixed some warnings:
- Unused `this` captured in lambda
- Added missing `override` keywords
- Marked `this` as unused on macOS since it is used on Windows and Linux