### PR TITLE
Fix missing files, when files cache is not in sync, fix stucked savin…

### DIFF
--- a/src/FilesCache.cpp
+++ b/src/FilesCache.cpp
@@ -24,6 +24,7 @@ QByteArray FilesCache::cardCPZ() const
 
 bool FilesCache::save(QList<QVariantMap> files)
 {
+    m_isFileCacheInSync = true;
     QFile file(m_filePath);
 
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
@@ -74,10 +75,12 @@ QList<QVariantMap> FilesCache::load()
         if (cacheDbChangeNumber != m_dbChangeNumber)
         {
             qDebug() << "dbChangeNumber miss";
+            m_isFileCacheInSync = false;
         }
         else
         {
             qDebug() << "dbChangeNumber match";
+            m_isFileCacheInSync = true;
             QJsonArray filesJson = jsonRoot.value("files").toArray();
             for (QJsonValue file : filesJson)
             {
@@ -101,6 +104,7 @@ void FilesCache::resetState()
 {
     m_dbChangeNumberSet = false;
     m_cardCPZ = QByteArray();
+    m_isFileCacheInSync = true;
 }
 
 bool FilesCache::setDbChangeNumber(quint8 changeNumber)
@@ -127,6 +131,11 @@ bool FilesCache::exist()
 {
     QFile cache_file(m_filePath);
     return cache_file.exists();
+}
+
+bool FilesCache::isInSync() const
+{
+    return m_isFileCacheInSync;
 }
 
 bool FilesCache::setCardCPZ(QByteArray cardCPZ)

--- a/src/FilesCache.h
+++ b/src/FilesCache.h
@@ -26,6 +26,7 @@ public slots:
     bool setCardCPZ(QByteArray cardCPZ);
     bool setDbChangeNumber(quint8 changeNumber);
     bool exist();
+    bool isInSync() const;
 private:
     QByteArray m_cardCPZ;
     QString m_filePath;
@@ -33,6 +34,7 @@ private:
     bool m_dbChangeNumberSet = false;
     quint8 m_dbChangeNumber = -1;
     SimpleCrypt m_simpleCrypt;
+    bool m_isFileCacheInSync = true;
 };
 
 #endif // FILESCACHE_H

--- a/src/FilesManagement.cpp
+++ b/src/FilesManagement.cpp
@@ -136,10 +136,7 @@ void FilesManagement::setWsClient(WSClient *c)
         loadModel();
         ui->lineEditFilterFiles->clear();
     });
-    connect(wsClient, &WSClient::filesCacheChanged, [=]()
-    {
-        loadFilesCacheModel();
-    });
+    connect(wsClient, &WSClient::filesCacheChanged, this, &FilesManagement::loadFilesCacheModel);
 
     setFileCacheControlsVisible(wsClient->isFw12());
     connect(wsClient, &WSClient::fwVersionChanged, [=](const QString &)
@@ -218,7 +215,7 @@ void FilesManagement::loadModel()
     currentSelectionChanged(index, QModelIndex());
 }
 
