### PR TITLE
#368 Displaying notification on show_status_notification_warning mess…

### DIFF
--- a/src/AppGui.h
+++ b/src/AppGui.h
@@ -62,6 +62,7 @@ private slots:
     void slotConnectionEstablished();
     void daemonLogRead();
     void updateAvailableReceived(QString version, QString changesetURL);
+    void displayStatusWarningNotification();
 
 private:
      MainWindow *win = nullptr;

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -404,6 +404,10 @@ void WSClient::onTextMessageReceived(const QString &message)
         else
             emit cardResetFinished(false);
     }
+    else if (rootobj["msg"] == "show_status_notification_warning")
+    {
+        emit displayStatusWarning();
+    }
 }
 
 void WSClient::udateParameters(const QJsonObject &data)

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -133,6 +133,7 @@ signals:
     void filesCacheChanged();
     void cardDbMetadataChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
     void cardResetFinished(bool successfully);
+    void displayStatusWarning();
 
 public slots:
     void sendJsonData(const QJsonObject &data);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -81,6 +81,17 @@ void WSServerCon::processMessage(const QString &message)
         sendJsonMessage(oroot);
         return;
     }
+    else if (root["msg"] == "show_status_notification_warning")
+    {
+        QJsonDocument showWarningDoc(root);
+        bool isGuiRunning = false;
+        emit sendMessageToGUI(showWarningDoc.toJson(), isGuiRunning);
+        if (!isGuiRunning)
+        {
+            qDebug() << "Cannot show status notification warning, because Moolticute is not running";
+        }
+        return;
+    }
 
     //Strip the data for the progress lambda,
     //uneeded data should not be passed around


### PR DESCRIPTION
…age, depending on device state


Same messages used like on Extension side (https://github.com/mooltipass/extension/blob/master/background/event.js#L290), but conditions are fixed.

**Example**:
![devicestatusnotification](https://user-images.githubusercontent.com/11043249/48664161-f15bf980-ea9a-11e8-80e2-263af0fb8ecd.jpg)

