### PR TITLE
Implement store/get credential support for BLE on daemon side

### DIFF
--- a/daemon.pro
+++ b/daemon.pro
@@ -98,7 +98,8 @@ HEADERS  += \
     src/MessageProtocol/MessageProtocolMini.h \
     src/MessageProtocol/MessageProtocolBLE.h \
     src/MPDeviceBleImpl.h \
-    src/HaveIBeenPwned.h
+    src/HaveIBeenPwned.h \
+    src/BleCommon.h
 
 DISTFILES += \
     src/http-parser/CONTRIBUTIONS \

--- a/src/BleCommon.h
+++ b/src/BleCommon.h
@@ -19,7 +19,7 @@ public:
         PASSWORD
     };
 
-    BleCredential(QString service, QString login = "", QString pwd = "", QString desc = "", QString third = "")
+    BleCredential(QString service, QString login = "", QString desc = "", QString third = "", QString pwd = "")
     {
         m_attributes = { {CredAttr::SERVICE, service},
                          {CredAttr::LOGIN, login},

--- a/src/BleCommon.h
+++ b/src/BleCommon.h
@@ -1,0 +1,37 @@
+#ifndef BLECOMMON_H
+#define BLECOMMON_H
+
+#include <QString>
+#include <QMap>
+
+class BleCredential
+{
+public:
+    enum class CredAttr
+    {
+        SERVICE,
+        LOGIN,
+        DESCRIPTION,
+        THIRD,
+        PASSWORD
+    };
+
+    BleCredential(QString service, QString login = "", QString pwd = "", QString desc = "", QString third = "")
+    {
+        m_attributes = { {CredAttr::SERVICE, service},
+                         {CredAttr::LOGIN, login},
+                         {CredAttr::DESCRIPTION, desc},
+                         {CredAttr::THIRD, third},
+                         {CredAttr::PASSWORD, pwd}
+                       };
+    }
+
+    QMap<CredAttr, QString> getAttributes() const { return m_attributes; }
+    void set(CredAttr field, QString value) { m_attributes[field] = value; }
+    QString get(CredAttr field) const { return m_attributes[field]; }
+
+private:
+    QMap<CredAttr, QString> m_attributes;
+};
+
+#endif // BLECOMMON_H

--- a/src/BleCommon.h
+++ b/src/BleCommon.h
@@ -4,6 +4,9 @@
 #include <QString>
 #include <QMap>
 
+static constexpr quint16 MSG_FAILED = 0x00;
+static constexpr quint16 MSG_SUCCESS = 0x01;
+
 class BleCredential
 {
 public:
@@ -33,5 +36,7 @@ public:
 private:
     QMap<CredAttr, QString> m_attributes;
 };
+
+using CredMap = QMap<BleCredential::CredAttr, QString>;
 
 #endif // BLECOMMON_H

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -174,60 +174,63 @@ void MPDevice::sendData(MPCmd::Command c, const QByteArray &data, quint32 timeou
     cmd.retries_done = 0;
     cmd.sent_ts = QDateTime::currentMSecsSinceEpoch();
 
-    cmd.timerTimeout = new QTimer(this);
-    connect(cmd.timerTimeout, &QTimer::timeout, [this]()
+    if (!isBLE())
     {
-        auto cmd = pMesProt->getCommand(commandQueue.head().data[0]);
-        commandQueue.head().retry--;
-
-        //Retry is disabled for BLE
-        if (commandQueue.head().retry > 0 && !isBLE())
+        cmd.timerTimeout = new QTimer(this);
+        connect(cmd.timerTimeout, &QTimer::timeout, [this]()
         {
-            qDebug() << "> Retry command: " << pMesProt->printCmd(cmd);
-            commandQueue.head().sent_ts = QDateTime::currentMSecsSinceEpoch();
-            commandQueue.head().timerTimeout->start(); //restart timer
-            commandQueue.head().retries_done++;
-            for (const auto &data : commandQueue.head().data)
-            {
-                platformWrite(data);
-            }
-        }
-        else
-        {
-            //Failed after all retry
-            MPCommand currentCmd = commandQueue.head();
-            delete currentCmd.timerTimeout;
+            auto cmd = pMesProt->getCommand(commandQueue.head().data[0]);
+            commandQueue.head().retry--;
 
-            if (isBLE())
+            //Retry is disabled for BLE
+            if (commandQueue.head().retry > 0)
             {
-                qDebug() << "No response received from the device for: " << pMesProt->printCmd(cmd);
+                qDebug() << "> Retry command: " << pMesProt->printCmd(cmd);
+                commandQueue.head().sent_ts = QDateTime::currentMSecsSinceEpoch();
+                commandQueue.head().timerTimeout->start(); //restart timer
+                commandQueue.head().retries_done++;
+                for (const auto &data : commandQueue.head().data)
+                {
+                    platformWrite(data);
+                }
             }
             else
             {
-                qWarning() << "> Retry command: " << pMesProt->printCmd(cmd) << " has failed too many times. Give up.";
+                //Failed after all retry
+                MPCommand currentCmd = commandQueue.head();
+                delete currentCmd.timerTimeout;
+
+                if (isBLE())
+                {
+                    qDebug() << "No response received from the device for: " << pMesProt->printCmd(cmd);
+                }
+                else
+                {
+                    qWarning() << "> Retry command: " << pMesProt->printCmd(cmd) << " has failed too many times. Give up.";
+                }
+
+                bool done = true;
+                currentCmd.cb(false, QByteArray(3, 0x00), done);
+
+                if (done)
+                {
+                    commandQueue.dequeue();
+                    sendDataDequeue();
+                }
             }
-
-            bool done = true;
-            currentCmd.cb(false, QByteArray(3, 0x00), done);
-
-            if (done)
-            {
-                commandQueue.dequeue();
-                sendDataDequeue();
-            }
-        }
-    });
-    if (timeout == CMD_DEFAULT_TIMEOUT)
-    {
-        timeout = CMD_DEFAULT_TIMEOUT_VAL;
-
-        //If user interaction is required, add additional timeout
-        if (MPCmd::isUserRequired(c))
+        });
+        if (timeout == CMD_DEFAULT_TIMEOUT)
         {
-            timeout += get_userInteractionTimeout() * 1000;
+            timeout = CMD_DEFAULT_TIMEOUT_VAL;
+
+            //If user interaction is required, add additional timeout
+            if (MPCmd::isUserRequired(c))
+            {
+                timeout += static_cast<quint32>(get_userInteractionTimeout()) * 1000;
+            }
         }
+        cmd.timerTimeout->setInterval(static_cast<int>(timeout));
     }
-    cmd.timerTimeout->setInterval(static_cast<int>(timeout));
 
     commandQueue.enqueue(cmd);
 
@@ -293,8 +296,11 @@ void MPDevice::newDataRead(const QByteArray &data)
         dataCommand == MPCmd::MOOLTIPASS_STATUS &&
         (pMesProt->getFirstPayloadByte(data) & MP_UNLOCKING_SCREEN_BITMASK) != 0))
     {
-        /* Stop timeout timer */
-        commandQueue.head().timerTimeout->stop();
+        if (!isBLE())
+        {
+            /* Stop timeout timer */
+            commandQueue.head().timerTimeout->stop();
+        }
 
         /* Bear with me for this complex explanation.
          * In some case, USB commands may take quite a while to get an answer, especially when the user is prompted (or is deliberately trying to delay the answer)
@@ -319,11 +325,18 @@ void MPDevice::newDataRead(const QByteArray &data)
             {
                 timer->stop();
                 timer->deleteLater();
-                for (const auto &data : commandQueue.head().data)
+                if (!isBLE())
                 {
-                    platformWrite(data);
+                    for (const auto &data : commandQueue.head().data)
+                    {
+                        platformWrite(data);
+                    }
+                    commandQueue.head().timerTimeout->start(); //restart timer
                 }
-                commandQueue.head().timerTimeout->start(); //restart timer
+                else
+                {
+                    sendDataDequeue();
+                }
             });
             timer->start(300);
         }
@@ -446,7 +459,23 @@ void MPDevice::sendDataDequeue()
         platformWrite(data);
     }
 
-    currentCmd.timerTimeout->start();
+    if (isBLE())
+    {
+        /**
+          * If checkReturn is false, not required to wait
+          * for the response, so removing the cmd from
+          * commandQueue and finishing currentJob.
+          */
+        if (!currentCmd.checkReturn)
+        {
+            currentJobs->finished(QByteArray{});
+            commandQueue.dequeue();
+        }
+    }
+    else
+    {
+        currentCmd.timerTimeout->start();
+    }
 }
 
 void MPDevice::runAndDequeueJobs()

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -229,6 +229,11 @@ void MPDevice::sendData(MPCmd::Command cmd, MPCommandCb cb)
     sendData(cmd, QByteArray(), CMD_DEFAULT_TIMEOUT, std::move(cb));
 }
 
