### PR TITLE
Fix issue #331 MacOS, "The Moolticute Daemon is Not Running"

### DIFF
--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -153,5 +153,5 @@ QHostAddress AppDaemon::getListenAddress()
     if (anyAddress)
         return QHostAddress::Any;
 
-    return QHostAddress::LocalHost;
+    return QHostAddress::LocalHostIPv6;
 }


### PR DESCRIPTION
With QHostAddress::LocalHost there is a 30 secs delay until  we get the QWebSocketServer::newConnection signal, while with Any or LocalHostIPv6 it works instantly.