### PR TITLE
Implemented a new usb add&remove handle for exclusive device open crash fix on Windows

### DIFF
--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -80,7 +80,7 @@ HANDLE MPDevice_win::openDevice(QString path, bool exlusive /* =false */)
                            nullptr,
                            OPEN_EXISTING,
                            FILE_FLAG_OVERLAPPED,
-                           0);
+                           nullptr);
 
     if (GetLastError() == ERROR_ACCESS_DENIED)
         h = CreateFileA(qToChar(path),
@@ -89,7 +89,7 @@ HANDLE MPDevice_win::openDevice(QString path, bool exlusive /* =false */)
                         nullptr,
                         OPEN_EXISTING,
                         FILE_FLAG_OVERLAPPED,
-                        0);
+                        nullptr);
 
     return h;
 }

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -71,12 +71,13 @@ QString MPDevice_win::getLastError(DWORD err)
     return result;
 }
 
-HANDLE MPDevice_win::openDevice(QString path)
+HANDLE MPDevice_win::openDevice(QString path, bool exlusive /* =false */)
 {
+    DWORD sharedOptRW = exlusive ? 0 : FILE_SHARE_READ | FILE_SHARE_WRITE;
     HANDLE h = CreateFileA(qToChar(path),
                            GENERIC_WRITE | GENERIC_READ,
-                           0, //Open exclusively
-                           NULL,
+                           sharedOptRW,
+                           nullptr,
                            OPEN_EXISTING,
                            FILE_FLAG_OVERLAPPED,
                            0);
@@ -84,8 +85,8 @@ HANDLE MPDevice_win::openDevice(QString path)
     if (GetLastError() == ERROR_ACCESS_DENIED)
         h = CreateFileA(qToChar(path),
                         GENERIC_READ,
-                        0,
-                        NULL,
+                        sharedOptRW & FILE_SHARE_READ,
+                        nullptr,
                         OPEN_EXISTING,
                         FILE_FLAG_OVERLAPPED,
                         0);
@@ -95,7 +96,7 @@ HANDLE MPDevice_win::openDevice(QString path)
 
 bool MPDevice_win::openPath()
 {
-    platformDef.devHandle = openDevice(platformDef.path);
+    platformDef.devHandle = openDevice(platformDef.path, true);
 
     if (platformDef.devHandle == INVALID_HANDLE_VALUE)
     {
@@ -210,7 +211,6 @@ QList<MPPlatformDef> MPDevice_win::enumerateDevices()
                                        &dev_data))
     {
         DWORD required_size = 0;
-        HIDD_ATTRIBUTES attrib;
 
         //first call is to get the required_size
         bool ret = SetupDiGetDeviceInterfaceDetailA(dev_info_set,
@@ -232,50 +232,64 @@ QList<MPPlatformDef> MPDevice_win::enumerateDevices()
                                                nullptr,
                                                nullptr);
 
+        ++idx;
         if (!ret)
         {
             free(dev_detail_data);
-            idx++;
             continue;
         }
 
         QString path = QString(dev_detail_data->DevicePath);
         free(dev_detail_data);
 
-        //Get vendorid/productid
-        attrib.Size = sizeof(HIDD_ATTRIBUTES);
-        HANDLE h = openDevice(path);
-        if (h == INVALID_HANDLE_VALUE)
+        bool isBLE = false;
+        if (!checkDevice(path, isBLE))
         {
-            idx++;
             continue;
         }
-
-        HID.HidD_GetAttributes(h, &attrib);
-        CloseHandle(h);
-
-        if ((attrib.VendorID != MOOLTIPASS_VENDORID && attrib.VendorID != MOOLTIPASS_BLE_VENDORID) ||
-            (attrib.ProductID != MOOLTIPASS_PRODUCTID && attrib.ProductID != MOOLTIPASS_BLE_PRODUCTID))
-        {
-            idx++;
-            continue;
-        }
-
         qDebug() << "Found mooltipass: " << path;
 
         //TODO: extract interface number from path string and check it
 
-        MPPlatformDef def;
-        def.path = path;
-        def.id = path; //use path for ID
-        def.isBLE = attrib.VendorID == MOOLTIPASS_BLE_VENDORID;
-        devlist << def;
-        idx++;
+        devlist << getPlatDef(path, isBLE);
     }
 
     SetupDiDestroyDeviceInfoList(dev_info_set);
 
     return devlist;
+}
+
+bool MPDevice_win::checkDevice(QString path, bool &isBLE /* out */)
+{
+    HIDD_ATTRIBUTES attrib;
+    //Get vendorid/productid
+    attrib.Size = sizeof(HIDD_ATTRIBUTES);
+    HANDLE h = openDevice(path);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        return false;
+    }
+
+    HID.HidD_GetAttributes(h, &attrib);
+    CloseHandle(h);
+
+    if ((attrib.VendorID != MOOLTIPASS_VENDORID && attrib.VendorID != MOOLTIPASS_BLE_VENDORID) ||
+        (attrib.ProductID != MOOLTIPASS_PRODUCTID && attrib.ProductID != MOOLTIPASS_BLE_PRODUCTID))
+    {
+        return false;
+    }
+
+    isBLE = attrib.VendorID == MOOLTIPASS_BLE_VENDORID;
+    return true;
+}
+
+MPPlatformDef MPDevice_win::getPlatDef(QString path, bool isBLE)
+{
+    MPPlatformDef def;
+    def.path = path;
+    def.id = path; //use path for ID
+    def.isBLE = isBLE;
+    return def;
 }
 
 void MPDevice_win::ovlpNotified(quint32 numberOfBytes, quint32 errorCode, OVERLAPPED *overlapped)

