### PR TITLE
Appimage search for root CA in different locations

### DIFF
--- a/data/moolticute.sh
+++ b/data/moolticute.sh
@@ -115,8 +115,53 @@ export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 # $ cd squashfs-root
 # $ ./AppRun
 if [ -z "$APPDIR" ] ; then
-    APPDIR=`dirname $0`
+    APPDIR=`dirname -- "$0"`
 fi
+
+# Point our lib OpenSSL to its bundled config:
+export OPENSSL_CONF="$APPDIR/usr/lib/ssl/openssl.cnf"
+
+
+# Search root certificates on a system in well-known locations:
+# https://github.com/darealshinji/vlc-AppImage/issues/1#issuecomment-321041496
+# https://serverfault.com/questions/62496/ssl-certificate-location-on-unix-linux
+# https://www.happyassassin.net/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/
+if [ -s "/etc/ssl/ca-bundle.pem" ] ; then
+    # OpenSuSE
+    export SSL_CERT_FILE="/etc/ssl/ca-bundle.pem"
+elif [ -s "/var/lib/ca-certificates/ca-bundle.pem" ] ; then
+    # alternative OpenSuSE path (different versions have different locations)
+    export SSL_CERT_FILE="/var/lib/ca-certificates/ca-bundle.pem"
+elif [ -s "/etc/pki/tls/cacert.pem" ] ; then
+    # OpenELEC
+    export SSL_CERT_FILE="/etc/pki/tls/cacert.pem"
+elif [ -s "/etc/ssl/certs/ca-certificates.crt" ] ; then
+    # Debian/Ubuntu/Gentoo etc.
+    export SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+elif [ -s "/etc/pki/tls/cert.pem" ] ; then
+    export SSL_CERT_FILE="/etc/pki/tls/cert.pem"
+elif [ -s "/usr/local/share/certs/ca-root-nss.crt" ] ; then
+    export SSL_CERT_FILE="/usr/local/share/certs/ca-root-nss.crt"
+elif [ -s "/etc/ssl/cert.pem" ] ; then
+    export SSL_CERT_FILE="/etc/ssl/cert.pem"
+elif [ -s "/etc/pki/tls/certs/ca-bundle.crt" ] ; then
+    # Fedora/RHEL 6
+    export SSL_CERT_FILE="/etc/pki/tls/certs/ca-bundle.crt"
+elif [ -s "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] ; then
+    # CentOS/RHEL 7
+    export SSL_CERT_FILE="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+elif [ -s "/usr/local/ssl/cert.pem" ] ; then
+    # OpenSSL library default
+    export SSL_CERT_FILE="/usr/local/ssl/cert.pem"
+fi
+
+if [ -d "/usr/local/ssl" ] ; then
+    # OpenSSL library default
+    export SSL_CERT_DIR="/usr/local/ssl"
+elif [ -d "/etc/ssl/certs" ] ; then
+    export SSL_CERT_DIR="/etc/ssl/certs"
+fi
+
 
 if (( $DAEMON_ONLY == 1 )) ;
 then

--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -597,6 +597,9 @@ void AppGui::checkUpdate(bool displayMessage)
     u->setDownloaderEnabled(GITHUB_UPDATE_URL, true);
     u->setNotifyOnFinish(GITHUB_UPDATE_URL, displayMessage);
 
+    if (QStringLiteral(APP_TYPE) == "appimage")
+        u->setPlatformKey(GITHUB_UPDATE_URL, "appimage");
+
     u->checkForUpdates(GITHUB_UPDATE_URL);
 
     //Recheck in at least 30minutes plus some random time

--- a/src/QSimpleUpdater/src/Updater.cpp
+++ b/src/QSimpleUpdater/src/Updater.cpp
@@ -376,6 +376,9 @@ void Updater::onReply (QNetworkReply* reply)
     if (platformKey().compare("linux") == 0)
         releaseFileSuffix = ".deb";
 
+    if (platformKey().compare("appimage") == 0)
+        releaseFileSuffix = ".AppImage";
+
     if (platformKey().compare("windows") == 0)
         releaseFileSuffix = ".exe";
 
@@ -413,6 +416,9 @@ void Updater::onReply (QNetworkReply* reply)
 
         /* Compare latest and current version */
         setUpdateAvailable (latestVersion() != moduleVersion());
+    }
+    else {
+        qInfo() << "No any appropriate update was found";
     }
     emit checkingFinished (url());
 }


