### PR TITLE
#415 Display device informations for BLE on About tab

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -34,7 +34,7 @@ BleDev::~BleDev()
 void BleDev::setWsClient(WSClient *c)
 {
     wsClient = c;
-    connect(wsClient, &WSClient::displayPlatInfo, this, &BleDev::displayPlatInfoReceived);
+    connect(wsClient, &WSClient::displayDebugPlatInfo, this, &BleDev::displayDebugPlatInfoReceived);
     connect(wsClient, &WSClient::displayUploadBundleResult, this, &BleDev::displayUploadBundleResultReceived);
 }
 
@@ -112,7 +112,7 @@ void BleDev::on_btnPlatInfo_clicked()
     wsClient->sendPlatInfoRequest();
 }
 
-void BleDev::displayPlatInfoReceived(int auxMajor, int auxMinor, int mainMajor, int mainMinor)
+void BleDev::displayDebugPlatInfoReceived(int auxMajor, int auxMinor, int mainMajor, int mainMinor)
 {
     ui->lineEditAuxMCUMaj->setText(QString::number(auxMajor));
     ui->lineEditAuxMCUMin->setText(QString::number(auxMinor));

--- a/src/BleDev.h
+++ b/src/BleDev.h
@@ -25,7 +25,7 @@ private slots:
 
     void on_btnPlatInfo_clicked();
 
-    void displayPlatInfoReceived(int auxMajor, int auxMinor, int mainMajor, int mainMinor);
+    void displayDebugPlatInfoReceived(int auxMajor, int auxMinor, int mainMajor, int mainMinor);
 
     void displayUploadBundleResultReceived(bool success);
     

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -130,6 +130,7 @@ void MPDevice::setupMessageProtocol()
             qDebug() << "Resetting flip bit for BLE";
 #endif
             bleImpl->sendResetFlipBit();
+            bleImpl->getPlatInfo();
         }
 
         exitMemMgmtMode(false);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -102,8 +102,6 @@ class MPDevice: public QObject
     QT_WRITABLE_PROPERTY(quint8, dataDbChangeNumber, 0)         // data db change number
     QT_WRITABLE_PROPERTY(QByteArray, cardCPZ, QByteArray())     // Card CPZ
 
-    QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
-    QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
     QT_WRITABLE_PROPERTY(qint64, uid, -1)
 
 public:

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -102,6 +102,8 @@ class MPDevice: public QObject
     QT_WRITABLE_PROPERTY(quint8, dataDbChangeNumber, 0)         // data db change number
     QT_WRITABLE_PROPERTY(QByteArray, cardCPZ, QByteArray())     // Card CPZ
 
+    QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
+    QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
     QT_WRITABLE_PROPERTY(qint64, uid, -1)
 
 public:

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -22,9 +22,9 @@ bool MPDeviceBleImpl::isLastPacket(const QByteArray &data)
     return actPacket == totalPacketNum;
 }
 
-void MPDeviceBleImpl::getPlatInfo(const MessageHandlerCbData &cb)
+void MPDeviceBleImpl::getDebugPlatInfo(const MessageHandlerCbData &cb)
 {
-    auto *jobs = new AsyncJobs("Get PlatInfo", mpDev);
+    auto *jobs = new AsyncJobs("Get Debug PlatInfo", mpDev);
 
     jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_GET_PLAT_INFO, bleProt->getDefaultFuncDone()));
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -33,10 +33,10 @@ void MPDeviceBleImpl::getPlatInfo()
         QByteArray response = bleProt->getFullPayload(data);
         const auto mainMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[0]), static_cast<quint8>(response[1]));
         const auto mainMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[2]), static_cast<quint8>(response[3]));
-        mpDev->set_mainMCUVersion(QString::number(mainMajor) + "." + QString::number(mainMinor));
+        set_mainMCUVersion(QString::number(mainMajor) + "." + QString::number(mainMinor));
         const auto auxMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[4]), static_cast<quint8>(response[5]));
         const auto auxMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[6]), static_cast<quint8>(response[7]));
