### PR TITLE
fix #319: add new level of knock sensitivity: "Very Low"

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -554,10 +554,16 @@ void MPDevice::loadParameters()
                                   QByteArray(1, MPParams::MINI_KNOCK_THRES_PARAM),
                                   [this](const QByteArray &data, bool &) -> bool
     {
-        qDebug() << "received knockSensitivity: " << (quint8)data.at(2);
-        int v = 1;
-        if (data.at(2) == 11) v = 0;
-        else if (data.at(2) == 5) v = 2;
+        qDebug() << "received knock threshold: " << (quint8)data.at(2);
+
+        // The conversion of the real-device 'knock threshold' property
+        // to our made-up 'knock sensitivity' property:
+        int v;
+        quint8 s = data.at(2);
+        if      (s >= KNOCKING_VERY_LOW) v = 0;
+        else if (s >= KNOCKING_LOW)      v = 1;
+        else if (s >= KNOCKING_MEDIUM)   v = 2;
+        else v = 3;
         set_knockSensitivity(v);
         return true;
     }));
@@ -833,11 +839,19 @@ void MPDevice::updateDelayAfterKeyEntry(int val)
     updateParam(MPParams::DELAY_AFTER_KEY_ENTRY_PARAM, val);
 }
 
-void MPDevice::updateKnockSensitivity(int s) // 0-low, 1-medium, 2-high
+void MPDevice::updateKnockSensitivity(int s) // 0-very low, 1-low, 2-medium, 3-high
 {
-    quint8 v = 8;
-    if (s == 0) v = 11;
-    else if (s == 2) v = 5;
+    quint8 v;
+    switch(s)
+    {
+    case 0: v = KNOCKING_VERY_LOW; break;
+    case 1: v = KNOCKING_LOW; break;
+    case 2: v = KNOCKING_MEDIUM; break;
+    case 3: v = KNOCKING_HIGH; break;
+    default:
+        v = KNOCKING_MEDIUM;
+    }
+
     updateParam(MPParams::MINI_KNOCK_THRES_PARAM, v);
 }
 

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -83,7 +83,7 @@ class MPDevice: public QObject
     //MP Mini only
     QT_WRITABLE_PROPERTY(int, screenBrightness, 0) //51-20%, 89-35%, 128-50%, 166-65%, 204-80%, 255-100%
     QT_WRITABLE_PROPERTY(bool, knockEnabled, false)
-    QT_WRITABLE_PROPERTY(int, knockSensitivity, 0) // 0-low, 1-medium, 2-high
+    QT_WRITABLE_PROPERTY(int, knockSensitivity, 0) // 0-very low, 1-low, 2-medium, 3-high
     QT_WRITABLE_PROPERTY(bool, randomStartingPin, false)
     QT_WRITABLE_PROPERTY(bool, hashDisplay, false)
     QT_WRITABLE_PROPERTY(int, lockUnlockMode, 0)
@@ -98,6 +98,14 @@ class MPDevice: public QObject
 public:
     MPDevice(QObject *parent);
     virtual ~MPDevice();
+
+    enum KnockSensitivityThreshold
+    {
+        KNOCKING_VERY_LOW = 15,
+        KNOCKING_LOW = 11,
+        KNOCKING_MEDIUM = 8,
+        KNOCKING_HIGH = 5
+    };
 
     /* Send a command with data to the device */
     void sendData(MPCmd::Command cmd, const QByteArray &data = QByteArray(), quint32 timeout = CMD_DEFAULT_TIMEOUT, MPCommandCb cb = [](bool, const QByteArray &, bool &){}, bool checkReturn = true);
@@ -124,7 +132,7 @@ public:
     //MP Mini only
     void updateScreenBrightness(int bval); //51-20%, 89-35%, 128-50%, 166-65%, 204-80%, 255-100%
     void updateKnockEnabled(bool en);
-    void updateKnockSensitivity(int s); // 0-low, 1-medium, 2-high
+    void updateKnockSensitivity(int s); // 0-very low, 1-low, 2-medium, 3-high
     void updateRandomStartingPin(bool);
     void updateHashDisplay(bool);
     void updateLockUnlockMode(int);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -265,9 +265,10 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->comboBoxScreenBrightness->addItem("65%", 166);
     ui->comboBoxScreenBrightness->addItem("80%", 204);
     ui->comboBoxScreenBrightness->addItem("100%", 255);
-    ui->comboBoxKnock->addItem(tr("Low"), 0);
-    ui->comboBoxKnock->addItem(tr("Medium"), 1);
-    ui->comboBoxKnock->addItem(tr("High"), 2);
+    ui->comboBoxKnock->addItem(tr("Very Low"), 0);
+    ui->comboBoxKnock->addItem(tr("Low"), 1);
+    ui->comboBoxKnock->addItem(tr("Medium"), 2);
+    ui->comboBoxKnock->addItem(tr("High"), 3);
     ui->comboBoxLoginOutput->addItem(tr("Tab"), 43);
     ui->comboBoxLoginOutput->addItem(tr("Enter"), 40);
     ui->comboBoxLoginOutput->addItem(tr("Space"), 44);


### PR DESCRIPTION
WebSocket API was changed: parameter "knock_sensitivity":
  old values:  0-low, 1-medium, 2-high
  new values:  0-very low, 1-low, 2-medium, 3-high