### PR TITLE
318 odd export behavior

### DIFF
--- a/src/DbBackupsTracker.cpp
+++ b/src/DbBackupsTracker.cpp
@@ -183,7 +183,7 @@ QString DbBackupsTracker::getTrackedBackupFileFormat()
         return "none";
 
     if (isAnEncryptedBackup(d))
-        return "SympleCrypt";
+        return "SimpleCrypt";
 
     return "none";
 }

--- a/src/DbBackupsTracker.h
+++ b/src/DbBackupsTracker.h
@@ -53,7 +53,7 @@ public:
 
     /**
      * Guess the current tracked backup file format,
-     * currently suported: "none" and "SympleCrypt"
+     * currently suported: "none" and "SimpleCrypt"
      * throws: DbBackupsTrackerNoBackupFileSet
      */
     QString getTrackedBackupFileFormat();

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -160,15 +160,7 @@ void DbBackupsTrackerController::askForExportBackup()
 
 void DbBackupsTrackerController::exportDbBackup()
 {
-    QString format;
-    try
-    {
-        format = dbBackupsTracker.getTrackedBackupFileFormat();
-    }
-    catch (DbBackupsTrackerNoBackupFileSet)
-    {
-        format = "SimpleCrypt";
-    }
+    QString format = "SimpleCrypt";
 
     window->wantExportDatabase();
 

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -167,7 +167,7 @@ void DbBackupsTrackerController::exportDbBackup()
     }
     catch (DbBackupsTrackerNoBackupFileSet)
     {
-        format = "SympleCrypt";
+        format = "SimpleCrypt";
     }
 
     window->wantExportDatabase();

--- a/src/DbExportsRegistryController.cpp
+++ b/src/DbExportsRegistryController.cpp
@@ -41,6 +41,7 @@ void DbExportsRegistryController::setWSClient(WSClient *wsClient)
 {
     DbExportsRegistryController::wsClient = wsClient;
     dbExportsRegistry->setCurrentCardDbMetadata(wsClient->get_cardId(), wsClient->get_credentialsDbChangeNumber(), wsClient->get_dataDbChangeNumber());
+    connect(wsClient, &WSClient::dbExported, this, &DbExportsRegistryController::registerDbExported, Qt::UniqueConnection);
 }
 
 void DbExportsRegistryController::hidePrompt()
@@ -62,6 +63,17 @@ void DbExportsRegistryController::handleCardIdChanged(QString cardId, int creden
         dbExportsRegistry->setCurrentCardDbMetadata(QString(), -1, -1);
 }
 
+/**! Register the last export time by any reason.
+ *  This method will be called every time WSClient::dbExported signal is fired.
+ *
+ * The reason export was done may be:
+ *  - user clicked 'Export to File' button;
+ *  - monitored backup file was updated
+ *  - periodic backup was done
+ *
+ * FIXME: the fact daemon sent a backup doesn't mean it was actually
+ * written to file.
+ */
 void DbExportsRegistryController::registerDbExported(const QByteArray &, bool success)
 {
     if (success)
@@ -107,22 +119,24 @@ void DbExportsRegistryController::handleDbExportRecommended()
 
 void DbExportsRegistryController::handleExportDbResult(const QByteArray &d, bool success)
 {
-    if (! handleExportResultEnabled)
-        return;
-    handleExportResultEnabled = false;
+    // one-time connection
+    disconnect(wsClient, &WSClient::dbExported, this, &DbExportsRegistryController::handleExportDbResult);
 
     if (window)
         window->handleBackupExported();
 
-    if (success)
+    if (! success)
     {
-        QString fname = QFileDialog::getSaveFileName(window, tr("Save database export..."), QString(),
-                                                     "Memory exports (*.bin);;All files (*.*)");
-        if (!fname.isEmpty())
-            writeDbToFile(d, fname);
-    }
-    else
         QMessageBox::warning(window, tr("Error"), tr(d));
+        return;
+    }
+
+    QString fname = QFileDialog::getSaveFileName(window, tr("Save database export..."), QString(),
+                                                 "Memory exports (*.bin);;All files (*.*)");
+    if (fname.isEmpty())
+        return;
+
+    writeDbToFile(d, fname);
 }
 
 void DbExportsRegistryController::handleDeviceStatusChanged(const Common::MPStatus &status)
@@ -154,5 +168,9 @@ void DbExportsRegistryController::exportDbBackup()
 
     if (window)
         window->wantExportDatabase();
+
+    // one-time connection, must be disconected immediately in the slot
+    connect(wsClient, &WSClient::dbExported, this, &DbExportsRegistryController::handleExportDbResult);
+
     wsClient->exportDbFile(format);
 }

