### PR TITLE
Fixing crash on Mac from orderFrontRegardless

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -378,10 +378,14 @@ void AppGui::mainWindowShow()
     }
 
     win->show();
+#ifdef Q_OS_MAC
+    win->raise();
+    win->activateWindow();
+#endif
+
     showConfigApp->setText(tr("&Hide Moolticute App"));
 #ifdef Q_OS_MAC
     utils::mac::hideDockIcon(false);
-    utils::mac::orderFrontRegardless(win->winId(), true);
 #endif
 }
 


### PR DESCRIPTION
orderFrontRegardless was responsible on Mac to show the MainWindow on the top after it was hidden. However it crashed very often and even if it was not crashing, it hasn't brought the window in front.
It crashed because the used winId is changing during runtime, so it is dangerous to use it:
http://doc.qt.io/archives/qt-4.8/qwidget.html#winId
Instead of orderFrontRegardless the raise and activateWIndow call is bringing the MainWindow to the top level after clicking show without a crash.