### PR TITLE
issue #324 fix crash on second instance run

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -347,7 +347,9 @@ void AppGui::updateSystrayTooltip()
 
 AppGui::~AppGui()
 {
-    timerDaemon->stop();
+    if (timerDaemon)
+        timerDaemon->stop();
+
 #ifndef Q_OS_WIN
     if (sshAgentProcess)
     {
@@ -505,6 +507,10 @@ void AppGui::slotConnectionEstablished()
 {
     //We have a new instance that wants to be opened
     QLocalSocket *currSocket = localServer->nextPendingConnection();
+
+    connect(currSocket, &QLocalSocket::disconnected,
+            currSocket, &QLocalSocket::deleteLater);
+
     connect(currSocket, &QLocalSocket::readyRead, [=]()
     {
         QString data(currSocket->readAll());
@@ -526,10 +532,6 @@ void AppGui::slotConnectionEstablished()
             ::SetWindowPos(hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
 #endif
         }
-    });
-    connect(currSocket, &QLocalSocket::disconnected, [=]()
-    {
-        delete currSocket;
     });
 }
 


### PR DESCRIPTION
* timerDaemon is not initialized when an instance is already running;
* currSocket: use 'deleteLater' as shown in http://doc.qt.io/qt-5/qtcore-ipc-localfortuneserver-server-cpp.html
code clean up: daemonAction is not unused

Note: in the current state GUI is unable to connect to the daemon
because daemon is listening on IPv6 interface, but GUI tries to connect via IPv4
after 844e09eca53d - this problem is out-of-scope or this PR