### PR TITLE
#403 Fix MMM denied stuck

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1418,9 +1418,9 @@ void MainWindow::updateTabButtons()
 void MainWindow::memMgmtModeFailed(int errCode, QString errMsg)
 {
     Q_UNUSED(errCode)
-    QMessageBox::warning(this,
-                         tr("Memory Management Error"),
-                         tr("An error occured when trying to go into Memory Management mode.\n\n%1").arg(errMsg));
+    updatePage();
+    showPrompt(new PromptMessage{"<b>" + tr("Memory Management Error") + "</b><br>" +
+                                 tr("An error occured when trying to go into Memory Management mode.\n\n%1").arg(errMsg)});
 }
 
 void MainWindow::refreshAppLangCb()

--- a/src/PromptWidget.cpp
+++ b/src/PromptWidget.cpp
@@ -11,7 +11,7 @@ PromptWidget::PromptWidget(QWidget *parent) :
     QFrame(parent),
     m_hideAfterAccepted(true),
     m_messageLabel(new QLabel),
-    m_buttonBox(new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No)),
+    m_buttonBox(new QDialogButtonBox),
     m_promptMessage(nullptr)
 {
     QHBoxLayout *lay = new QHBoxLayout(this);
@@ -22,8 +22,8 @@ PromptWidget::PromptWidget(QWidget *parent) :
     lay->addWidget(m_buttonBox);
     lay->addStretch();
 
-    for (auto btn : m_buttonBox->buttons())
-        btn->setStyleSheet(CSS_BLUE_BUTTON);
+    initButtons();
+
     setStyleSheet("PromptWidget {border: 5px solid #60B1C7;}");
 
     m_messageLabel->setAlignment(Qt::AlignCenter);
@@ -53,10 +53,21 @@ void PromptWidget::setPromptMessage(PromptMessage *promptMessage)
 
     if (m_promptMessage)
         m_messageLabel->setText(m_promptMessage->getText());
+
+    if (!promptMessage->containsButtonCb())
+    {
+        m_buttonBox->setStandardButtons(QDialogButtonBox::Ok);
+        for (auto btn : m_buttonBox->buttons())
+        {
+            btn->setStyleSheet(CSS_BLUE_BUTTON);
+        }
+    }
 }
 
 void PromptWidget::cleanPromptMessage()
 {
+    initButtons();
+
     if (m_promptMessage)
     {
         delete m_promptMessage;
@@ -81,4 +92,13 @@ void PromptWidget::onRejected()
         m_promptMessage->runRejectCallBack();
 
     emit rejected();
+}
+
+void PromptWidget::initButtons()
+{
+    m_buttonBox->setStandardButtons(QDialogButtonBox::Yes | QDialogButtonBox::No);
+    for (auto btn : m_buttonBox->buttons())
+    {
+        btn->setStyleSheet(CSS_BLUE_BUTTON);
+    }
 }

--- a/src/PromptWidget.h
+++ b/src/PromptWidget.h
@@ -25,6 +25,7 @@ public:
     {}
 
     QString getText() const { return m_text; }
+    bool containsButtonCb() const { return nullptr != m_acceptCallBack; }
     void runAcceptCallBack() { if (m_acceptCallBack) m_acceptCallBack(); }
     void runRejectCallBack() { if (m_rejectCallBack) m_rejectCallBack(); }
 
@@ -60,6 +61,9 @@ protected slots:
     void onRejected();
 
 private:
+    void initButtons();
+
+
     bool m_hideAfterAccepted;
     QLabel *m_messageLabel;
     QDialogButtonBox *m_buttonBox;


### PR DESCRIPTION
**Original issue:**
Enter Credentials Management Mode and deny it on the device. The app stucks at the waiting screen with a messagebox.
![creddenystuck](https://user-images.githubusercontent.com/11043249/52223662-67a41700-28a6-11e9-8d23-6a4031624433.gif)

**Fix:**
Instead of the waiting screen and the message box, displaying the original credentials with a message prompt, when enter MMM is denied. According to the expected behavior described in #403.
![creddenyfix](https://user-images.githubusercontent.com/11043249/52223767-a934c200-28a6-11e9-9851-368b843b18bc.gif)

The fix resolve the same issue on Files Management screen too.
I extended PromptWidget to support a simple information message with an OK button which hides the prompt.