### PR TITLE
Sketch of an approach for ' Bind sockets to localhost #398 '

### DIFF
--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -96,11 +96,9 @@ bool AppDaemon::initialize()
                                      QCoreApplication::translate("main", "Activate emulation mode, all Websocket API function return emulated string, useful if you want to try the API."));
     parser.addOption(emulMode);
 
-#ifndef Q_OS_MAC
     QCommandLineOption anyAddressOption(QStringList() << "a" << "any-address",
                                      QCoreApplication::translate("main", "Listen on any address. By default, it listens only on localhost."));
     parser.addOption(anyAddressOption);
-#endif
 
     // An option with a value
     QCommandLineOption debugHttpServer(QStringList() << "s" << "debug-http-server",
@@ -112,11 +110,7 @@ bool AppDaemon::initialize()
 
     emulationMode = parser.isSet(emulMode);
 
-#ifdef Q_OS_MAC
-    anyAddress = true;
-#else
     anyAddress = parser.isSet(anyAddressOption);
-#endif
 
     if (parser.isSet(debugHttpServer))
     {
@@ -160,5 +154,5 @@ QHostAddress AppDaemon::getListenAddress()
     if (anyAddress)
         return QHostAddress::Any;
 
-    return QHostAddress::LocalHost;
+    return MOOLTICUTE_DAEMON_ADDR;
 }

--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -222,6 +222,7 @@ bool AppGui::initialize()
             needRestart = false;
         }
     });
+    qDebug() << "Started moolticutd(aemon)";
 
     connect(daemonProcess, &QProcess::started, [=]()
     {

--- a/src/Common.h
+++ b/src/Common.h
@@ -46,6 +46,7 @@
 #define MP_DATA_HEADER_SIZE      4
 
 #define MOOLTICUTE_DAEMON_PORT  30035
+#define MOOLTICUTE_DAEMON_ADDR  QHostAddress::LocalHostIPv6
 
 //Max file size for standard data file
 #define MP_MAX_FILE_SIZE        1024 * 10

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -19,7 +19,6 @@
 #include "WSClient.h"
 #include "SystemNotifications/SystemNotification.h"
 
-#define WS_URI                      "ws://localhost"
 #define QUERY_RANDOM_NUMBER_TIME    10 * 60 * 1000 //10 min
 
 WSClient::WSClient(QObject *parent):
@@ -56,8 +55,17 @@ void WSClient::openWebsocket()
                 this, SLOT(onWsError()));
     }
 
-    QString url = QString("%1:%2").arg(WS_URI).arg(MOOLTICUTE_DAEMON_PORT);
-    wsocket->open(url);
+    // Unfortunately a nummeric IPv6 address needs some additional '[..]' brackets around
+    // it before putting it into a URL; whereas an IPv4 address does not. So we need to
+    // construct this through a URL - rather than just string concatenation.
+    //
+    QUrl qurl = QUrl();
+    qurl.setScheme("ws");
+    qurl.setHost(QHostAddress(MOOLTICUTE_DAEMON_ADDR).toString());
+    qurl.setPort(MOOLTICUTE_DAEMON_PORT);
+
+    wsocket->open(qurl);
+    qDebug() << "openWebsocket open(" << qurl.toString() << ")";
 }
 
 void WSClient::closeWebsocket()
@@ -83,8 +91,11 @@ void WSClient::onWsConnected()
 {
     qDebug() << "Websocket connected";
     connect(wsocket, &QWebSocket::textMessageReceived, this, &WSClient::onTextMessageReceived);
+    qDebug() << "queryRandomNumbers()";
     queryRandomNumbers();
+    qDebug() << "emit  wsConnected()";
     emit wsConnected();
+    qDebug() << "done onWsConnected()";
 }
 
 bool WSClient::isConnected() const


### PR DESCRIPTION
Minor tweak to bind the deamon to localhost -and- have the app do the same (on OSX), to hopefully quell issue #398 and revert the security issue introduced in #331 / #338.
