### PR TITLE
Implement Acceleration Data Fetch for BLE Dev tab

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -180,18 +180,21 @@ void BleDev::on_btnAccDataBrowse_clicked()
 
 void BleDev::on_btnFetchAccData_clicked()
 {
-    if (AccState::STOPPED == accState && !ui->lineEditAccData->text().isEmpty())
+    QString fileName = ui->lineEditAccData->text();
+    if (Common::AccState::STOPPED == accState && !ui->lineEditAccData->text().isEmpty())
     {
         ui->progressBarAccData->show();
         ui->progressBarAccData->setMinimum(0);
         ui->progressBarAccData->setMaximum(0);
         ui->btnFetchAccData->setText(tr("Stop Fetch"));
-        accState = AccState::STARTED;
+        accState = Common::AccState::STARTED;
+        wsClient->sendFetchAccData(fileName);
     }
     else
     {
         ui->progressBarAccData->hide();
         ui->btnFetchAccData->setText(tr("Fetch"));
-        accState = AccState::STOPPED;
+        accState = Common::AccState::STOPPED;
+        wsClient->sendStopFetchAccData();
     }
 }

--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -26,6 +26,12 @@ BleDev::BleDev(QWidget *parent) :
     ui->btnAccDataBrowse->setIcon(AppGui::qtAwesome()->icon(fa::file, whiteButtons));
     ui->progressBarAccData->setVisible(false);
     ui->horizontalLayout_Fetch->setAlignment(Qt::AlignLeft);
+    ui->progressBarAccData->setMinimum(0);
+    ui->progressBarAccData->setMaximum(0);
+
+#if defined(Q_OS_LINUX)
+    ui->label_AccDataFile->setMaximumWidth(150);
+#endif
     initUITexts();
 }
 
@@ -174,6 +180,19 @@ void BleDev::on_btnAccDataBrowse_clicked()
                                             s.value("last_used_path/accdata_dir", QDir::homePath()).toString(),
                                             "*.bin");
 
+#if defined(Q_OS_LINUX)
+            /**
+             * getSaveFileName is using native dialog
+             * On Linux it is not saving the choosen extension,
+             * so need to add it from code.
+             */
+            const QString BIN_EXT = ".bin";
+            if (!fileName.endsWith(BIN_EXT))
+            {
+                fileName += BIN_EXT;
+            }
+#endif
+
     ui->lineEditAccData->setText(fileName);
     s.setValue("last_used_path/accdata_dir", fileName.mid(0, fileName.lastIndexOf('/')));
 }
@@ -184,8 +203,6 @@ void BleDev::on_btnFetchAccData_clicked()
     if (Common::AccState::STOPPED == accState && !ui->lineEditAccData->text().isEmpty())
     {
         ui->progressBarAccData->show();
-        ui->progressBarAccData->setMinimum(0);
-        ui->progressBarAccData->setMaximum(0);
         ui->btnFetchAccData->setText(tr("Stop Fetch"));
         accState = Common::AccState::STARTED;
         wsClient->sendFetchAccData(fileName);

--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -23,6 +23,9 @@ BleDev::BleDev(QWidget *parent) :
     ui->label_UploadProgress->hide();
 
     ui->btnFileBrowser->setIcon(AppGui::qtAwesome()->icon(fa::file, whiteButtons));
+    ui->btnAccDataBrowse->setIcon(AppGui::qtAwesome()->icon(fa::file, whiteButtons));
+    ui->progressBarAccData->setVisible(false);
+    ui->horizontalLayout_11->setAlignment(Qt::AlignLeft);
     initUITexts();
 }
 
@@ -49,12 +52,13 @@ void BleDev::clearWidgets()
 
 void BleDev::initUITexts()
 {
+    const auto browseText = tr("Browse");
     ui->label_DevTab->setText(tr("BLE Developer Tab"));
     ui->label_BLEDesc->setText(tr("BLE description"));
 
     ui->groupBoxUploadBundle->setTitle(tr("Upload Bundle"));
     ui->label_bundleText->setText(tr("Select Bundle File:"));
-    ui->btnFileBrowser->setText(tr("Browse"));
+    ui->btnFileBrowser->setText(browseText);
 
     ui->groupBoxPlatInfo->setTitle(tr("Platform informations"));
     ui->label_AuxMCUMaj->setText(tr("Aux MCU major:"));
@@ -69,6 +73,11 @@ void BleDev::initUITexts()
     ui->btnReflashAuxMCU->setText(flashText);
     ui->label_FlashMainMCU->setText(tr("Flash Main MCU:"));
     ui->btnFlashMainMCU->setText(flashText);
+
+    ui->groupBoxAccData->setTitle(tr("Acceleration Data"));
+    ui->label_AccDataFile->setText(tr("Acceleration Data File:"));
+    ui->btnAccDataBrowse->setText(browseText);
+    ui->btnFetchAccData->setText(tr("Fetch"));
 }
 
 void BleDev::on_btnFileBrowser_clicked()
