### PR TITLE
Fix ui: show monitored backup control for unknown card

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -946,6 +946,7 @@ void MainWindow::hidePrompt()
 void MainWindow::showDbBackTrackingControls(const bool &show)
 {
     dbBackupTrakingControlsVisible = show;
+    updatePage();
 }
 
 void MainWindow::wantExitFilesManagement()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -552,6 +552,7 @@ void MainWindow::changeEvent(QEvent *event)
 void MainWindow::updateBackupControlsVisibility()
 {
     ui->label_backupControlsTitle->setVisible(dbBackupTrakingControlsVisible);
+    ui->label_dbBackupMonitoringHelp->setVisible(dbBackupTrakingControlsVisible);
     ui->label_backupControlsDescription->setVisible(dbBackupTrakingControlsVisible);
     ui->lineEdit_dbBackupFilePath->setVisible(dbBackupTrakingControlsVisible);
     ui->toolButton_clearBackupFilePath->setVisible(dbBackupTrakingControlsVisible);


### PR DESCRIPTION
Fixed by the simplest way possible, but there were other variants of fix that I'd like to mention here.

Daemon sends messages in the following order (listed with connected MainWindow slots):

"mp_connected"    -> updatePage()
"status_changed"  -> updatePage()
"version_changed" -> DBBackupController::handleFirmwareVersionChange() -> window->showDbBackTrackingControls(true/false)

But the problem was showDbBackTrackingControls() only stores a 'bool' flag. It didn't actually change visibility status of widgets.

So I just called updatePage() from showDbBackTrackingControls().
Currently, there is no recursion possible because showDbBackTrackingControls() is called only from handleFirmwareVersionChange() which is called only by a signal WSClient::fwVersionChanged(). To avoid any possible recursion with future code change it may be called with QTimer::singleShot().

Another variant of fix is 'queued' connection in MainWindow constructor:

`    connect(wsClient, &WSClient::fwVersionChanged, this, &MainWindow::updatePage, Qt::QueuedConnection);
`
Queued connection is needed because DBBackupController is created after MainWindow, and connect to signals later, so will be called after MainWindow slots. But we need MainWindow::updatePage() to execute afterwards.