+void MPDevice::sendData(MPCmd::Command cmd, const QByteArray &data, MPCommandCb cb)
+{
+    sendData(cmd, data, CMD_DEFAULT_TIMEOUT, std::move(cb));
+}
+
 void MPDevice::commandFailed()
 {
     //TODO: fix this to work as it should on all platforms

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -325,17 +325,19 @@ void MPDevice::newDataRead(const QByteArray &data)
             {
                 timer->stop();
                 timer->deleteLater();
-                if (!isBLE())
+                if (isBLE())
+                {
+                    //Need to flip the bit before resend
+                    bleImpl->flipMessageBit(commandQueue.head().data[0]);
+                    sendDataDequeue();
+                }
+                else
                 {
                     for (const auto &data : commandQueue.head().data)
                     {
                         platformWrite(data);
                     }
                     commandQueue.head().timerTimeout->start(); //restart timer
-                }
-                else
-                {
-                    sendDataDequeue();
                 }
             });
             timer->start(300);

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -148,6 +148,7 @@ void MPDevice::setupMessageProtocol()
     });
 
     //For testing storeCredential and getCredential
+    //TODO: Only for testing
 //    QTimer::singleShot(2000, [this](){
 //        if (isBLE())
 //        {

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -22,6 +22,7 @@
 #include "MessageProtocol/MessageProtocolMini.h"
 #include "MessageProtocol/MessageProtocolBLE.h"
 #include "MPDeviceBleImpl.h"
