### PR TITLE
Detect memory usage while checking integrity

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -1243,6 +1243,8 @@ void MPDevice::loadSingleNodeAndScan(AsyncJobs *jobs, const QByteArray &address,
     {
         if (data[MP_LEN_FIELD_INDEX] == 1)
         {
+            diagTotalBlocks++;
+
             /* Received one byte as answer: we are not allowed to read */
             //qDebug() << "Loading Node" << getNodeIdFromAddress(address) << "at page" << getFlashPageFromAddress(address) << ": we are not allowed to read there";
 
@@ -1268,10 +1270,13 @@ void MPDevice::loadSingleNodeAndScan(AsyncJobs *jobs, const QByteArray &address,
             }
             else
             {
+                diagTotalBlocks++;
+
                 // Node is loaded
                 if (!pnode->isValid())
                 {
                     //qDebug() << address.toHex() << ": empty node loaded";
+                    diagFreeBlocks++;
 
                     /* No point in keeping these nodes, simply delete them */
                     delete pnodeClone;
@@ -6201,6 +6206,8 @@ void MPDevice::startIntegrityCheck(const std::function<void(bool success, QStrin
     diagLastNbBytesPSec = 0;
     lastFlashPageScanned = 0;
     diagLastSecs = QDateTime::currentMSecsSinceEpoch()/1000;
+    diagFreeBlocks = 0;
+    diagTotalBlocks = 0;
 
     /* Load CTR, favorites, nodes... */
     memMgmtModeReadFlash(jobs, true, cbProgress, true, true, true);
@@ -6208,6 +6215,10 @@ void MPDevice::startIntegrityCheck(const std::function<void(bool success, QStrin
     connect(jobs, &AsyncJobs::finished, [this, cb](const QByteArray &)
     {
         qInfo() << "Finished loading the nodes in memory";
+        qInfo() << "Total blocks:" << diagTotalBlocks;
+        qInfo() << "Free blocks:" << diagFreeBlocks;
+        qInfo() << "Available blocks:" << diagTotalBlocks - diagFreeBlocks;
+        qInfo() << "Available credentials:" << (diagTotalBlocks - diagFreeBlocks) / 2;
 
         /* We finished loading the nodes in memory */
         AsyncJobs* repairJobs = new AsyncJobs("Checking memory contents...", this);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -137,7 +137,7 @@ public:
                           const MPDeviceProgressCb &cbProgress,
                           const std::function<void(bool success, int errCode, QString errMsg)> &cb);
     void exitMemMgmtMode(bool setMMMBool = true);
-    void startIntegrityCheck(const std::function<void(bool success, QString errstr)> &cb,
+    void startIntegrityCheck(const std::function<void(bool success, int freeBlocks, int totalBlocks, QString errstr)> &cb,
                              const MPDeviceProgressCb &cbProgress);
 
     //reload parameters from MP

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -337,6 +337,8 @@ private:
     qint64 diagLastSecs;
     quint32 diagNbBytesRec;
     quint32 diagLastNbBytesPSec;
+    int diagFreeBlocks = 0;
+    int diagTotalBlocks = 0;
 
     //command queue
     QQueue<MPCommand> commandQueue;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -75,7 +75,7 @@ private slots:
 //    void mpRemoved(MPDevice *);
 
     void integrityProgress(int total, int current, QString message);
-    void integrityFinished(bool success);
+    void integrityFinished(bool success, int freeBlocks, int totalBlocks);
 
     void loadingProgress(int total, int current, QString message);
 

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -203,9 +203,15 @@ void WSClient::onTextMessageReceived(const QString &message)
     {
         QJsonObject o = rootobj["data"].toObject();
         if (o.value("failed").toBool())
+        {
             emit memcheckFinished(false);
+        }
         else
-            emit memcheckFinished(true);
+        {
+            const auto freeBlocks = o.value("free_blocks").toInt();
+            const auto totalBlocks = o.value("total_blocks").toInt();
+            emit memcheckFinished(true, freeBlocks, totalBlocks);
+        }
     }
     else if (rootobj["msg"] == "progress_detailed")
     {

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -121,7 +121,7 @@ signals:
     void credentialsUpdated(const QString & service, const QString & login, const QString & description, bool success);
     void showAppRequested();
     void progressChanged(int total, int current, QString statusMsg);
-    void memcheckFinished(bool success);
+    void memcheckFinished(bool success, int freeBlocks = 0, int totalBlocks = 0);
     void dataFileRequested(const QString &service, const QByteArray &data, bool success);
     void dataFileSent(const QString &service, bool success);
     void dataFileDeleted(const QString &service, bool success);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -160,7 +160,7 @@ void WSServerCon::processMessage(const QString &message)
     {
         //start integrity check
         mpdevice->startIntegrityCheck(
-                    [=](bool success, QString errstr)
+                    [=](bool success, int freeBlocks, int totalBlocks, QString errstr)
         {
             if (!WSServer::Instance()->checkClientExists(this))
                 return;
@@ -176,6 +176,8 @@ void WSServerCon::processMessage(const QString &message)
 
             QJsonObject ores;
             ores["memcheck_status"] = "done"; //TODO: add return info here about the result of memcheck?
+            ores["free_blocks"] = freeBlocks;
+            ores["total_blocks"] = totalBlocks;
             oroot["data"] = ores;
             sendJsonMessage(oroot);
         },


### PR DESCRIPTION
While checking memory integrity the free and total blocks are counted. These two numbers are sent to MC in the end and displayed in the message box like "X of Y credential slots used."

Fixes #307.