### PR TITLE
Adding missing Hungarian language file

### DIFF
--- a/lang.qrc
+++ b/lang.qrc
@@ -9,5 +9,6 @@
         <file>lang/mc_br.qm</file>
         <file>lang/mc_tr.qm</file>
         <file>lang/mc_sv.qm</file>
+        <file>lang/mc_hu.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
There is a mc_hu.ts translation file, but it is not included in lang.qrc so it is unavailable from the GUI.