-void FilesManagement::loadFilesCacheModel()
+void FilesManagement::loadFilesCacheModel(bool isInSync)
 {
     if (!wsClient->isFw12())
     {
@@ -285,13 +282,25 @@ void FilesManagement::loadFilesCacheModel()
     }
 
     listWidget->setVisible(listWidget->count() > 0);
-    ui->emptyCacheLabel->setVisible(listWidget->count() == 0);
+    bool isListWidgetEmpty = listWidget->count() == 0;
+    ui->emptyCacheLabel->setVisible(isListWidgetEmpty);
+    if (isListWidgetEmpty)
+    {
+        if (isInSync)
+        {
+            ui->emptyCacheLabel->setText(tr("No files in the device."));
+        }
+        else
+        {
+            ui->emptyCacheLabel->setText(tr("Please enter file management mode to list the files in your device."));
+        }
+    }
+
     ui->listFilesButton->setVisible(false);
 }
 
 void FilesManagement::currentSelectionChanged(const QModelIndex &curr, const QModelIndex &)
 {
-    qDebug() << "Selection changed";
     if (!curr.isValid())
     {
         ui->filesDisplayFrame->hide();

--- a/src/FilesManagement.h
+++ b/src/FilesManagement.h
@@ -81,9 +81,10 @@ private slots:
 
     void on_pushButtonFilename_clicked();
 
+    void loadFilesCacheModel(bool isInSync);
+
 private:
     void loadModel();
-    void loadFilesCacheModel();
     void addUpdateFile(QString service, QString filename, QProgressBar *pbar);
 
     virtual void changeEvent(QEvent *event);

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3389,12 +3389,11 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
     {
         QVariantMap data = {
             {"total", progressTotal},
-            {"current", progressCurrent},
+            {"current", ++progressCurrent},
             {"msg", "Writing Data To Device: %1/%2 Packets Sent" },
             {"msg_args", QVariantList({progressCurrent, progressTotal})}
         };
         cbProgress(data);
-        progressCurrent++;
     };
 
     /* Change numbers */
@@ -7122,6 +7121,11 @@ QList<QVariantMap> MPDevice::getFilesCache()
 bool MPDevice::hasFilesCache()
 {
     return filesCache.exist();
+}
+
+bool MPDevice::isFilesCacheInSync() const
+{
+    return filesCache.isInSync();
 }
 
 void MPDevice::getStoredFiles(std::function<void (bool, QList<QVariantMap>)> cb)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -244,6 +244,7 @@ public:
 
     QList<QVariantMap> getFilesCache();
     bool hasFilesCache();
+    bool isFilesCacheInSync() const;
     void getStoredFiles(std::function<void(bool, QList<QVariantMap>)> cb);
     void updateFilesCache();
     void addFileToCache(QString fileName, int size);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1053,6 +1053,14 @@ void MainWindow::wantExitFilesManagement()
     ui->labelProgressMessage->hide();
 
     connect(wsClient, &WSClient::progressChanged, this, &MainWindow::loadingProgress);
+    auto conn = std::make_shared<QMetaObject::Connection>();
+    *conn = connect(wsClient, &WSClient::deleteDataNodesFinished, [this, conn]()
+                {
+                    qDebug() << "Removing files is finished";
+                    updatePage();
+                    disconnect(wsClient, &WSClient::progressChanged, this, &MainWindow::loadingProgress);
+                    disconnect(*conn);
+                });
 
     updateTabButtons();
 }

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -372,7 +372,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if (rootobj["msg"] == "files_cache_list")
     {
         filesCache = rootobj["data"].toArray();
-        emit filesCacheChanged();
+        emit filesCacheChanged(rootobj["sync"].toBool());
     }
     else if (rootobj["msg"] == "get_random_numbers")
     {
@@ -407,6 +407,10 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if (rootobj["msg"] == "show_status_notification_warning")
     {
         emit displayStatusWarning();
+    }
+    else if (rootobj["msg"] == "delete_data_nodes")
+    {
+        emit deleteDataNodesFinished();
     }
 }
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -130,10 +130,11 @@ signals:
     void dbExported(const QByteArray &fileData, bool success);
     void dbImported(bool success, QString message);
     void memMgmtModeFailed(int errCode, QString errMsg);
-    void filesCacheChanged();
+    void filesCacheChanged(bool isInSync);
     void cardDbMetadataChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
     void cardResetFinished(bool successfully);
     void displayStatusWarning();
+    void deleteDataNodesFinished();
 
 public slots:
     void sendJsonData(const QJsonObject &data);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1057,6 +1057,7 @@ void WSServerCon::sendFilesCache()
         array.append(QJsonDocument::fromVariant(item).object());
 
     oroot["data"] = array;
+    oroot["sync"] = mpdevice->isFilesCacheInSync();
     sendJsonMessage(oroot);
 }
 


### PR DESCRIPTION
…g screen after a deleted file

If I used the device on computer B, and added/removed files from it, then on computer A the filesCache is not synchronized anymore. When I'm using it on computer A again, then it is displaying "No files in the device.", but when I enter Files Management Mode, I can see the files:
![missingfiles](https://user-images.githubusercontent.com/11043249/52375510-1ccdff00-2a60-11e9-9982-848992c2f397.gif)
I implemented a solution after discussing with @limpkin, to display this message only if there are actually no file on the device and filesCache is in sync, else if it isn't in sync it displays "Please enter file management mode to list the files in your device." message.

During implementing this solution I found another issue, if we remove a file from the device and want to save this, then the saving screen stucks before 100% and it remains:
![fileremovesavestucks](https://user-images.githubusercontent.com/11043249/52375977-489db480-2a61-11e9-9804-76ccef9fa1dc.gif)
Fixed this issue by connecting delete_data_nodes finished, and update page when it is emitted.