@@ -155,4 +164,34 @@ void BleDev::updateProgress(int total, int curr, QString msg)
     ui->progressBarUpload->setMaximum(total);
     ui->progressBarUpload->setValue(curr);
     ui->label_UploadProgress->setText(msg);
+}
+
+void BleDev::on_btnAccDataBrowse_clicked()
+{
+    QSettings s;
+
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Select file to fetch acceleration data"),
+                                            s.value("last_used_path/accdata_dir", QDir::homePath()).toString(),
+                                            "*.bin");
+
+    ui->lineEditAccData->setText(fileName);
+    s.setValue("last_used_path/accdata_dir", fileName.mid(0, fileName.lastIndexOf('/')));
+}
+
+void BleDev::on_btnFetchAccData_clicked()
+{
+    if (AccState::STOPPED == accState && !ui->lineEditAccData->text().isEmpty())
+    {
+        ui->progressBarAccData->show();
+        ui->progressBarAccData->setMinimum(0);
+        ui->progressBarAccData->setMaximum(0);
+        ui->btnFetchAccData->setText(tr("Stop Fetch"));
+        accState = AccState::STARTED;
+    }
+    else
+    {
+        ui->progressBarAccData->hide();
+        ui->btnFetchAccData->setText(tr("Fetch"));
+        accState = AccState::STOPPED;
+    }
 }

--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -25,7 +25,7 @@ BleDev::BleDev(QWidget *parent) :
     ui->btnFileBrowser->setIcon(AppGui::qtAwesome()->icon(fa::file, whiteButtons));
     ui->btnAccDataBrowse->setIcon(AppGui::qtAwesome()->icon(fa::file, whiteButtons));
     ui->progressBarAccData->setVisible(false);
-    ui->horizontalLayout_11->setAlignment(Qt::AlignLeft);
+    ui->horizontalLayout_Fetch->setAlignment(Qt::AlignLeft);
     initUITexts();
 }
 

--- a/src/BleDev.h
+++ b/src/BleDev.h
@@ -13,6 +13,12 @@ class BleDev : public QWidget
 {
     Q_OBJECT
 
+    enum class AccState
+    {
+        STOPPED,
+        STARTED
+    };
+
 public:
     explicit BleDev(QWidget *parent = nullptr);
     ~BleDev();
@@ -35,12 +41,17 @@ private slots:
 
     void updateProgress(int total, int curr, QString msg);
 
+    void on_btnAccDataBrowse_clicked();
+
+    void on_btnFetchAccData_clicked();
+
 private:
     void initUITexts();
 
 
     Ui::BleDev *ui;
     WSClient *wsClient = nullptr;
+    AccState accState = AccState::STOPPED;
 };
 
 #endif // BLEDEV_H

--- a/src/BleDev.h
+++ b/src/BleDev.h
@@ -2,6 +2,7 @@
 #define BLEDEV_H
 
 #include <QWidget>
+#include <Common.h>
 
 class WSClient;
 
@@ -12,12 +13,6 @@ class BleDev;
 class BleDev : public QWidget
 {
     Q_OBJECT
-
-    enum class AccState
-    {
-        STOPPED,
-        STARTED
-    };
 
 public:
     explicit BleDev(QWidget *parent = nullptr);
@@ -51,7 +46,7 @@ private:
 
     Ui::BleDev *ui;
     WSClient *wsClient = nullptr;
-    AccState accState = AccState::STOPPED;
+    Common::AccState accState = Common::AccState::STOPPED;
 };
 
 #endif // BLEDEV_H

--- a/src/BleDev.ui
+++ b/src/BleDev.ui
@@ -654,6 +654,154 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBoxAccData">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Acceleration Data</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="leftMargin">
+         <number>30</number>
+        </property>
+        <property name="rightMargin">
+         <number>30</number>
+        </property>
+        <property name="bottomMargin">
+         <number>6</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_AccDataFile">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>135</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Acceleration Data File:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEditAccData">
+          <property name="minimumSize">
+           <size>
+            <width>250</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>325</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnAccDataBrowse">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <property name="leftMargin">
+         <number>30</number>
+        </property>
+        <property name="rightMargin">
+         <number>30</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="btnFetchAccData">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Fetch</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QProgressBar" name="progressBarAccData">
+          <property name="value">
+           <number>24</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/BleDev.ui
+++ b/src/BleDev.ui
@@ -757,7 +757,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
+       <layout class="QHBoxLayout" name="horizontalLayout_Fetch">
         <property name="leftMargin">
          <number>30</number>
         </property>

--- a/src/Common.h
+++ b/src/Common.h
@@ -194,6 +194,12 @@ public:
         FAV_13,
         FAV_14,
     };
+
+    enum class AccState
+    {
+        STOPPED,
+        STARTED
+    };
 };
 
 Q_DECLARE_METATYPE(Common::MPStatus)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -172,7 +172,7 @@ void MPDeviceBleImpl::fetchAccData(QString filePath, const MessageHandlerCb &cb)
                         QFile *file = new QFile(filePath);
                         if (file->open(QIODevice::WriteOnly))
                         {
-                            file->write(bleProt->getFullPayload(data).toHex() + "\n");
+                            file->write(bleProt->getFullPayload(data));
                         }
                         writeAccData(file);
                         return true;
