### PR TITLE
Fixed DbBackupsTrackerTests to correctly find test data

### DIFF
--- a/tests/DbBackupsTrackerTests.cpp
+++ b/tests/DbBackupsTrackerTests.cpp
@@ -61,7 +61,12 @@ void DbBackupsTrackerTests::trackFileNoCpz()
 
 QString DbBackupsTrackerTests::getTestsDataDirPath()
 {
+#ifdef SRCDIR
+    QString dir(SRCDIR);
+#else
     QString dir(__FILE__);
+#endif
+
     QFileInfo fileInfo(dir);
     dir = fileInfo.absoluteDir().absolutePath() + "/data/";
 


### PR DESCRIPTION
It didn't find the test data correctly when using a build folder, like "build/", not directly in the
root of the repository.

`SRCDIR` is defined in tests/tests.pro but DbBackupsTrackerTests.cpp used `__FILE__`.

Tests output excerpt before:
```
Totals: 8 passed, 10 failed, 0 skipped, 0 blacklisted
```

And after:
```
Totals: 18 passed, 0 failed, 0 skipped, 0 blacklisted
```