### PR TITLE
Fixing build issue with newer compiler

### DIFF
--- a/src/WSServer.cpp
+++ b/src/WSServer.cpp
@@ -109,7 +109,7 @@ void WSServer::notifyGUI(const QString &message, bool &isGuiRunning)
         //Notify GUI
         if (it.key()->resourceName().contains("localhost") && !(it.key()->origin().contains("extension")))
         {
-            it.value()->sendJsonMessage(message);
+            it.value()->sendJsonMessageString(message);
             isGuiRunning = true;
             return;
         }

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -41,7 +41,7 @@ void WSServerCon::sendJsonMessage(const QJsonObject &data)
     // wsClient->flush();
 }
 
-void WSServerCon::sendJsonMessage(const QString &data)
+void WSServerCon::sendJsonMessageString(const QString &data)
 {
     wsClient->sendTextMessage(data);
 }

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -34,7 +34,7 @@ public:
     virtual ~WSServerCon();
 
     void sendJsonMessage(const QJsonObject &data);
-    void sendJsonMessage(const QString &data);
+    void sendJsonMessageString(const QString &data);
     void resetDevice(MPDevice *dev);
     void sendInitialStatus();
 


### PR DESCRIPTION
I experienced this issue with the newest Qt version and compiler, there was no problem on the previous one and on Travis.
Function calls like "sendJsonMessage({{ "msg", "mp_disconnected" }});" causing compile error because of  the brace initialization calls.