-        mpDev->set_auxMCUVersion(QString::number(auxMajor) + "." + QString::number(auxMinor));
+        set_auxMCUVersion(QString::number(auxMajor) + "." + QString::number(auxMinor));
         const auto serialLower = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[8]), static_cast<quint8>(response[9]));
         const auto serialUpper = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[10]), static_cast<quint8>(response[11]));
         quint32 serialNum = serialLower;

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -31,12 +31,12 @@ void MPDeviceBleImpl::getPlatInfo()
     connect(jobs, &AsyncJobs::finished, [this](const QByteArray &data)
     {
         QByteArray response = bleProt->getFullPayload(data);
-        const auto auxMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[0]), static_cast<quint8>(response[1]));
-        const auto auxMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[2]), static_cast<quint8>(response[3]));
-        mpDev->set_auxMCUVersion(QString::number(auxMajor) + "." + QString::number(auxMinor));
-        const auto mainMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[4]), static_cast<quint8>(response[5]));
-        const auto mainMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[6]), static_cast<quint8>(response[7]));
+        const auto mainMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[0]), static_cast<quint8>(response[1]));
+        const auto mainMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[2]), static_cast<quint8>(response[3]));
         mpDev->set_mainMCUVersion(QString::number(mainMajor) + "." + QString::number(mainMinor));
+        const auto auxMajor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[4]), static_cast<quint8>(response[5]));
+        const auto auxMinor = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[6]), static_cast<quint8>(response[7]));
+        mpDev->set_auxMCUVersion(QString::number(auxMajor) + "." + QString::number(auxMinor));
         const auto serialLower = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[8]), static_cast<quint8>(response[9]));
         const auto serialUpper = bleProt->toIntFromLittleEndian(static_cast<quint8>(response[10]), static_cast<quint8>(response[11]));
         quint32 serialNum = serialLower;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -18,8 +18,10 @@ public:
 
     bool isFirstPacket(const QByteArray &data);
     bool isLastPacket(const QByteArray &data);
+
+    void getPlatInfo();
     void getDebugPlatInfo(const MessageHandlerCbData &cb);
-    QVector<int> calcPlatInfo(const QByteArray &platInfo);
+    QVector<int> calcDebugPlatInfo(const QByteArray &platInfo);
 
     void flashMCU(QString type, const MessageHandlerCb &cb);
     void uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -18,7 +18,7 @@ public:
 
     bool isFirstPacket(const QByteArray &data);
     bool isLastPacket(const QByteArray &data);
-    void getPlatInfo(const MessageHandlerCbData &cb);
+    void getDebugPlatInfo(const MessageHandlerCbData &cb);
     QVector<int> calcPlatInfo(const QByteArray &platInfo);
 
     void flashMCU(QString type, const MessageHandlerCb &cb);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -13,6 +13,10 @@ class MessageProtocolBLE;
 class MPDeviceBleImpl: public QObject
 {
     Q_OBJECT
+
+    QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
+    QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
+
 public:
     MPDeviceBleImpl(MessageProtocolBLE *mesProt, MPDevice *dev);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -122,6 +122,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     ui->labelAboutVers->setText(ui->labelAboutVers->text().arg(APP_VERSION));
 
+    ui->labelAboutAuxMCU->setText(tr("Aux MCU version:"));
+    ui->labelAboutMainMCU->setText(tr("Main MCU version:"));
+
     initHelpLabels();
 
     //Disable this option for now, firmware does not support it
@@ -354,9 +357,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     //When device has new parameters, update the GUI
     connect(wsClient, &WSClient::mpHwVersionChanged, [=]()
     {
-        const auto hwVersion = wsClient->get_mpHwVersion();
-        ui->widgetParamMini->setVisible(wsClient->get_mpHwVersion() == Common::MP_Mini);
-        ui->labelAbouHwSerial->setVisible(hwVersion == Common::MP_Mini || hwVersion == Common::MP_BLE);
+        ui->widgetParamMini->setVisible(wsClient->isMPMini());
+        ui->labelAbouHwSerial->setVisible(wsClient->isMPMini() || wsClient->isMPBLE());
+        displayMCUVersion(wsClient->isMPBLE());
     });
 
     connect(wsClient, &WSClient::connectedChanged, this, &MainWindow::updateSerialInfos);
@@ -759,21 +762,23 @@ void MainWindow::updateSerialInfos() {
 
     ui->deviceInfoWidget->setVisible(connected);
 
-    const QString noneString = tr("None");
     if(connected)
     {
         ui->labelAboutFwVersValue->setText(wsClient->get_fwVersion());
-        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : noneString);
-        ui->labelAbouHwMemoryValue->setText(wsClient->get_hwMemory() > 0 ? tr("%1Mb").arg(wsClient->get_hwMemory()): noneString);
+        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : NONE_STRING);
+        ui->labelAbouHwMemoryValue->setText(wsClient->get_hwMemory() > 0 ? tr("%1Mb").arg(wsClient->get_hwMemory()): NONE_STRING);
+        displayMCUVersion(wsClient->isMPBLE());
     }
     else
     {
-        ui->labelAboutFwVersValue->setText(noneString);
-        ui->labelAbouHwSerialValue->setText(noneString);
-        ui->labelAbouHwMemoryValue->setText(noneString);
-        wsClient->set_fwVersion(noneString);
+        ui->labelAboutFwVersValue->setText(NONE_STRING);
+        ui->labelAbouHwSerialValue->setText(NONE_STRING);
+        ui->labelAbouHwMemoryValue->setText(NONE_STRING);
+        wsClient->set_fwVersion(NONE_STRING);
         wsClient->set_hwSerial(0);
         wsClient->set_hwMemory(0);
+        wsClient->set_auxMCUVersion(NONE_STRING);
+        wsClient->set_mainMCUVersion(NONE_STRING);
 
     }
 }
