### PR TITLE
Proper ⌘+Q behavior on Mac

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -234,5 +234,11 @@ Q_DECLARE_METATYPE(Common::MPHwVersion)
                                 "border: 1px solid #FcFcFc;"\
                             "}"
 
+enum class CloseBehavior
+{
+    CloseApp,
+    HideWindow
+};
+
 #endif // COMMON_H
 

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -2913,6 +2913,39 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </layout>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="closeBehaviorLayout">
+              <item>
+               <widget class="QLabel" name="closeBehaviorLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Behavior of ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="closeBehaviorSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QComboBox" name="closeBehaviorComboBox"/>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_41">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Two behaviors can be configured in app settings:
1. Close App -> Correctly closes down app
2. Hide Window -> Hides window and doesn't close the app

Since no File->Quit menu action was defined before, ⌘+Q would abruptly terminate the app without
calling all deleters as expected.