### PR TITLE
#247 Develop247 device settings read fix

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -187,8 +187,7 @@ bool AppGui::initialize()
     dbMasterController = new DbMasterController(this);
     dbMasterController->setWSClient(wsClient);
 
-    if (!autoLaunched)
-        mainWindowShow();
+    mainWindowShow(autoLaunched);
 
     connect(wsClient, &WSClient::showAppRequested, [=]()
     {
@@ -408,13 +407,17 @@ AppGui::~AppGui()
     delete win;
 }
 
-void AppGui::mainWindowShow()
+void AppGui::mainWindowShow(bool autoLaunched)
 {
     if (!win)
     {
         //Postpone qtawesome initialisation when the windows is showed
         //This fix a crash when starting the app with system in macOS
         createMainWindow();
+        if (autoLaunched)
+        {
+            return;
+        }
     }
 
     win->show();

--- a/src/AppGui.h
+++ b/src/AppGui.h
@@ -42,7 +42,7 @@ public:
 
     bool initialize();
 
-    void mainWindowShow();
+    void mainWindowShow(bool autoLaunched = false);
     void mainWindowHide();
     void enableDaemon();
     void disableDaemon();

--- a/win/installer.iss
+++ b/win/installer.iss
@@ -57,7 +57,6 @@ Filename: "{app}\moolticute.exe"; WorkingDir: "{app}"; Description: "Start Moolt
 
 [Registry]
 Root: "HKCU"; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "Moolticute"; ValueData: "{app}\moolticute.exe --autolaunched"; Flags: uninsdeletevalue
-Root: "HKCU"; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\cli"
 
 [Code]
 function IsAppRunning(const FileName : string): Boolean;

--- a/win/installer.iss
+++ b/win/installer.iss
@@ -57,6 +57,7 @@ Filename: "{app}\moolticute.exe"; WorkingDir: "{app}"; Description: "Start Moolt
 
 [Registry]
 Root: "HKCU"; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "Moolticute"; ValueData: "{app}\moolticute.exe --autolaunched"; Flags: uninsdeletevalue
+Root: "HKCU"; Subkey: "Environment"; ValueType: expandsz; ValueName: "PATH"; ValueData: "{olddata};{app}\cli"
 
 [Code]
 function IsAppRunning(const FileName : string): Boolean;


### PR DESCRIPTION
If autolaunch was enabled, then after OS start, the settings from the device were not loaded.
This was because in that case mainwindow wasn't created during startup, so when the daemon sent the parameter loaded signals, then the mainwindow could not process them.