@@ -1591,6 +1596,16 @@ void MainWindow::retranslateUi()
 {
     ui->labelAboutVers->setText(ui->labelAboutVers->text().arg(APP_VERSION));
     updateSerialInfos();
+}
+
+void MainWindow::displayMCUVersion(bool visible)
+{
+    ui->labelAboutAuxMCU->setVisible(visible);
+    ui->labelAboutAuxMCUValue->setVisible(visible);
+    ui->labelAboutAuxMCUValue->setText(wsClient->get_auxMCUVersion());
+    ui->labelAboutMainMCU->setVisible(visible);
+    ui->labelAboutMainMCUValue->setVisible(visible);
+    ui->labelAboutMainMCUValue->setText(wsClient->get_mainMCUVersion());
 }
 
 void MainWindow::on_toolButton_clearBackupFilePath_released()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -354,8 +354,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     //When device has new parameters, update the GUI
     connect(wsClient, &WSClient::mpHwVersionChanged, [=]()
     {
+        const auto hwVersion = wsClient->get_mpHwVersion();
         ui->widgetParamMini->setVisible(wsClient->get_mpHwVersion() == Common::MP_Mini);
-        ui->labelAbouHwSerial->setVisible(wsClient->get_mpHwVersion() == Common::MP_Mini);
+        ui->labelAbouHwSerial->setVisible(hwVersion == Common::MP_Mini || hwVersion == Common::MP_BLE);
     });
 
     connect(wsClient, &WSClient::connectedChanged, this, &MainWindow::updateSerialInfos);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -768,6 +768,9 @@ void MainWindow::updateSerialInfos() {
         ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : NONE_STRING);
         ui->labelAbouHwMemoryValue->setText(wsClient->get_hwMemory() > 0 ? tr("%1Mb").arg(wsClient->get_hwMemory()): NONE_STRING);
         displayMCUVersion(wsClient->isMPBLE());
+        //When ble is detected not displaying fw version
+        ui->labelAboutFwVers->setVisible(!wsClient->isMPBLE());
+        ui->labelAboutFwVersValue->setVisible(!wsClient->isMPBLE());
     }
     else
     {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -147,6 +147,8 @@ private:
 
     void retranslateUi();
 
+    void displayMCUVersion(bool visible = true);
+
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 
@@ -176,6 +178,7 @@ private:
     SystemEventHandler eventHandler;
 
     const QString HIBP_URL = "https://haveibeenpwned.com/Passwords";
+    const QString NONE_STRING = tr("None");
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -2373,6 +2373,74 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </item>
             </layout>
            </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_47">
+             <item>
+              <widget class="QLabel" name="labelAboutAuxMCU">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Aux MCU Version:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelAboutAuxMCUValue">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_48">
+             <item>
+              <widget class="QLabel" name="labelAboutMainMCU">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Main MCU Version:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelAboutMainMCUValue">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
           </layout>
          </widget>
         </item>

--- a/src/MessageProtocol/IMessageProtocol.h
+++ b/src/MessageProtocol/IMessageProtocol.h
@@ -127,7 +127,7 @@ public:
         return printCmd(cmd);
     }
 