### PR DESCRIPTION
Appimage: search for root CA in different locations

Recently I digged in OpenSSL on how it loads root certificates.
While I was reading the code I noticed that OpenSSL understands environment variables,
so I decided to use this shortcut instead of patching OpenSSL.

Also, Updater in Moolticute was fixed to work with ".AppImage" suffix.

Here the results of testing on Ubuntu 18.10 live CD:

```
ubuntu@ubuntu:~/Downloads$ grep ssl moolticute.strace.log 
6247  openat(AT_FDCWD, "/tmp/.mount_MooltiHWvuAH/usr/bin/../lib/libssl.so.1.0.2k", O_RDONLY|O_CLOEXEC) = 14

^^^ OK, OpenSSL is loaded from AppImage

6247  openat(AT_FDCWD, "/tmp/.mount_MooltiHWvuAH/usr/lib/ssl/openssl.cnf", O_RDONLY) = 14

^^^ OK, OpenSSL config is read from AppImage

6247  openat(AT_FDCWD, "/etc/ssl/certs/", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 14
6247  stat("/etc/ssl/certs/02265526.0", {st_mode=S_IFREG|0644, st_size=1533, ...}) = 0
6275  openat(AT_FDCWD, "/tmp/.mount_MooltiHWvuAH/usr/bin/../lib/libssl.so.1.0.2k", O_RDONLY|O_CLOEXEC) = 7
6275  openat(AT_FDCWD, "/tmp/.mount_MooltiHWvuAH/usr/lib/ssl/openssl.cnf", O_RDONLY) = 7
6275  openat(AT_FDCWD, "/etc/ssl/certs/", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 7
6275  stat("/etc/ssl/certs/02265526.0", {st_mode=S_IFREG|0644, st_size=1533, ...}) = 0
6281  stat("/etc/ssl/certs//244b5494.0", {st_mode=S_IFREG|0644, st_size=1367, ...}) = 0
6281  openat(AT_FDCWD, "/etc/ssl/certs//244b5494.0", O_RDONLY) = 30

^^^ NOTICE: I expected it to read root CA bundle file first from /etc/ssl/certs/ca-certificates.crt but maybe I'm wrong.  OK, let it work as it wants as long as the job was done successfully (https connection was made successfully).

6281  stat("/etc/ssl/certs//244b5494.1", 0x7f6471f63090) = -1 ENOENT (No such file or directory)

ubuntu@ubuntu:~/Downloads$ strings /proc/6247/environ | grep "APP\|SSL"
OPENSSL_CONF=/tmp/.mount_MooltiHWvuAH/usr/lib/ssl/openssl.cnf
APPIMAGE=/home/ubuntu/Downloads/Moolticute-x86_64.AppImage
SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
SSL_CERT_DIR=/etc/ssl/certs
APPDIR=/tmp/.mount_MooltiHWvuAH

ubuntu@ubuntu:~/Downloads$ lsof -p 6247 | grep ssl
moolticut 6247 ubuntu  mem       REG               0,56   444392    3301 /tmp/.mount_MooltiHWvuAH/usr/lib/libssl.so.1.0.0


Make doublesure OpenSSL from AppImage bundle is used:

ubuntu@ubuntu:~/Downloads$ lsof -p 6247 | grep crypto
moolticut 6247 ubuntu  mem       REG               0,56  2530048    1687 /tmp/.mount_MooltiHWvuAH/usr/lib/libcrypto.so.1.0.0

```
![screenshot from 2018-10-26 06-02-14](https://user-images.githubusercontent.com/5078434/47548802-46856f00-d924-11e8-8ad1-cef563f05a19.png)
