### PR TITLE
291 app image cant create desktop file for system integration

### DIFF
--- a/scripts/ci/linux/after_success.sh
+++ b/scripts/ci/linux/after_success.sh
@@ -14,7 +14,7 @@ FILENAME=moolticute_setup_$VERSION
 #Only build if the commit we are building is for the last tag
 if [ "$(git rev-list -n 1 $VERSION)" != "$(cat .git/HEAD)"  ]; then
     echo "Not uploading package"
-    return 0
+    exit 0
 fi
 
 mkdir -p $WDIR/redist

--- a/scripts/ci/linux/appimage.sh
+++ b/scripts/ci/linux/appimage.sh
@@ -90,7 +90,7 @@ cp -r /usr/lib/x86_64-linux-gnu/qt5/plugins/platforms/* $TARGET_DIR/lib/x86_64-l
 #TOFIX: Actually copying openssl is not working. SSL is going to try to load root certificates from the system
 # and the path differs from all distro...
 # More information here:
-# https://github.com/AppImage/AppImageKit/wiki/Desktop-Linux-Platform-Issues#certificates
+# https://gitlab.com/probono/platformissues#certificates
 
 #mkdir -p $APPDIR/lib/x86_64-linux-gnu/
 #cp /lib/x86_64-linux-gnu/libcrypto* /lib/x86_64-linux-gnu/libssl* $APPDIR/lib/x86_64-linux-gnu/

--- a/scripts/ci/linux/appimage.sh
+++ b/scripts/ci/linux/appimage.sh
@@ -121,6 +121,7 @@ delete_blacklisted
 ########################################################################
 
 get_desktopintegration $LOWERAPP
+patch -p0 ./usr/bin/moolticute.sh.wrapper < moolticute.sh.wrapper.patch
 
 ########################################################################
 # Determine the version of the app; also include needed glibc version

--- a/scripts/ci/linux/appimage.sh
+++ b/scripts/ci/linux/appimage.sh
@@ -121,7 +121,7 @@ delete_blacklisted
 ########################################################################
 
 get_desktopintegration $LOWERAPP
-patch -p0 ./usr/bin/moolticute.sh.wrapper < moolticute.sh.wrapper.patch
+patch -p0 ./usr/bin/moolticute.sh.wrapper < $SCRIPTDIR/moolticute.sh.wrapper.patch
 
 ########################################################################
 # Determine the version of the app; also include needed glibc version

--- a/scripts/ci/linux/moolticute.sh.wrapper.patch
+++ b/scripts/ci/linux/moolticute.sh.wrapper.patch
@@ -1,0 +1,10 @@
+--- moolticute.sh.wrapper.orig	2018-06-20 20:33:04.704640676 +0700
++++ moolticute.sh.wrapper	2018-06-20 20:35:06.145255625 +0700
+@@ -257,6 +257,7 @@
+   # For Exec we must use quotes
+   # For TryExec quotes is not supported, so, space must be replaced to \s
+   # https://askubuntu.com/questions/175404/how-to-add-space-to-exec-path-in-a-thumbnailer-descrption/175567
++  mkdir -p "$STAMP_DIR"
+   RESOURCE_NAME=$(echo "$VENDORPREFIX-$DESKTOPFILE_NAME" | sed -e 's/\.desktop//g')
+   desktop-file-install --rebuild-mime-info-cache \
+     --vendor=$VENDORPREFIX --set-key=Exec --set-value="\"${APPIMAGE}\" %U" \


### PR DESCRIPTION
Extra "mkdir" won't break anything.
I just need to make sure I didn't break the build process itself (let's see what CI says)