-    quint16 toIntFromBigEndian(quint8 lowerByte, quint8 upperByte)
+    quint16 toIntFromLittleEndian(quint8 lowerByte, quint8 upperByte)
     {
         return (lowerByte|(upperByte<<8));
     }

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -56,7 +56,7 @@ quint16 MessageProtocolBLE::getMessageSize(const QByteArray &data)
 
 MPCmd::Command MessageProtocolBLE::getCommand(const QByteArray &data)
 {
-   const quint16 bleCommandId = toIntFromBigEndian(static_cast<quint8>(data[CMD_LOWER_BYTE]), static_cast<quint8>(data[CMD_UPPER_BYTE]));
+   const quint16 bleCommandId = toIntFromLittleEndian(static_cast<quint8>(data[CMD_LOWER_BYTE]), static_cast<quint8>(data[CMD_UPPER_BYTE]));
    return MPCmd::Command(m_commandMapping.key(bleCommandId));
 }
 
@@ -209,7 +209,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::ADD_UNKNOWN_CARD      , 0xB8},
         {MPCmd::MOOLTIPASS_STATUS     , 0x0001},
         {MPCmd::FUNCTIONAL_TEST_RES   , 0xBA},
-        {MPCmd::SET_DATE              , 0xBB},
+        {MPCmd::SET_DATE              , 0x0004},
         {MPCmd::SET_UID               , 0xBC},
         {MPCmd::GET_UID               , 0xBD},
         {MPCmd::SET_DATA_SERVICE      , 0xBE},
@@ -218,7 +218,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::READ_32B_IN_DN        , 0xC1},
         {MPCmd::GET_CUR_CARD_CPZ      , 0xC2},
         {MPCmd::CANCEL_USER_REQUEST   , 0xC3},
-        {MPCmd::PLEASE_RETRY          , 0xC4},
+        {MPCmd::PLEASE_RETRY          , 0x0002},
         {MPCmd::READ_FLASH_NODE       , 0xC5},
         {MPCmd::WRITE_FLASH_NODE      , 0xC6},
         {MPCmd::GET_FAVORITE          , 0xC7},
@@ -241,6 +241,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::LOCK_DEVICE           , 0xD9},
         {MPCmd::GET_SERIAL            , 0xDA},
         {MPCmd::CMD_DBG_MESSAGE       , 0x8000},
+        {MPCmd::GET_PLAT_INFO         , 0x0003},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -126,6 +126,7 @@ public:
             SET_DESCRIPTION     ,
             LOCK_DEVICE         ,
             GET_SERIAL          ,
+            GET_PLAT_INFO       ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -425,10 +425,10 @@ void WSClient::onTextMessageReceived(const QString &message)
     {
         emit deleteDataNodesFinished();
     }
