### PR TITLE
#378 Fixing cut subdomain during saving credentials

### DIFF
--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -495,7 +495,8 @@ void WSClient::addOrUpdateCredential(const QString &service, const QString &logi
     QJsonObject o = {{ "service", service.toLower()},
                      { "login",   login},
                      { "password", password },
-                     { "description", description}};
+                     { "description", description},
+                     { "saveDomainConfirmed", 1}};
     sendJsonData({{ "msg", "set_credential" },
                   { "data", o }});
 }


### PR DESCRIPTION
It caused a problem when we are not in Credentials Management Mode, fixed that case:
![kep](https://user-images.githubusercontent.com/11043249/49038605-b6a24180-f1bd-11e8-87f4-5c6bc7c94b72.png)
It is saving the service entered by the user, not depending on subdomain selection setting.
