### PR TITLE
Lock device via Linux system events

### DIFF
--- a/gui.pro
+++ b/gui.pro
@@ -12,6 +12,9 @@ mac {
 win32 {
     LIBS += -luser32
 }
+linux {
+    QT += dbus
+}
 
 include(src/QtAwesome/QtAwesome/QtAwesome.pri)
 include (src/QSimpleUpdater/QSimpleUpdater.pri)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -538,12 +538,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(ui->checkBoxBoot, SIGNAL(toggled(bool)), this, SLOT(checkSettingsChanged()));
     connect(ui->checkBoxTuto, SIGNAL(toggled(bool)), this, SLOT(checkSettingsChanged()));
 
-#ifdef Q_OS_LINUX
-    ui->checkBoxLockDevice->setChecked(false);
-    ui->checkBoxLockDevice->setVisible(false);
-#else
     ui->checkBoxLockDevice->setChecked(s.value("settings/LockDeviceOnSystemEvents", true).toBool());
-#endif
     connect(ui->checkBoxLockDevice, &QCheckBox::toggled, this, &MainWindow::onLockDeviceSystemEventsChanged);
 
     connect(ui->comboBoxScreenBrightness, SIGNAL(currentIndexChanged(int)), this, SLOT(checkSettingsChanged()));
@@ -562,12 +557,10 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     //Setup the confirm view
     ui->widgetSpin->setPixmap(AppGui::qtAwesome()->icon(fa::circleonotch).pixmap(QSize(80, 80)));
 
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     connect(&eventHandler, &SystemEventHandler::screenLocked, this, &MainWindow::onSystemEvents);
     connect(&eventHandler, &SystemEventHandler::loggingOff, this, &MainWindow::onSystemEvents);
     connect(&eventHandler, &SystemEventHandler::goingToSleep, this, &MainWindow::onSystemEvents);
     connect(&eventHandler, &SystemEventHandler::shuttingDown, this, &MainWindow::onSystemEvents);
-#endif
 
     checkAutoStart();
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -24,10 +24,7 @@
 #include <QtAwesome.h>
 #include "DbMasterController.h"
 #include "WindowLog.h"
-
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
 #include "SystemEventHandler.h"
-#endif
 
 #include <DbBackupsTrackerController.h>
 
@@ -161,9 +158,7 @@ private:
     DbMasterController *dbMasterController;
     void initHelpLabels();
 
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     SystemEventHandler eventHandler;
-#endif
 };
 
 #endif // MAINWINDOW_H

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -57,6 +57,10 @@ SystemEventHandler::SystemEventHandler()
     // Catch suspend event from org.freedesktop.login1.
     sysBus.connect("", "/org/freedesktop/login1", "", "PrepareForSleep", "b", this,
                    SLOT(login1PrepareForSleep(bool)));
+
+    // Catch shutdown event from org.freedesktop.login1.
+    sysBus.connect("", "/org/freedesktop/login1", "", "PrepareForShutdown", "b", this,
+                   SLOT(login1PrepareForShutdown(bool)));
 #endif
 }
 
@@ -90,6 +94,8 @@ SystemEventHandler::~SystemEventHandler()
     auto sysBus = QDBusConnection::systemBus();
     sysBus.disconnect("", "/org/freedesktop/login1", "", "PrepareForSleep", "b", this,
                       SLOT(login1PrepareForSleep(bool)));
+    sysBus.connect("", "/org/freedesktop/login1", "", "PrepareForShutdown", "b", this,
+                   SLOT(login1PrepareForShutdown(bool)));
 #endif
 }
 
@@ -207,5 +213,13 @@ void SystemEventHandler::login1PrepareForSleep(bool active)
     if (active)
     {
         emit goingToSleep();
+    }
+}
+
+void SystemEventHandler::login1PrepareForShutdown(bool active)
+{
+    if (active)
+    {
+        emit shuttingDown();
     }
 }

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -41,6 +41,10 @@ SystemEventHandler::SystemEventHandler()
     // Catch Gnome shutdown events.
     bus.connect("", "", "org.gnome.SessionManager.ClientPrivate", "EndSession", "u", this,
                 SLOT(clientPrivateEndSession(quint32)));
+
+    // Catch org.freedesktop.ScreenSaver event (Used with KDE at least).
+    bus.connect("", "/org/freedesktop/ScreenSaver", "", "ActiveChanged", "b", this,
+                SLOT(screenSaverActiveChanged(bool)));
 #endif
 }
 
@@ -66,6 +70,8 @@ SystemEventHandler::~SystemEventHandler()
                 SLOT(upstartEventEmitted(QString,QStringList)));
     bus.disconnect("", "", "org.gnome.SessionManager.ClientPrivate", "EndSession", "u", this,
                 SLOT(clientPrivateEndSession(quint32)));
