### PR TITLE
#392 Add .bin extension to exported db file for Appimage

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1307,6 +1307,18 @@ void MainWindow::dbExported(const QByteArray &d, bool success)
                                                      "Memory exports (*.bin);;All files (*.*)");
         if (!fname.isEmpty())
         {
+#if defined(Q_OS_LINUX)
+            /**
+             * getSaveFileName is using native dialog
+             * On Linux it is not saving the choosen extension,
+             * so need to add it from code.
+             */
+            const QString BIN_EXT = ".bin";
+            if (!fname.endsWith(BIN_EXT))
+            {
+                fname += BIN_EXT;
+            }
+#endif
             QFile f(fname);
             if (!f.open(QFile::WriteOnly | QFile::Truncate))
                 QMessageBox::warning(this, tr("Error"), tr("Unable to write to file %1").arg(fname));


### PR DESCRIPTION
**getSaveFileName** is using native dialog:
"On Windows, Mac OS X and Symbian^3, this static function will use the native file dialog and not a QFileDialog."
On Linux it is not saving the choosen extension, so need to add it from code.
https://stackoverflow.com/questions/9822177/is-there-a-way-to-automatically-add-extensions-to-a-file-using-qfiledialog-on-li