### PR TITLE
Fixing Windows release build

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -99,7 +99,7 @@ bool AppGui::initialize()
     });
 
     QAction* quitAction = new QAction(tr("&Quit"), this);
-    connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
+    connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit, Qt::QueuedConnection);
 
     QMenu *systrayMenu = new QMenu();
 
@@ -334,6 +334,7 @@ void AppGui::updateSystrayTooltip()
 
 AppGui::~AppGui()
 {
+    timerDaemon->stop();
 #ifndef Q_OS_WIN
     if (sshAgentProcess)
     {

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -70,6 +70,7 @@ SystemEventHandler::~SystemEventHandler()
     Q_ASSERT(eventHandler);
     unregisterSystemHandler(eventHandler);
 #elif defined(Q_OS_WIN)
+    qDebug() << "Closing SystemEventHandler";
     qApp->removeNativeEventFilter(this);
 
     if (wtsApi32Lib.isLoaded())


### PR DESCRIPTION
Issues:
-timerDaemon was still running during destruction so it was possible that AppGui::searchDaemonTick()  was called with during that time
-~SystemEventHandler() had some issue, if I added a qDebug log, then it did no crashed anymore (maybe some timing issue). This was called after MainWindow's destructor finished. Crashed only in release build.
-Added Qt::QueuedConnection flag to quitAction for safer quit.