+#include "BleCommon.h"
 
 const QRegularExpression regVersion("v([0-9]+)\\.([0-9]+)(.*)");
 
@@ -145,6 +146,21 @@ void MPDevice::setupMessageProtocol()
             flashMbSizeChanged(0);
         }
     });
+
+    //For testing storeCredential and getCredential
+//    QTimer::singleShot(2000, [this](){
+//        if (isBLE())
+//        {
+//            bleImpl->storeCredential(BleCredential{"test", "user", "desc", "3rd", "pwd"});
+//        }
+//    });
+
+//    QTimer::singleShot(20000, [this](){
+//        if (isBLE())
+//        {
+//            bleImpl->getCredential("test", "user");
+//        }
+//    });
 }
 
 void MPDevice::sendData(MPCmd::Command c, const QByteArray &data, quint32 timeout, MPCommandCb cb, bool checkReturn)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -130,6 +130,7 @@ public:
     void sendData(MPCmd::Command cmd, const QByteArray &data = QByteArray(), quint32 timeout = CMD_DEFAULT_TIMEOUT, MPCommandCb cb = [](bool, const QByteArray &, bool &){}, bool checkReturn = true);
     void sendData(MPCmd::Command cmd, quint32 timeout, MPCommandCb cb);
     void sendData(MPCmd::Command cmd, MPCommandCb cb);
+    void sendData(MPCmd::Command cmd, const QByteArray &data, MPCommandCb cb);
 
     void updateKeyboardLayout(int lang);
     void updateLockTimeoutEnabled(bool en);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -237,10 +237,11 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
                                         return true;
                                     }
                                     qDebug() << "Credential got successfully";
+                                    QByteArray response = bleProt->getFullPayload(data);
     #ifdef DEV_DEBUG
-                                    qDebug() << data.toHex();
+                                    qDebug() << response.toHex();
     #endif
-                                    BleCredential cred = retrieveCredentialFromResponse(bleProt->getFullPayload(data), service, login);
+                                    BleCredential cred = retrieveCredentialFromResponse(response, service, login);
                                     return true;
                                 }));
 
