### PR TITLE
Fix displaying previous device informations

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -758,17 +758,22 @@ void MainWindow::updateSerialInfos() {
 
     ui->deviceInfoWidget->setVisible(connected);
 
+    const QString noneString = tr("None");
     if(connected)
     {
         ui->labelAboutFwVersValue->setText(wsClient->get_fwVersion());
-        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : tr("None"));
-        ui->labelAbouHwMemoryValue->setText(tr("%1Mb").arg(wsClient->get_hwMemory()));
+        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : noneString);
+        ui->labelAbouHwMemoryValue->setText(wsClient->get_hwMemory() > 0 ? tr("%1Mb").arg(wsClient->get_hwMemory()): noneString);
     }
     else
     {
-        ui->labelAboutFwVersValue->setText(tr("None"));
-        ui->labelAbouHwSerialValue->setText(tr("None"));
-        ui->labelAbouHwMemoryValue->setText(tr("None"));
+        ui->labelAboutFwVersValue->setText(noneString);
+        ui->labelAbouHwSerialValue->setText(noneString);
+        ui->labelAbouHwMemoryValue->setText(noneString);
+        wsClient->set_fwVersion(noneString);
+        wsClient->set_hwSerial(0);
+        wsClient->set_hwMemory(0);
+
     }
 }
 


### PR DESCRIPTION
On device disconnect the serial number field is cleared.
However when we connect the other device the parameters only read after enter the pin finished, but the previously connected device's parameters are still represented in wsClient (gui side) so on the connect signal it is loading those outdated informations.
Fix: On device disconnect I reset these informations, so until enter the pin is presented it is displaying "None" on About tab.