-    else if (rootobj["msg"] == "get_platinfo")
+    else if (rootobj["msg"] == "get_debug_platinfo")
     {
         QJsonObject o = rootobj["data"].toObject();
-        emit displayPlatInfo(o["aux_major"].toInt(), o["aux_minor"].toInt(), o["main_major"].toInt(), o["main_minor"].toInt());
+        emit displayDebugPlatInfo(o["aux_major"].toInt(), o["aux_minor"].toInt(), o["main_major"].toInt(), o["main_minor"].toInt());
     }
     else if (rootobj["msg"] == "upload_bundle")
     {
@@ -640,7 +640,7 @@ void WSClient::sendRefreshFilesCacheRequest()
 
 void WSClient::sendPlatInfoRequest()
 {
-    sendJsonData({{ "msg", "get_platinfo" }});
+    sendJsonData({{ "msg", "get_debug_platinfo" }});
 }
 
 void WSClient::sendFlashMCU(QString type)

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -188,6 +188,8 @@ void WSClient::onTextMessageReceived(const QString &message)
         else if (o["hw_version"].toString().contains("ble"))
         {
             set_mpHwVersion(Common::MP_BLE);
+            set_auxMCUVersion(o["aux_mcu_version"].toString());
+            set_mainMCUVersion(o["main_mcu_version"].toString());
         }
         else
         {

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -68,6 +68,9 @@ class WSClient: public QObject
     QT_WRITABLE_PROPERTY(int, credentialsDbChangeNumber, 0)
     QT_WRITABLE_PROPERTY(int, dataDbChangeNumber, 0)
 
+    QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
+    QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
+
 public:
     explicit WSClient(QObject *parent = nullptr);
     ~WSClient();

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -142,7 +142,7 @@ signals:
     void cardDbMetadataChanged(QString cardId, int credentialsDbChangeNumber, int dataDbChangeNumber);
     void cardResetFinished(bool successfully);
     void displayStatusWarning();
-    void displayPlatInfo(int auxMajor, int auxMinor, int mainMajor, int mainMinor);
+    void displayDebugPlatInfo(int auxMajor, int auxMinor, int mainMajor, int mainMinor);
     void displayUploadBundleResult(bool success);
     void deleteDataNodesFinished();
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1103,8 +1103,11 @@ void WSServerCon::sendVersion()
     if (mpdevice->isBLE())
     {
         data["hw_version"] = "ble";
-        data["aux_mcu_version"] = mpdevice->get_auxMCUVersion();
-        data["main_mcu_version"] = mpdevice->get_mainMCUVersion();
+        if (auto bleImpl = mpdevice->ble())
+        {
+            data["aux_mcu_version"] = bleImpl->get_auxMCUVersion();
+            data["main_mcu_version"] = bleImpl->get_mainMCUVersion();
+        }
     }
     sendJsonMessage({{ "msg", "version_changed" }, { "data", data }});
 }

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -711,9 +711,9 @@ void WSServerCon::processMessage(const QString &message)
             return;
         }
 
-        if (root["msg"] == "get_platinfo")
+        if (root["msg"] == "get_debug_platinfo")
         {
-            bleImpl->getPlatInfo([this, root, bleImpl](bool success, QString errstr, QByteArray data)
+            bleImpl->getDebugPlatInfo([this, root, bleImpl](bool success, QString errstr, QByteArray data)
             {
                 if (!success)
                 {

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -721,7 +721,7 @@ void WSServerCon::processMessage(const QString &message)
                     return;
                 }
 
-                auto platInfo = bleImpl->calcPlatInfo(data);
+                auto platInfo = bleImpl->calcDebugPlatInfo(data);
                 QJsonObject ores;
                 QJsonObject oroot = root;
                 ores["aux_major"] = platInfo[0];
@@ -1099,13 +1099,12 @@ void WSServerCon::sendVersion()
         return;
     QJsonObject data = {{ "hw_version", mpdevice->get_hwVersion() },
                         { "flash_size", mpdevice->get_flashMbSize() }};
-    if (mpdevice->isMini())
-    {
-        data["hw_serial"] = (qint64)mpdevice->get_serialNumber();
-    }
+    data["hw_serial"] = static_cast<qint64>(mpdevice->get_serialNumber());
     if (mpdevice->isBLE())
     {
         data["hw_version"] = "ble";
+        data["aux_mcu_version"] = mpdevice->get_auxMCUVersion();
+        data["main_mcu_version"] = mpdevice->get_mainMCUVersion();
     }
     sendJsonMessage({{ "msg", "version_changed" }, { "data", data }});
 }


### PR DESCRIPTION
Rename the BLE Tab related platInfo functions to debug and added a new one for handling 0x0003 Get Platform Info command.
On GUI side, if BLE is detected Main and Aux MCU are also displayed:
![kep](https://user-images.githubusercontent.com/11043249/53683915-03d70780-3d07-11e9-808e-b53126b4a4a1.png)