--- a/src/MPDevice_win.h
+++ b/src/MPDevice_win.h
@@ -77,6 +77,15 @@ public:
 
     //Static function for enumerating devices on platform
     static QList<MPPlatformDef> enumerateDevices();
+    /**
+     * @brief checkDevice
+     * Checking if the device is a mooltipass device
+     * @param path to the device
+     * @param isBLE out param, true if device is a ble
+     * @return true, if the device is mini/ble
+     */
+    static bool checkDevice(QString path, bool &isBLE);
+    static MPPlatformDef getPlatDef(QString path, bool isBLE);
 
 private slots:
     void ovlpNotified(quint32 numberOfBytes, quint32 errorCode, OVERLAPPED *overlapped);
@@ -86,7 +95,7 @@ private:
     virtual void platformWrite(const QByteArray &data);
 
     bool openPath();
-    static HANDLE openDevice(QString path);
+    static HANDLE openDevice(QString path, bool exlusive = false);
 
     //GetLastError() helper
     QString getLastError(DWORD err);

--- a/src/MPManager.cpp
+++ b/src/MPManager.cpp
@@ -102,12 +102,12 @@ void MPManager::usbDeviceRemoved()
 
 void MPManager::usbDeviceAdded(QString path)
 {
+#if defined(Q_OS_WIN)
     if (!devices.contains(path))
     {
-        MPDevice *device;
+        MPDevice *device = nullptr;
 
         //Create our platform device object
-#if defined(Q_OS_WIN)
         bool isBLE = false;
         if (!MPDevice_win::checkDevice(path, isBLE))
         {
@@ -115,11 +115,6 @@ void MPManager::usbDeviceAdded(QString path)
             return;
         }
         device = new MPDevice_win(this, MPDevice_win::getPlatDef(path, isBLE));
-#elif defined(Q_OS_MAC)
-        //device = new MPDevice_mac(this, path);
-#elif defined(Q_OS_LINUX)
-        //device = new MPDevice_linux(this, path);
-#endif
 
         devices[path] = device;
         emit mpConnected(device);
@@ -128,6 +123,10 @@ void MPManager::usbDeviceAdded(QString path)
     {
         qDebug() << "Device is already added: " << path;
     }
+#else
+    Q_UNUSED(path)
+    return;
+#endif
 }
 
 void MPManager::usbDeviceRemoved(QString path)

--- a/src/MPManager.h
+++ b/src/MPManager.h
@@ -44,7 +44,7 @@ public:
     bool initialize();
 
     void stop();
-    MPDevice *getDevice(int at);
+    MPDevice* getDevice(int at);
     int getDeviceCount() { return devices.count(); }
 
 signals:
@@ -54,6 +54,8 @@ signals:
 private slots:
     void usbDeviceAdded();
     void usbDeviceRemoved();
+    void usbDeviceAdded(QString path);
+    void usbDeviceRemoved(QString path);
 
 private:
     MPManager();

--- a/src/UsbMonitor_win.cpp
+++ b/src/UsbMonitor_win.cpp
@@ -58,12 +58,12 @@ bool UsbMonitor_win::nativeEvent(const QByteArray &eventType, void *message, lon
         if (msg->wParam == DBT_DEVICEARRIVAL)
         {
             qDebug() << "Device added: " << guid.toString() << " - " << dev_path;
-            emit usbDeviceAdded(/*guid, dev_path*/);
+            emit usbDeviceAdded(dev_path.toLower());
         }
         else if (msg->wParam == DBT_DEVICEREMOVECOMPLETE)
         {
             qDebug() << "Device removed: " << guid.toString() << " - " << dev_path;
-            emit usbDeviceRemoved(/*guid, dev_path*/);
+            emit usbDeviceRemoved(dev_path.toLower());
         }
     }
 

--- a/src/UsbMonitor_win.h
+++ b/src/UsbMonitor_win.h
@@ -37,8 +37,8 @@ public:
     ~UsbMonitor_win();
 
 signals:
-    void usbDeviceAdded();
-    void usbDeviceRemoved();
+    void usbDeviceAdded(QString path);
+    void usbDeviceRemoved(QString path);
 
 private:
     UsbMonitor_win();


### PR DESCRIPTION
### Issue
On Windows when device is added or removed checkUsbDevices() is called. When there is an **exclusively opened device** it does not find the device again, because cannot open it for checking the product and vendor id, hence the MPDevice_win::enumerateDevices() function returns with an empty device list, so it disconnects every device.
  The crash is caused by the delayed exitMemMgmtMode, when we are calling it the device has already disconnected because of the issue mentioned above.

Also added an option for exclusive device opening, because when we are only peaking the device's vendor and product id from attributes it does not require an exclusive opening.

### Linux, Mac
If exclusive device opening will implemented for Linux or Mac we also need to check this issue and use this new handle for them too, if it is necessarily.