@@ -280,19 +281,17 @@ BleCredential MPDeviceBleImpl::retrieveCredentialFromResponse(QByteArray respons
     for (int attrIndex = 2, i = 0; i < ATTR_NUM; attrIndex+=2, ++i)
     {
         auto index = 0;
-        QString attrVal;
         if (BleCredential::CredAttr::PASSWORD != attr)
         {
             auto indexByte = response.mid(attrIndex, 2);
-            index = (bleProt->toIntFromLittleEndian(static_cast<quint8>(indexByte[0]), static_cast<quint8>(indexByte[1])) * 2) + MSG_ATTR_STARTING_INDEX;
-            attrVal = bleProt->toQString(response.mid(lastIndex, index - lastIndex - 2));
+            index = bleProt->toIntFromLittleEndian(static_cast<quint8>(indexByte[0]), static_cast<quint8>(indexByte[1])) * 2 + MSG_ATTR_STARTING_INDEX;
         }
         else
         {
             //Password is between its index and the end of the message
             index = response.size();
-            attrVal = bleProt->toQString(response.right(index - lastIndex));
         }
+        QString attrVal = bleProt->toQString(response.mid(lastIndex, index - lastIndex - 2));
 
         if (cred.get(attr).isEmpty())
         {

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -186,6 +186,105 @@ void MPDeviceBleImpl::sendResetFlipBit()
     bleProt->resetFlipBit();
 }
 
+QByteArray MPDeviceBleImpl::getStoreMessage(QString service, QString login, QString desc, QString third, QString password)
+{
+    QByteArray storeMessage;
+    //Add Service index
+    quint16 index = static_cast<quint16>(0);
+    storeMessage.append(bleProt->toLittleEndianFromInt(index));
+    //Add Login index
+    index += (service.size() + 1);
+    if (login.isEmpty())
+    {
+        storeMessage.append(static_cast<char>(0xFF));
+        storeMessage.append(static_cast<char>(0xFF));
+    }
+    else
+    {
+        storeMessage.append(bleProt->toLittleEndianFromInt(index));
+        index += (login.size() + 1);
+    }
+
+    //Add desc index
+    if (desc.isEmpty())
+    {
+        storeMessage.append(static_cast<char>(0xFF));
+        storeMessage.append(static_cast<char>(0xFF));
+    }
+    else
+    {
+        storeMessage.append(bleProt->toLittleEndianFromInt(index));
+        index += (desc.size() + 1);
+    }
+
+    //Add third index
+    if (third.isEmpty())
+    {
+        storeMessage.append(static_cast<char>(0xFF));
+        storeMessage.append(static_cast<char>(0xFF));
+    }
+    else
+    {
+        storeMessage.append(bleProt->toLittleEndianFromInt(index));
+        index += (third.size() + 1);
+    }
+
+    //Add password index
+    if (password.isEmpty())
+    {
+        storeMessage.append(static_cast<char>(0xFF));
+        storeMessage.append(static_cast<char>(0xFF));
+    }
+    else
+    {
+        storeMessage.append(bleProt->toLittleEndianFromInt(index));
+        index += (password.size() + 1);
+    }
+
+    //Add service
+    QByteArray serviceData = bleProt->toByteArray(service);
+    serviceData.append(static_cast<char>(0));
+    serviceData.append(static_cast<char>(0));
+    storeMessage.append(serviceData);
+
+    //Add login
+    if (!login.isEmpty())
+    {
+        QByteArray loginData = bleProt->toByteArray(login);
+        loginData.append(static_cast<char>(0));
+        loginData.append(static_cast<char>(0));
+        storeMessage.append(loginData);
+    }
+
+    //Add desc
+    if (!desc.isEmpty())
+    {
+        QByteArray descData = bleProt->toByteArray(desc);
+        descData.append(static_cast<char>(0));
+        descData.append(static_cast<char>(0));
+        storeMessage.append(descData);
+    }
+
+    //Add third
+    if (!third.isEmpty())
+    {
+        QByteArray thirdData = bleProt->toByteArray(third);
+        thirdData.append(static_cast<char>(0));
+        thirdData.append(static_cast<char>(0));
+        storeMessage.append(thirdData);
+    }
+
+    //Add desc
+    if (!password.isEmpty())
+    {
+        QByteArray passwordData = bleProt->toByteArray(password);
+        passwordData.append(static_cast<char>(0));
+        passwordData.append(static_cast<char>(0));
+        storeMessage.append(passwordData);
+    }
+    return storeMessage;
+}
+
 void MPDeviceBleImpl::checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress)
 {
     if (0x01 == bleProt->getFirstPayloadByte(data))

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -186,102 +186,29 @@ void MPDeviceBleImpl::sendResetFlipBit()
     bleProt->resetFlipBit();
 }
 
-QByteArray MPDeviceBleImpl::getStoreMessage(QString service, QString login, QString desc, QString third, QString password)
+QByteArray MPDeviceBleImpl::getStoreMessage(Credential cred)
 {
     QByteArray storeMessage;
     //Add Service index
     quint16 index = static_cast<quint16>(0);
-    storeMessage.append(bleProt->toLittleEndianFromInt(index));
-    //Add Login index
-    index += (service.size() + 1);
-    if (login.isEmpty())
+    QByteArray credDatas;
+    for (QString attr: cred.getAttributes())
     {
-        storeMessage.append(static_cast<char>(0xFF));
-        storeMessage.append(static_cast<char>(0xFF));
-    }
-    else
-    {
-        storeMessage.append(bleProt->toLittleEndianFromInt(index));
-        index += (login.size() + 1);
-    }
-
-    //Add desc index
-    if (desc.isEmpty())
-    {
-        storeMessage.append(static_cast<char>(0xFF));
-        storeMessage.append(static_cast<char>(0xFF));
-    }
-    else
-    {
-        storeMessage.append(bleProt->toLittleEndianFromInt(index));
-        index += (desc.size() + 1);
+        if (attr.isEmpty())
+        {
+            storeMessage.append(bleProt->toLittleEndianFromInt(static_cast<quint16>(0xFFFF)));
+        }
+        else
+        {
+            storeMessage.append(bleProt->toLittleEndianFromInt(index));
+            index += (attr.size() + 1);
+            QByteArray data = bleProt->toByteArray(attr);
+            data.append(bleProt->toLittleEndianFromInt(static_cast<quint16>(0x0)));
+            credDatas.append(data);
+        }
     }
 
-    //Add third index
-    if (third.isEmpty())
-    {
-        storeMessage.append(static_cast<char>(0xFF));
-        storeMessage.append(static_cast<char>(0xFF));
-    }
-    else
-    {
-        storeMessage.append(bleProt->toLittleEndianFromInt(index));
-        index += (third.size() + 1);
-    }
-
-    //Add password index
-    if (password.isEmpty())
-    {
-        storeMessage.append(static_cast<char>(0xFF));
-        storeMessage.append(static_cast<char>(0xFF));
-    }
-    else
-    {
-        storeMessage.append(bleProt->toLittleEndianFromInt(index));
-        index += (password.size() + 1);
-    }
-
-    //Add service
-    QByteArray serviceData = bleProt->toByteArray(service);
-    serviceData.append(static_cast<char>(0));
-    serviceData.append(static_cast<char>(0));
-    storeMessage.append(serviceData);
-
-    //Add login
-    if (!login.isEmpty())
-    {
-        QByteArray loginData = bleProt->toByteArray(login);
-        loginData.append(static_cast<char>(0));
-        loginData.append(static_cast<char>(0));
-        storeMessage.append(loginData);
-    }
-
-    //Add desc
-    if (!desc.isEmpty())
-    {
-        QByteArray descData = bleProt->toByteArray(desc);
-        descData.append(static_cast<char>(0));
-        descData.append(static_cast<char>(0));
-        storeMessage.append(descData);
-    }
-
-    //Add third
-    if (!third.isEmpty())
-    {
-        QByteArray thirdData = bleProt->toByteArray(third);
-        thirdData.append(static_cast<char>(0));
-        thirdData.append(static_cast<char>(0));
-        storeMessage.append(thirdData);
-    }
-
-    //Add desc
-    if (!password.isEmpty())
-    {
-        QByteArray passwordData = bleProt->toByteArray(password);
-        passwordData.append(static_cast<char>(0));
-        passwordData.append(static_cast<char>(0));
-        storeMessage.append(passwordData);
-    }
+    storeMessage.append(credDatas);
     return storeMessage;
 }
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -212,18 +212,10 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
     auto *jobs = new AsyncJobs(QString("Get Credential"), this);
 
     jobs->append(new MPCommandJob(mpDev, MPCmd::GET_CREDENTIAL, createGetCredMessage(service, login),
-                            [this](const QByteArray &data, bool &)
+                            [](const QByteArray &data, bool &)
                             {
-                                if (MSG_SUCCESS == bleProt->getFirstPayloadByte(data))
-                                {
-                                    qDebug() << "Credential got successfully";
-                                    qDebug() << data.toHex();
-                                }
-                                else
-                                {
-                                    qWarning() << "Credential get failed";
-                                    qDebug() << data.toHex();
-                                }
+                                qDebug() << "Credential got successfully";
+                                qDebug() << data.toHex();
                                 return true;
                             }));
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -238,9 +238,7 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
                                     }
                                     qDebug() << "Credential got successfully";
                                     QByteArray response = bleProt->getFullPayload(data);
