### PR TITLE
#368 Sending simple system notification with systray bellow Win10

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -23,6 +23,10 @@
 #include "PromptWidget.h"
 #include "SystemNotifications/SystemNotification.h"
 
+#ifdef Q_OS_WIN
+#include "SystemNotifications/SystemNotificationWindows.h"
+#endif
+
 #ifdef Q_OS_MAC
 #include "MacUtils.h"
 #endif
@@ -96,6 +100,22 @@ bool AppGui::initialize()
 #endif
     systray->setIcon(icon);
     systray->show();
+
+#ifdef Q_OS_WIN
+    const auto *winNotification = dynamic_cast<SystemNotificationWindows*>(SystemNotification::instance().getNotification());
+    if (winNotification != nullptr)
+    {
+        connect(winNotification, &SystemNotificationWindows::notifySystray,
+                [this] (QString title, QString text)
+                {
+                    if (systray)
+                    {
+                        systray->showMessage(title, text, QIcon(":/AppIcon_128.png"));
+                    }
+                }
+        );
+    }
+#endif
 
     showConfigApp = new QAction(tr("&Show Moolticute Application"), this);
     connect(showConfigApp, &QAction::triggered, [=]()

--- a/src/SystemNotifications/SystemNotificationWindows.cpp
+++ b/src/SystemNotifications/SystemNotificationWindows.cpp
@@ -12,6 +12,7 @@ const QString SystemNotificationWindows::SNORETOAST_INSTALL= "SnoreToast.exe -in
 const QString SystemNotificationWindows::WINDOWS10_VERSION = "10";
 const QString SystemNotificationWindows::NOTIFICATIONS_SETTING_REGENTRY = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Notifications\\Settings";
 const QString SystemNotificationWindows::DND_ENABLED_REGENTRY = "NOC_GLOBAL_SETTING_TOASTS_ENABLED";
+const bool SystemNotificationWindows::IS_WIN10 = QSysInfo::productVersion() == WINDOWS10_VERSION;
 
 
 SystemNotificationWindows::SystemNotificationWindows(QObject *parent)
@@ -46,8 +47,15 @@ SystemNotificationWindows::~SystemNotificationWindows()
 
 void SystemNotificationWindows::createNotification(const QString &title, const QString text)
 {
-    QString notification = SNORETOAST_FORMAT.arg(title, text, "", "", "");
-    process->start(notification);
+    if (IS_WIN10)
+    {
+        QString notification = SNORETOAST_FORMAT.arg(title, text, "", "", "");
+        process->start(notification);
+    }
+    else
+    {
+        emit notifySystray(title, text);
+    }
 }
 
 void SystemNotificationWindows::createButtonChoiceNotification(const QString &title, const QString text, const QStringList &buttons)
@@ -84,7 +92,7 @@ void SystemNotificationWindows::createTextBoxNotification(const QString &title, 
 
 bool SystemNotificationWindows::displayLoginRequestNotification(const QString &service, QString &loginName, QString message)
 {
-    if (QSysInfo::productVersion() == WINDOWS10_VERSION && !isDoNotDisturbEnabled())
+    if (IS_WIN10 && !isDoNotDisturbEnabled())
     {
         // A text box notification is displayed on Win10
         messageMap->insert(notificationId, message);
@@ -104,7 +112,7 @@ bool SystemNotificationWindows::displayLoginRequestNotification(const QString &s
 
 bool SystemNotificationWindows::displayDomainSelectionNotification(const QString &domain, const QString &subdomain, QString &serviceName, QString message)
 {
-    if (QSysInfo::productVersion() == WINDOWS10_VERSION && !isDoNotDisturbEnabled())
+    if (IS_WIN10 && !isDoNotDisturbEnabled())
     {
         // A button choice notification is displayed on Win10
         QStringList buttons;
@@ -126,7 +134,10 @@ bool SystemNotificationWindows::displayDomainSelectionNotification(const QString
 
 void SystemNotificationWindows::installSnoreToast()
 {
-    process->start(SNORETOAST_INSTALL);
+    if (IS_WIN10)
+    {
+        process->start(SNORETOAST_INSTALL);
+    }
 }
 
 bool SystemNotificationWindows::processResult(const QString &toastResponse, QString &result, size_t &id) const

--- a/src/SystemNotifications/SystemNotificationWindows.h
+++ b/src/SystemNotifications/SystemNotificationWindows.h
@@ -26,6 +26,10 @@ public:
     const static QString WINDOWS10_VERSION;
     const static QString NOTIFICATIONS_SETTING_REGENTRY;
     const static QString DND_ENABLED_REGENTRY;
+    const static bool IS_WIN10;
+
+signals:
+    void notifySystray(QString title, QString text);
 
 public slots:
     void callbackFunction(int exitCode, QProcess::ExitStatus exitStatus);


### PR DESCRIPTION
WinRT is not available on win7, so if the client wants to run SnoreToast it is getting an "_api-ms-win-core-winrt-l1-1-0.dll is missing_" error.

So on win7/win8 I implemented to send the simple notification through systray:
![win7systraynotification](https://user-images.githubusercontent.com/11043249/48510661-d0a26280-e854-11e8-90e0-06da07d55a51.jpg)

Also only checking if snoretoast is installed on win10.