### PR TITLE
#349 Adding default true for auto_start in pushButtonAutoStart clicked

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1080,7 +1080,7 @@ void MainWindow::on_pushButtonAutoStart_clicked()
 {
     QSettings s;
 
-    bool en = s.value("settings/auto_start").toBool();
+    bool en = s.value("settings/auto_start", true).toBool();
 
     int ret;
     if (en)


### PR DESCRIPTION
Need to add the default true value for "settings/auto_start" in _on_pushButtonAutoStart_clicked_ function too.
The current behavior, when the user clicks Disable for the first time is the following:
![screen shot 2018-10-26 at 10 39 24 pm](https://user-images.githubusercontent.com/11043249/47591893-845cb480-d971-11e8-8ee4-b2cd5209c69b.png)
After clicking Disable it is enabling AutoStart.
This default value solves the issue.