-    #ifdef DEV_DEBUG
                                     qDebug() << response.toHex();
-    #endif
                                     BleCredential cred = retrieveCredentialFromResponse(response, service, login);
                                     return true;
                                 }));
@@ -314,8 +312,8 @@ QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)
 
 QByteArray MPDeviceBleImpl::createGetCredMessage(QString service, QString login)
 {
-    CredMap getMsgMap {{BleCredential::CredAttr::SERVICE, service},
-                       {BleCredential::CredAttr::LOGIN, login}};
+    CredMap getMsgMap{{BleCredential::CredAttr::SERVICE, service},
+                      {BleCredential::CredAttr::LOGIN, login}};
     return createCredentialMessage(getMsgMap);
 }
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -198,6 +198,11 @@ void MPDeviceBleImpl::sendResetFlipBit()
     bleProt->resetFlipBit();
 }
 
+void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
+{
+    bleProt->flipMessageBit(msg);
+}
+
 void MPDeviceBleImpl::storeCredential(const BleCredential &cred)
 {
     auto *jobs = new AsyncJobs(QString("Store Credential"), this);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -228,8 +228,31 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
 {
     auto *jobs = new AsyncJobs(QString("Get Credential"), this);
 
+        jobs->append(new MPCommandJob(mpDev, MPCmd::GET_CREDENTIAL, createGetCredMessage(service, login),
+                                [this, service, login](const QByteArray &data, bool &)
+                                {
+                                    if (MSG_FAILED == bleProt->getMessageSize(data))
+                                    {
+                                        qWarning() << "Credential get failed";
+                                        return true;
+                                    }
+                                    qDebug() << "Credential got successfully";
+    #ifdef DEV_DEBUG
+                                    qDebug() << data.toHex();
+    #endif
+                                    BleCredential cred = retrieveCredentialFromResponse(bleProt->getFullPayload(data), service, login);
+                                    return true;
+                                }));
+
+    dequeueAndRun(jobs);
+}
+
+void MPDeviceBleImpl::getCredential(QString service, QString login, const MessageHandlerCbData &cb)
+{
+    auto *jobs = new AsyncJobs(QString("Get Credential"), this);
+
     jobs->append(new MPCommandJob(mpDev, MPCmd::GET_CREDENTIAL, createGetCredMessage(service, login),
-                            [this, service, login](const QByteArray &data, bool &)
+                            [this, service, login, cb](const QByteArray &data, bool &)
                             {
                                 if (MSG_FAILED == bleProt->getMessageSize(data))
                                 {
@@ -240,7 +263,7 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
 #ifdef DEV_DEBUG
                                 qDebug() << data.toHex();
 #endif
-                                BleCredential cred = retrieveCredentialFromResponse(data, service, login);
+                                cb(true, "", bleProt->getFullPayload(data));
                                 return true;
                             }));
 
@@ -250,26 +273,25 @@ void MPDeviceBleImpl::getCredential(QString service, QString login)
 BleCredential MPDeviceBleImpl::retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const
 {
     BleCredential cred{service, login};
-    const int MSG_ATTR_STARTING_INDEX = 14;
-    const int MSG_HEADER_SIZE = 6;
-    const int MSG_LAST_ATTR_INDEX = 10;
+    const int MSG_ATTR_STARTING_INDEX = 8;
+    const int ATTR_NUM = 4;
     int lastIndex = MSG_ATTR_STARTING_INDEX;
     BleCredential::CredAttr attr = BleCredential::CredAttr::LOGIN;
-    for (int i = 2; i < MSG_LAST_ATTR_INDEX; i+=2)
+    for (int attrIndex = 2, i = 0; i < ATTR_NUM; attrIndex+=2, ++i)
     {
         auto index = 0;
         QString attrVal;
         if (BleCredential::CredAttr::PASSWORD != attr)
         {
-            auto indexByte = bleProt->getPayloadBytes(response, i, i+1);
+            auto indexByte = response.mid(attrIndex, 2);
             index = (bleProt->toIntFromLittleEndian(static_cast<quint8>(indexByte[0]), static_cast<quint8>(indexByte[1])) * 2) + MSG_ATTR_STARTING_INDEX;
             attrVal = bleProt->toQString(response.mid(lastIndex, index - lastIndex - 2));
         }
         else
         {
             //Password is between its index and the end of the message
-            index = bleProt->getMessageSize(response);
-            attrVal = bleProt->toQString(response.right(index - lastIndex + MSG_HEADER_SIZE));
+            index = response.size();
+            attrVal = bleProt->toQString(response.right(index - lastIndex));
         }
 
         if (cred.get(attr).isEmpty())

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -34,6 +34,8 @@ public:
 
     void sendResetFlipBit();
 
+    QByteArray getStoreMessage(QString service, QString login, QString desc, QString third, QString password);
+
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -41,6 +41,7 @@ public:
      * @brief getCredential
      * Only for testing without the callback
      */
+    //TODO: Only for testing
     void getCredential(QString service, QString login = "");
     void getCredential(QString service, QString login, const MessageHandlerCbData &cb);
     BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -37,7 +37,8 @@ public:
     void flipMessageBit(QByteArray &msg);
 
     void storeCredential(const BleCredential &cred);
-    void getCredential(QString service, QString login);
+    void getCredential(QString service, QString login = "");
+    BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -36,12 +36,16 @@ public:
     void sendResetFlipBit();
 
     void storeCredential(const BleCredential &cred);
-    QByteArray getStoreMessage(const BleCredential &cred);
+    void getCredential(QString service, QString login);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
     void writeAccData(QFile *file);
+
+    QByteArray createStoreCredMessage(const BleCredential &cred);
+    QByteArray createGetCredMessage(QString service, QString login);
+    QByteArray createCredentialMessage(const CredMap &credMap);
 
     void dequeueAndRun(AsyncJobs *job);
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -34,6 +34,7 @@ public:
     inline void stopFetchAccData() { accState = Common::AccState::STOPPED; }
 
     void sendResetFlipBit();
+    void flipMessageBit(QByteArray &msg);
 
     void storeCredential(const BleCredential &cred);
     void getCredential(QString service, QString login);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -2,8 +2,39 @@
 #define MPDEVICEBLEIMPL_H
 
 #include "MPDevice.h"
+#include <QMap>
 
 class MessageProtocolBLE;
+
+class Credential
+{
+public:
+    enum class CredValue
+    {
+        SERVICE,
+        LOGIN,
+        PASSWORD,
+        DESCRIPTION,
+        THIRD
+    };
+
+    Credential(QString service, QString login = "", QString pwd = "", QString desc = "", QString third = "")
+    {
+        m_attributes = { {CredValue::SERVICE, service},
+                         {CredValue::LOGIN, login},
+                         {CredValue::PASSWORD, pwd},
+                         {CredValue::DESCRIPTION, desc},
+                         {CredValue::THIRD, third}
+                       };
+    }
+
+    QMap<CredValue, QString> getAttributes() const { return m_attributes; }
+    void set(CredValue field, QString value) { m_attributes[field] = value; }
+    QString get(CredValue field) const { return m_attributes[field]; }
+
+private:
+    QMap<CredValue, QString> m_attributes;
+};
 
 /**
  * @brief The MPDeviceBleImpl class
@@ -34,7 +65,7 @@ public:
 
     void sendResetFlipBit();
 
-    QByteArray getStoreMessage(QString service, QString login, QString desc, QString third, QString password);
+    QByteArray getStoreMessage(Credential cred);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -2,39 +2,9 @@
 #define MPDEVICEBLEIMPL_H
 
 #include "MPDevice.h"
-#include <QMap>
+#include "BleCommon.h"
 
 class MessageProtocolBLE;
-
-class Credential
-{
-public:
-    enum class CredValue
-    {
-        SERVICE,
-        LOGIN,
-        PASSWORD,
-        DESCRIPTION,
-        THIRD
-    };
-
-    Credential(QString service, QString login = "", QString pwd = "", QString desc = "", QString third = "")
-    {
-        m_attributes = { {CredValue::SERVICE, service},
-                         {CredValue::LOGIN, login},
-                         {CredValue::PASSWORD, pwd},
-                         {CredValue::DESCRIPTION, desc},
-                         {CredValue::THIRD, third}
-                       };
-    }
-
-    QMap<CredValue, QString> getAttributes() const { return m_attributes; }
-    void set(CredValue field, QString value) { m_attributes[field] = value; }
-    QString get(CredValue field) const { return m_attributes[field]; }
-
-private:
-    QMap<CredValue, QString> m_attributes;
-};
 
 /**
  * @brief The MPDeviceBleImpl class
@@ -65,7 +35,8 @@ public:
 
     void sendResetFlipBit();
 
-    QByteArray getStoreMessage(Credential cred);
+    void storeCredential(const BleCredential &cred);
+    QByteArray getStoreMessage(const BleCredential &cred);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -37,7 +37,12 @@ public:
     void flipMessageBit(QByteArray &msg);
 
     void storeCredential(const BleCredential &cred);
+    /**
+     * @brief getCredential
+     * Only for testing without the callback
+     */
     void getCredential(QString service, QString login = "");
+    void getCredential(QString service, QString login, const MessageHandlerCbData &cb);
     BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;
 
 private:

--- a/src/MessageProtocol/IMessageProtocol.h
+++ b/src/MessageProtocol/IMessageProtocol.h
@@ -136,7 +136,7 @@ public:
     {
         QByteArray littleEndian;
         littleEndian.append(static_cast<char>(num&0xFF));
-        littleEndian.append(static_cast<char>((num&0xFF00)>>16));
+        littleEndian.append(static_cast<char>((num&0xFF00)>>8));
         return littleEndian;
     }
 

--- a/src/MessageProtocol/IMessageProtocol.h
+++ b/src/MessageProtocol/IMessageProtocol.h
@@ -132,6 +132,14 @@ public:
         return (lowerByte|(upperByte<<8));
     }
 
+    QByteArray toLittleEndianFromInt(quint16 num)
+    {
+        QByteArray littleEndian;
+        littleEndian.append(static_cast<char>(num&0xFF));
+        littleEndian.append(static_cast<char>((num&0xFF00)>>16));
+        return littleEndian;
+    }
+
     QMap<quint16,quint16> m_commandMapping;
 };
 

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -51,7 +51,7 @@ Common::MPStatus MessageProtocolBLE::getStatus(const QByteArray &data)
 
 quint16 MessageProtocolBLE::getMessageSize(const QByteArray &data)
 {
-    return (static_cast<quint8>(data[PAYLOAD_LEN_LOWER_BYTE])|static_cast<quint8>((data[PAYLOAD_LEN_UPPER_BYTE]<<8)));
+    return (static_cast<quint8>(data[PAYLOAD_LEN_LOWER_BYTE])|static_cast<quint16>((data[PAYLOAD_LEN_UPPER_BYTE]<<8)));
 }
 
 MPCmd::Command MessageProtocolBLE::getCommand(const QByteArray &data)

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -119,8 +119,8 @@ QByteArray MessageProtocolBLE::toByteArray(const QString &input)
     for (QChar ch : input)
     {
         quint16 uniChar = ch.unicode();
-        unicodeArray.append(static_cast<char>((0xFF00&uniChar)>>8));
         unicodeArray.append(static_cast<char>((0xFF&uniChar)));
+        unicodeArray.append(static_cast<char>((0xFF00&uniChar)>>8));
     }
     return unicodeArray;
 }
@@ -242,6 +242,8 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_SERIAL            , 0xDA},
         {MPCmd::CMD_DBG_MESSAGE       , 0x8000},
         {MPCmd::GET_PLAT_INFO         , 0x0003},
+        {MPCmd::STORE_CREDENTIAL      , 0x0006},
+        {MPCmd::GET_CREDENTIAL        , 0x0007},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -78,7 +78,7 @@ QByteArray MessageProtocolBLE::getFullPayload(const QByteArray &data)
 QByteArray MessageProtocolBLE::getPayloadBytes(const QByteArray &data, int fromPayload, int to)
 {
     int start = getStartingPayloadPosition(data);
-    return data.mid(fromPayload + start, to + start);
+    return data.mid(fromPayload + start, (to - fromPayload) + 1);
 }
 
 quint32 MessageProtocolBLE::getSerialNumber(const QByteArray &data)
@@ -136,8 +136,8 @@ QString MessageProtocolBLE::toQString(const QByteArray &data)
             qCritical() << "Out of bounds";
             break;
         }