@@ -272,7 +272,7 @@ void MPDeviceBleImpl::writeAccData(QFile *file)
     mpDev->sendData(MPCmd::CMD_DBG_GET_ACC_32_SAMPLES,
                     [this, file](bool, const QByteArray &data, bool &) -> bool
                     {
-                        file->write(bleProt->getFullPayload(data).toHex() + "\n");
+                        file->write(bleProt->getFullPayload(data));
                         if (Common::AccState::STARTED == accState)
                         {
                             writeAccData(file);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -158,11 +158,8 @@ void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb,
     dequeueAndRun(jobs);
 }
 
-void MPDeviceBleImpl::fetchAccData(QString filePath, const MessageHandlerCb &cb)
+void MPDeviceBleImpl::fetchAccData(QString filePath)
 {
-    Q_UNUSED(cb);
-    qDebug() << "Fetching acc data: " << filePath;
-
     accState = Common::AccState::STARTED;
     auto *jobs = new AsyncJobs(QString("Fetch Acc Data"), this);
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -29,7 +29,7 @@ public:
 
     void flashMCU(QString type, const MessageHandlerCb &cb);
     void uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress);
-    void fetchAccData(QString filePath, const MessageHandlerCb &cb);
+    void fetchAccData(QString filePath);
     inline void stopFetchAccData() { accState = Common::AccState::STOPPED; }
 
     void sendResetFlipBit();

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -29,18 +29,22 @@ public:
 
     void flashMCU(QString type, const MessageHandlerCb &cb);
     void uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress);
+    void fetchAccData(QString filePath, const MessageHandlerCb &cb);
+    inline void stopFetchAccData() { accState = Common::AccState::STOPPED; }
 
     void sendResetFlipBit();
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
+    void writeAccData(QFile *file);
 
     void dequeueAndRun(AsyncJobs *job);
 
 
     MessageProtocolBLE *bleProt;
     MPDevice *mpDev;
+    Common::AccState accState = Common::AccState::STOPPED;
 
     static constexpr int BUNBLE_DATA_WRITE_SIZE = 256;
     static constexpr int BUNBLE_DATA_ADDRESS_SIZE = 4;

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -661,6 +661,19 @@ void WSClient::sendUploadBundle(QString bundleFilePath)
                   {"data", o}});
 }
 
+void WSClient::sendFetchAccData(QString fileName)
+{
+    QJsonObject o;
+    o["file"] = fileName;
+    sendJsonData({{ "msg", "fetch_acc_data" },
+                  {"data", o}});
+}
+
+void WSClient::sendStopFetchAccData()
+{
+    sendJsonData({{ "msg", "stop_fetch_acc_data" }});
+}
+
 bool WSClient::isFw12()
 {
     static QRegularExpression regVersion("v([0-9]+)\\.([0-9]+)(.*)");

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -119,6 +119,8 @@ public:
     void sendPlatInfoRequest();
     void sendFlashMCU(QString type);
     void sendUploadBundle(QString bundleFilePath);
+    void sendFetchAccData(QString fileName);
+    void sendStopFetchAccData();
 
     bool isFw12();
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -762,6 +762,26 @@ void WSServerCon::processMessage(const QString &message)
                 sendJsonMessage(oroot);
             }, defaultProgressCb);
         }
+        else if (root["msg"] == "fetch_acc_data")
+        {
+            QJsonObject o = root["data"].toObject();
+            bleImpl->fetchAccData(o["file"].toString(), [this, root](bool success, QString errstr)
+            {
+                QJsonObject ores;
+                QJsonObject oroot = root;
+                ores["success"] = success;
+                if (!success)
+                {
+                    qCritical() << errstr;
+                }
+                oroot["data"] = ores;
+                sendJsonMessage(oroot);
+            });
+        }
+        else if (root["msg"] == "stop_fetch_acc_data")
+        {
+            bleImpl->stopFetchAccData();
+        }
     }
 
 }

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -765,18 +765,7 @@ void WSServerCon::processMessage(const QString &message)
         else if (root["msg"] == "fetch_acc_data")
         {
             QJsonObject o = root["data"].toObject();
-            bleImpl->fetchAccData(o["file"].toString(), [this, root](bool success, QString errstr)
-            {
-                QJsonObject ores;
-                QJsonObject oroot = root;
-                ores["success"] = success;
-                if (!success)
-                {
-                    qCritical() << errstr;
-                }
-                oroot["data"] = ores;
-                sendJsonMessage(oroot);
-            });
+            bleImpl->fetchAccData(o["file"].toString());
         }
         else if (root["msg"] == "stop_fetch_acc_data")
         {


### PR DESCRIPTION
Added a "Acceleration Data Fetch" button to BLE Dev tab. When clicking it will open a prompt to save a binary file, then it is constantly saving data from the device to that binary file. 
Process can be stopped by clicking the same button, now renamed to "Stop Fetch"
![fetchAccData](https://user-images.githubusercontent.com/11043249/54312994-98c7e380-45d8-11e9-9979-152fc1c0f658.gif)
