### PR TITLE
Implement issue #326 feature request: github release notes in update …

### DIFF
--- a/src/QSimpleUpdater/src/Updater.cpp
+++ b/src/QSimpleUpdater/src/Updater.cpp
@@ -431,6 +431,10 @@ void Updater::setUpdateAvailable (const bool available)
 
     if (updateAvailable() && (notifyOnUpdate() || notifyOnFinish())) {
         QString text = tr ("Would you like to download the update now?");
+        if (!m_changelog.isEmpty())
+        {
+            text += getFormattedChangeLog();
+        }
         QString title = "<h3>"
                         + tr ("Version %1 of %2 has been released!")
                         .arg (latestVersion()).arg (moduleName())
@@ -492,4 +496,36 @@ bool Updater::compare (const QString& x, const QString& y)
     }
 
     return versionsY.count() < versionsX.count();
+}
+
+/**
+ * Returns the formatted changeLog with HTML tags.
+ */
+QString Updater::getFormattedChangeLog() const
+{
+    const QString LIST_NEWLINE = "\r\n";
+
+    QString formattedChangeLog = "<br><br><b>"
+            + tr("Change log:")
+            + "</b><br>";
+
+    /*Handling list, if the changeLog contains \r\n.*/
+    if (m_changelog.contains(LIST_NEWLINE))
+    {
+        QStringList listParts = m_changelog.split(LIST_NEWLINE);
+        auto listItr = listParts.begin();
+        formattedChangeLog += *listItr++;
+
+        formattedChangeLog += "<ul>";
+        while (listItr != listParts.end())
+        {
+            formattedChangeLog += "<li>" + *listItr++ + "</li>";
+        }
+        formattedChangeLog += "</ul>";
+    }
+    else
+    {
+        formattedChangeLog += m_changelog;
+    }
+    return formattedChangeLog;
 }

--- a/src/QSimpleUpdater/src/Updater.h
+++ b/src/QSimpleUpdater/src/Updater.h
@@ -89,6 +89,7 @@ private slots:
 
 private:
     bool compare (const QString& x, const QString& y);
+    QString getFormattedChangeLog() const;
 
 private:
     QString m_url;


### PR DESCRIPTION
…prompt

Adding changelog informations if available to Updater's messageBox  with formatting.

e.g.: Using Release information from v.0.18.6-testing release (https://github.com/mooltipass/moolticute/releases/tag/v0.18.6-testing):
![changelog18_6_testing](https://user-images.githubusercontent.com/11043249/45268819-1ae91b00-b483-11e8-9a30-a44c696b05bd.jpg)

