### PR TITLE
Fixing crash after adding credential in MMM and discarding save password

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6805,11 +6805,11 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
 
                     pwdChangeJobs->append(new MPCommandJob(this, MPCmd::SET_LOGIN,
                                                   ldata,
-                                                  [this, &pwdChangeJobs, i](const QByteArray &data, bool &) -> bool
+                                                  [this, i](const QByteArray &data, bool &) -> bool
                     {
                         if (data[MP_PAYLOAD_FIELD_INDEX] == 0)
                         {
-                            pwdChangeJobs->setCurrentJobError("set_login failed on device");
+                            this->currentJobs->setCurrentJobError("set_login failed on device");
                             qWarning() << "failed to set login to " << mmmPasswordChangeArray[i][1];
                             return false;
                         }
@@ -6825,11 +6825,11 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
 
                     pwdChangeJobs->append(new MPCommandJob(this, MPCmd::SET_PASSWORD,
                                                    pdata,
-                                                   [this, &pwdChangeJobs, i](const QByteArray &data, bool &) -> bool
+                                                   [this, i](const QByteArray &data, bool &) -> bool
                     {
                         if (data[MP_PAYLOAD_FIELD_INDEX] == 0)
                         {
-                            pwdChangeJobs->setCurrentJobError("set_password failed on device");
+                            this->currentJobs->setCurrentJobError("set_password failed on device");
                             qWarning() << "failed to set_password for " << mmmPasswordChangeArray[i][0];
                             /* Below: no call back as the user can approve the next changes */
                             //return false;


### PR DESCRIPTION
By the time the lambda is called the captured **pwdChangeJobs** pointer contains memory garbage. During _setCurrentJobError_ function it crashes.
In _runAndDequeueJobs()_ function **currentJobs** is set to the actual job, which is valid, when the lambda is called.

**Crash Repro**:
1. Go to Credentials
2. Enter Credentials Management Mode with Mooltipass device
3. Add a new credential with "Add or update a credential" section
4. Click Save all changes
5. Mooltipass device asks "Change Password For" if the user discards it or timeouts, then the daemon crashes, the user cannot use MC, until restarting the daemon and the added credential is saved with some invalid password (originaly it was "test" too):
6. ![kep](https://user-images.githubusercontent.com/11043249/47529879-5c098300-d8a9-11e8-97cd-1c038eecadbf.png)

**Occurrence**: every time
**Test on**: Windows, Ubuntu

After this fix it does not crash.