+    bus.disconnect("", "/org/freedesktop/ScreenSaver", "", "ActiveChanged", "b", this,
+                SLOT(screenSaverActiveChanged(bool)));
 #endif
 }
 
@@ -159,4 +165,12 @@ void SystemEventHandler::upstartEventEmitted(const QString &name, const QStringL
 void SystemEventHandler::clientPrivateEndSession(quint32 id)
 {
   emit loggingOff();
+}
+
+void SystemEventHandler::screenSaverActiveChanged(bool on)
+{
+    if (on)
+    {
+        emit screenLocked();
+    }
 }

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -45,6 +45,10 @@ SystemEventHandler::SystemEventHandler()
     // Catch org.freedesktop.ScreenSaver event (Used with KDE at least).
     bus.connect("", "/org/freedesktop/ScreenSaver", "", "ActiveChanged", "b", this,
                 SLOT(screenSaverActiveChanged(bool)));
+
+    // Catch KDE about-to-suspend event.
+    bus.connect("", "/org/kde/Solid/PowerManagement/Actions/SuspendSession", "", "aboutToSuspend",
+                this, SLOT(kdeAboutToSuspend()));
 #endif
 }
 
@@ -72,6 +76,8 @@ SystemEventHandler::~SystemEventHandler()
                 SLOT(clientPrivateEndSession(quint32)));
     bus.disconnect("", "/org/freedesktop/ScreenSaver", "", "ActiveChanged", "b", this,
                 SLOT(screenSaverActiveChanged(bool)));
+    bus.disconnect("", "/org/kde/Solid/PowerManagement/Actions/SuspendSession", "", "aboutToSuspend",
+                this, SLOT(kdeAboutToSuspend()));
 #endif
 }
 
@@ -177,4 +183,9 @@ void SystemEventHandler::screenSaverActiveChanged(bool on)
     {
         emit screenLocked();
     }
+}
+
+void SystemEventHandler::kdeAboutToSuspend()
+{
+    emit goingToSleep();
 }

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -155,10 +155,13 @@ void SystemEventHandler::readyToTerminate()
 
 void SystemEventHandler::upstartEventEmitted(const QString &name, const QStringList &env)
 {
-    Q_UNUSED(env);
     if (name == "desktop-lock")
     {
         emit screenLocked();
+    }
+    else if (name == "session-end" && env.size() == 1 && env.first().toLower() == "type=shutdown")
+    {
+        emit shuttingDown();
     }
 }
 

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -167,7 +167,8 @@ void SystemEventHandler::upstartEventEmitted(const QString &name, const QStringL
 
 void SystemEventHandler::clientPrivateEndSession(quint32 id)
 {
-  emit loggingOff();
+    Q_UNUSED(id);
+    emit loggingOff();
 }
 
 void SystemEventHandler::screenSaverActiveChanged(bool on)

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -37,6 +37,7 @@ private slots:
     void clientPrivateEndSession(quint32 id);
     void screenSaverActiveChanged(bool on);
     void kdeAboutToSuspend();
+    void login1PrepareForSleep(bool active);
 
 private:
 #ifdef Q_OS_MAC

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -35,6 +35,7 @@ public slots:
 private slots:
     void upstartEventEmitted(const QString &name, const QStringList &env);
     void clientPrivateEndSession(quint32 id);
+    void screenSaverActiveChanged(bool on);
 
 private:
 #ifdef Q_OS_MAC

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -36,6 +36,7 @@ private slots:
     void upstartEventEmitted(const QString &name, const QStringList &env);
     void clientPrivateEndSession(quint32 id);
     void screenSaverActiveChanged(bool on);
+    void kdeAboutToSuspend();
 
 private:
 #ifdef Q_OS_MAC

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -32,6 +32,9 @@ public slots:
     void readyToTerminate();
 #endif
 
+private slots:
+    void upstartEventEmitted(const QString &name, const QStringList &env);
+
 private:
 #ifdef Q_OS_MAC
     void *eventHandler = nullptr;

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -38,6 +38,7 @@ private slots:
     void screenSaverActiveChanged(bool on);
     void kdeAboutToSuspend();
     void login1PrepareForSleep(bool active);
+    void login1PrepareForShutdown(bool active);
 
 private:
 #ifdef Q_OS_MAC

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -34,6 +34,7 @@ public slots:
 
 private slots:
     void upstartEventEmitted(const QString &name, const QStringList &env);
+    void clientPrivateEndSession(quint32 id);
 
 private:
 #ifdef Q_OS_MAC


### PR DESCRIPTION
This builds on top of the previous feature about locking the device if certain system events were detected. Since Linux has a lot of different ways of handling things, it's a best effort trying to support general events and certain ones from Ubuntu, GNOME, and KDE environments.

DBus is used to detect the events so on Linux the project now depends on the QtDBus module.