### PR TITLE
#272 Develop272 edit service name in mmm

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -479,6 +479,11 @@ void CredentialsManagement::on_pushButtonCancel_clicked()
         ui->credDisplayPasswordInput->setText(pLoginItem->password());
         ui->credDisplayDescriptionInput->setText(pLoginItem->description());
         ui->credDisplayLoginInput->setText(pLoginItem->name());
+        auto *serviceItem = pLoginItem->parentItem();
+        if (nullptr != serviceItem)
+        {
+            ui->credDisplayServiceInput->setText(serviceItem->name());
+        }
         updateSaveDiscardState();
     }
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -352,6 +352,11 @@ void CredentialsManagement::saveCredential(const QModelIndex currentSelectionInd
     if (pLoginItem != nullptr) {
         m_pCredModel->updateLoginItem(srcIndex, ui->credDisplayPasswordInput->text(), ui->credDisplayDescriptionInput->text(), ui->credDisplayLoginInput->text());
         ui->credentialTreeView->refreshLoginItem(srcIndex);
+        if (pLoginItem->parentItem()->name() != ui->credDisplayServiceInput->text())
+        {
+            pLoginItem->parentItem()->setName(ui->credDisplayServiceInput->text());
+            qDebug() << "Service name is changed";
+        }
     }
 }
 

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -81,6 +81,8 @@ private slots:
 
     void on_toolButtonFavFilter_clicked();
 
+    void on_toolButtonEditService_clicked();
+
 private:
     void updateLoginDescription(const QModelIndex &srcIndex);
     void updateLoginDescription(LoginItem *pLoginItem);
@@ -92,6 +94,8 @@ private:
 private:
     void disableNonCredentialEditWidgets();
     void enableNonCredentialEditWidgets();
+    bool isServiceNameExist(const QString& serviceName) const;
+    void setServiceInputAttributes(const QString& tooltipText, Qt::GlobalColor col);
 
     void changeCurrentFavorite(int iFavorite);
     virtual void changeEvent(QEvent *event);

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -418,7 +418,7 @@ border-right: none;
                    <set>Qt::AlignCenter</set>
                   </property>
                   <property name="readOnly">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -418,7 +418,32 @@ border-right: none;
                    <set>Qt::AlignCenter</set>
                   </property>
                   <property name="readOnly">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="toolButtonEditService">
+                  <property name="minimumSize">
+                   <size>
+                    <width>18</width>
+                    <height>18</height>
+                   </size>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>ArrowCursor</cursorShape>
+                  </property>
+                  <property name="mouseTracking">
                    <bool>false</bool>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="checkable">
+                   <bool>false</bool>
+                  </property>
+                  <property name="autoRaise">
+                   <bool>true</bool>
                   </property>
                  </widget>
                 </item>

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6599,6 +6599,13 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 /* Set favorite */
                 nodePtr->setFavoriteProperty(favorite);
 
+                /* Check for changed service */
+                if (service != nodePtr->getService())
+                {
+                    qDebug() << "Detected service change new: " << service << ", old: " << nodePtr->getService();
+                    //TODO implement service change
+                }
+
                 /* Check for changed description */
                 if (description != nodePtr->getDescription())
                 {


### PR DESCRIPTION
I merged @limpkin's  backend solution, and finished GUI side.

Added an edit icon next to the service name with tooltip:
![kep](https://user-images.githubusercontent.com/11043249/49344928-eea5fa80-f67d-11e8-996d-12dc2916a9a7.png)

If the user enters already existing service name, then unable to save it:
![kep](https://user-images.githubusercontent.com/11043249/49344941-1e550280-f67e-11e8-999a-f32c63be5d06.png)

They can save it with valid service name, and after saving the credential tree view is ordered:
![kep](https://user-images.githubusercontent.com/11043249/49344955-6411cb00-f67e-11e8-82f5-95395c139d1b.png)
![kep](https://user-images.githubusercontent.com/11043249/49344976-a63b0c80-f67e-11e8-8790-e77c9315899c.png)