--- a/src/DbExportsRegistryController.cpp
+++ b/src/DbExportsRegistryController.cpp
@@ -164,7 +164,7 @@ void DbExportsRegistryController::exportDbBackup()
 {
     handleExportResultEnabled = true;
 
-    QString format = "SympleCrypt";
+    QString format = "SimpleCrypt";
 
     if (window)
         window->wantExportDatabase();

--- a/src/DbMasterController.cpp
+++ b/src/DbMasterController.cpp
@@ -34,7 +34,6 @@ void DbMasterController::setWSClient(WSClient *client)
     connect(wsClient, &WSClient::cardDbMetadataChanged, this, &DbMasterController::handleCardIdChanged);
     connect(wsClient, &WSClient::statusChanged, this, &DbMasterController::handleDeviceStatusChanged);
     connect(wsClient, &WSClient::connectedChanged, this, &DbMasterController::handleDeviceConnectedChanged);
-    connect(wsClient, &WSClient::dbExported, this, &DbMasterController::registerDbExported);
 
     dbExportsRegistryController->setWSClient(wsClient);
 }
@@ -84,16 +83,4 @@ void DbMasterController::handleDeviceConnectedChanged(const bool &connected)
     }
 
     dbExportsRegistryController->handleDeviceConnectedChanged(connected);
-}
-
-void DbMasterController::registerDbExported(const QByteArray &data, bool success)
-{
-    if (dbBackupsTrackerController) {
-        dbBackupsTrackerController->handleExportDbResult(data, success);
-        if (! dbBackupsTrackerController->getBackupFilePath().isEmpty())
-            return;
-    }
-
-    dbExportsRegistryController->registerDbExported(data, success);
-    dbExportsRegistryController->handleExportDbResult(data, success);
 }

--- a/src/DbMasterController.h
+++ b/src/DbMasterController.h
@@ -44,7 +44,6 @@ private slots:
     void handleCardIdChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
     void handleDeviceStatusChanged(const Common::MPStatus &status);
     void handleDeviceConnectedChanged(const bool &connected);
-    void registerDbExported(const QByteArray &data, bool success);
 
 private:
     MainWindow *window = nullptr;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1168,8 +1168,9 @@ void MainWindow::on_pushButtonExportFile_clicked()
     else
         wsClient->exportDbFile("SimpleCrypt");
 
-
+    // one-time connection, must be disconected immediately in the slot
     connect(wsClient, &WSClient::dbExported, this, &MainWindow::dbExported);
+
     wantExportDatabase();
 }
 
@@ -1194,8 +1195,10 @@ void MainWindow::on_pushButtonImportFile_clicked()
 
 void MainWindow::dbExported(const QByteArray &d, bool success)
 {
-    ui->widgetHeader->setEnabled(true);
+    // one-time connection
     disconnect(wsClient, &WSClient::dbExported, this, &MainWindow::dbExported);
+
+    ui->widgetHeader->setEnabled(true);
     if (!success)
         QMessageBox::warning(this, tr("Error"), tr(d));
     else

--- a/tests/DbBackupsTrackerTests.cpp
+++ b/tests/DbBackupsTrackerTests.cpp
@@ -323,13 +323,13 @@ void DbBackupsTrackerTests::getFileFormatLegacy()
     t->deleteLater();
 }
 
-void DbBackupsTrackerTests::getFileFormatSympleCrypt()
+void DbBackupsTrackerTests::getFileFormatSimpleCrypt()
 {
     DbBackupsTracker* t = new DbBackupsTracker("/tmp/test_db_backups_tracker.info");
     t->setCardId("00000");
     QString file = getTestsDataDirPath() + "tests_backup";
     t->track(file);
 
-    QCOMPARE(QString("SympleCrypt"), t->getTrackedBackupFileFormat());
+    QCOMPARE(QString("SimpleCrypt"), t->getTrackedBackupFileFormat());
     t->deleteLater();
 }

--- a/tests/DbBackupsTrackerTests.h
+++ b/tests/DbBackupsTrackerTests.h
@@ -30,7 +30,7 @@ private slots:
     void credentialChangenumberWrapOver();
 
     void getFileFormatLegacy();
-    void getFileFormatSympleCrypt();
+    void getFileFormatSimpleCrypt();
 
 private:
     DbBackupsTracker tracker;


### PR DESCRIPTION
fix #318: fix WSClient::dbExported signal handling

Use the signal consistently: only a part of the program which requested an export should give the export results.

Fix typo SympleCrypt => SimpleCrypt to use 'SimpleCrypt' encryption instead of 'none' in periodic and auto-prompted exports.