### PR TITLE
Fix Issue #331 MacOS, "The Moolticute Daemon is Not Running"

### DIFF
--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -96,9 +96,11 @@ bool AppDaemon::initialize()
                                      QCoreApplication::translate("main", "Activate emulation mode, all Websocket API function return emulated string, useful if you want to try the API."));
     parser.addOption(emulMode);
 
+#ifndef Q_OS_MAC
     QCommandLineOption anyAddressOption(QStringList() << "a" << "any-address",
                                      QCoreApplication::translate("main", "Listen on any address. By default, it listens only on localhost."));
     parser.addOption(anyAddressOption);
+#endif
 
     // An option with a value
     QCommandLineOption debugHttpServer(QStringList() << "s" << "debug-http-server",
@@ -109,10 +111,11 @@ bool AppDaemon::initialize()
     parser.process(qApp->arguments());
 
     emulationMode = parser.isSet(emulMode);
-    anyAddress = parser.isSet(anyAddressOption);
 
 #ifdef Q_OS_MAC
     anyAddress = true;
+#else
+    anyAddress = parser.isSet(anyAddressOption);
 #endif
 
     if (parser.isSet(debugHttpServer))

--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -111,6 +111,10 @@ bool AppDaemon::initialize()
     emulationMode = parser.isSet(emulMode);
     anyAddress = parser.isSet(anyAddressOption);
 
+#ifdef Q_OS_MAC
+    anyAddress = true;
+#endif
+
     if (parser.isSet(debugHttpServer))
     {
         httpServer = new HttpServer(this);
@@ -153,5 +157,5 @@ QHostAddress AppDaemon::getListenAddress()
     if (anyAddress)
         return QHostAddress::Any;
 
-    return QHostAddress::LocalHostIPv6;
+    return QHostAddress::LocalHost;
 }


### PR DESCRIPTION
Communication with browser extension did not worked with LocalHostIPv6, so reverted to using Localhost and Any on Mac. Because on Mac with Localhost option "The Moolticute Daemon is Not Running" message remains for 30 seconds before Device Settings appears.