-        quint16 unicode = static_cast<quint8>(data[i+1]);
-        unicode |= (data[i]<<8);
+        quint16 unicode = static_cast<quint8>(data[i]);
+        unicode |= (data[i+1]<<8);
         out += QChar(unicode);
     }
     return out;

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -148,6 +148,12 @@ void MessageProtocolBLE::setAckFlag(bool on)
     m_ackFlag = on ? ACK_FLAG_BIT : 0x00;
 }
 
+void MessageProtocolBLE::flipMessageBit(QByteArray &msg)
+{
+    flipBit();
+    msg[0] = msg[0]^MESSAGE_FLIP_BIT;
+}
+
 void MessageProtocolBLE::resetFlipBit()
 {
     m_flipBit = 0x00;

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -72,7 +72,12 @@ quint8 MessageProtocolBLE::getPayloadByteAt(const QByteArray &data, int at)
 
 QByteArray MessageProtocolBLE::getFullPayload(const QByteArray &data)
 {
-    return data.mid(getStartingPayloadPosition(data));
+    int startingPos = getStartingPayloadPosition(data);
+    if (FIRST_PAYLOAD_BYTE_PACKET == startingPos)
+    {
+        return data.mid(startingPos);
+    }
+    return data.mid(startingPos, getMessageSize(data));
 }
 
 QByteArray MessageProtocolBLE::getPayloadBytes(const QByteArray &data, int fromPayload, int to)

--- a/src/MessageProtocol/MessageProtocolBLE.h
+++ b/src/MessageProtocol/MessageProtocolBLE.h
@@ -30,6 +30,7 @@ public:
 
     void resetFlipBit();
     inline void setAckFlag(bool on);
+    void flipMessageBit(QByteArray &msg);
 
 private:
     inline void flipBit();

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -127,6 +127,8 @@ public:
             LOCK_DEVICE         ,
             GET_SERIAL          ,
             GET_PLAT_INFO       ,
+            STORE_CREDENTIAL    ,
+            GET_CREDENTIAL      ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,


### PR DESCRIPTION
### Changeset:

- Implement store/get credential support for BLE on daemon side
    - Currently not available from gui, but I left commented example usage in MPDevice.cpp:151
    - Store a credential with service name, login, description, third field and password (**0x0006: Store Credential**)
    - Get credential with service name and login (**0x0007: Get Credential**)
    - Created a get_message interface to get and return the credential for a request from GUI
- Eliminated message timeout for BLE:
    - Daemon is waiting until it does not receive the response for the message
    - Handled the **checkReturn** option for messages, which does not require response from device. (E.g.: 0x8007: Reboot main MCU to Bootloader or 0x8009: Flash Aux MCU with Bundle Contents)
    - **Known issue**: After Aux MCU Flash the usb is reconnecting and daemon does not receive an answer for the first message. Need to check it on fw side.
- Fixed handle for PLEASE_RETRY message:
    - Before sending the message again with a delay, needed to flip the message flip bit.
- Fixed some BLE message protocol functions
    - Found issues during usage in getMessageSize, getFullPayload, getPayloadBytes and Unicode conversions