### PR TITLE
#351 Adding exit button to Credentials management in clean state

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -50,6 +50,10 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->pushButtonEnterMMM->setIcon(AppGui::qtAwesome()->icon(fa::unlock, whiteButtons));
     ui->pushButtonConfirm->setStyleSheet(CSS_BLUE_BUTTON);
 
+    ui->buttonExit->setText(tr("Exit Credential Management"));
+    ui->buttonExit->setStyleSheet(CSS_BLUE_BUTTON);
+    connect(ui->buttonExit, &QPushButton::clicked, this, &CredentialsManagement::onButtonDiscard_confirmed);
+
     ui->horizontalLayout_filterCred->removeWidget(ui->toolButtonClearFilter);
 
     setFilterCredLayout();
@@ -162,9 +166,14 @@ void CredentialsManagement::setPasswordProfilesModel(PasswordProfilesModel *pass
 void CredentialsManagement::enableCredentialsManagement(bool enable)
 {
     if (enable)
+    {
         ui->stackedWidget->setCurrentWidget(ui->pageUnlocked);
+        setCredentialsClean();
+    }
     else
+    {
         ui->stackedWidget->setCurrentWidget(ui->pageLocked);
+    }
 
     ui->pageUnlocked->setFocus();
 }
@@ -684,6 +693,16 @@ QModelIndex CredentialsManagement::getProxyIndexFromSourceIndex(const QModelInde
     return m_pCredModelFilter->mapFromSource(srcIndex);
 }
 
+void CredentialsManagement::setCredentialsClean()
+{
+    ui->buttonExit->setVisible(true);
+    ui->buttonDiscard->setVisible(false);
+    ui->buttonSaveChanges->setVisible(false);
+    connect(m_pCredModel, &CredentialModel::dataChanged, this, &CredentialsManagement::credentialDataChanged);
+    connect(m_pCredModel, &CredentialModel::rowsInserted, this, &CredentialsManagement::credentialDataChanged);
+    connect(m_pCredModel, &CredentialModel::rowsRemoved, this, &CredentialsManagement::credentialDataChanged);
+}
+
 void CredentialsManagement::disableNonCredentialEditWidgets()
 {
     ui->quickInsertWidget->setEnabled(false);
@@ -791,6 +810,16 @@ void CredentialsManagement::updateFavMenu()
             }
         }
     }
+}
+
+void CredentialsManagement::credentialDataChanged()
+{
+    ui->buttonExit->setVisible(false);
+    ui->buttonSaveChanges->setVisible(true);
+    ui->buttonDiscard->setVisible(true);
+    disconnect(m_pCredModel, &CredentialModel::dataChanged, this, &CredentialsManagement::credentialDataChanged);
+    disconnect(m_pCredModel, &CredentialModel::rowsInserted, this, &CredentialsManagement::credentialDataChanged);
+    disconnect(m_pCredModel, &CredentialModel::rowsRemoved, this, &CredentialsManagement::credentialDataChanged);
 }
 
 void CredentialsManagement::changeEvent(QEvent *event)

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -75,6 +75,7 @@ private slots:
     void onSelectLoginItem(LoginItem *pLoginItem);
     void onSelectLoginTimerTimeOut();
     void updateFavMenu();
+    void credentialDataChanged();
 
 private:
     void updateLoginDescription(const QModelIndex &srcIndex);
@@ -82,6 +83,7 @@ private:
     void clearLoginDescription();
     QModelIndex getSourceIndexFromProxyIndex(const QModelIndex &proxyIndex);
     QModelIndex getProxyIndexFromSourceIndex(const QModelIndex &srcIndex);
+    void setCredentialsClean();
 
 private:
     void disableNonCredentialEditWidgets();

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -679,12 +679,6 @@ border-right: none;
        <item>
         <widget class="QWidget" name="controlsWidget" native="true">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <property name="spacing">
-           <number>35</number>
-          </property>
-          <property name="leftMargin">
-           <number>20</number>
-          </property>
           <item>
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
@@ -711,6 +705,22 @@ border-right: none;
               <width>158</width>
               <height>0</height>
              </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonExit">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>158</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Exit Credential Management</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Added the new exit button:
![mmmexit](https://user-images.githubusercontent.com/11043249/47529431-14362c00-d8a8-11e8-9eba-c9556cdbb9fa.jpg)
It is presented until a change made regarding credentials (added, removed, modified, added to fav), after that the original save and discard is displayed.