### PR TITLE
Implementing storing/getting credential for BLE from browser and GUI

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -205,11 +205,13 @@ QByteArray Common::dateToBytes(const QDate &dt)
     QByteArray data;
     data.resize(2);
 
-    data[0] = (quint8)(((dt.year() - 2010) << 1) & 0xFE);
+    data[0] = static_cast<char>(((dt.year() - 2010) << 1) & 0xFE);
     if(dt.month() - 1  >= 8)
-        data[0] = (quint8)((quint8)data[0] | 0x01);
-    data[1] = (quint8)((((dt.month() -1) % 8) << 5) & 0xE0);
-    data[1] = (quint8)((quint8)data[1] | dt.day());
+    {
+        data[0] = static_cast<char>((static_cast<quint8>(data[0]) | 0x01));
+    }
+    data[1] = static_cast<char>((((dt.month() -1) % 8) << 5) & 0xE0);
+    data[1] = static_cast<char>(static_cast<quint8>(data[1])|dt.day());
 
     return data;
 }

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -59,15 +59,15 @@ MPDevice::MPDevice(QObject *parent):
 
                 if (prevStatus == Common::UnknownStatus)
                 {
-                    if (!isBLE())
+                    QTimer::singleShot(10, [this]()
                     {
-                        QTimer::singleShot(10, [this]()
+                        /* First start: load parameters */
+                        if (!isBLE())
                         {
-                            /* First start: load parameters */
                             loadParameters();
-                            setCurrentDate();
-                        });
-                    }
+                        }
+                        setCurrentDate();
+                    });
                 }
 
                 if ((s == Common::Unlocked) || (s == Common::UnkownSmartcad))

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -59,19 +59,25 @@ MPDevice::MPDevice(QObject *parent):
 
                 if (prevStatus == Common::UnknownStatus)
                 {
-                    /* First start: load parameters */
-                    QTimer::singleShot(10, [this]()
+                    if (!isBLE())
                     {
-                        loadParameters();
-                        setCurrentDate();
-                    });
+                        QTimer::singleShot(10, [this]()
+                        {
+                            /* First start: load parameters */
+                            loadParameters();
+                            setCurrentDate();
+                        });
+                    }
                 }
 
                 if ((s == Common::Unlocked) || (s == Common::UnkownSmartcad))
                 {
                     QTimer::singleShot(20, [this]()
                     {
-                        getCurrentCardCPZ();
+                        if (!isBLE())
+                        {
+                            getCurrentCardCPZ();
+                        }
                     });
                 }
                 else

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -224,6 +224,29 @@ void MPDeviceBleImpl::storeCredential(const BleCredential &cred)
     dequeueAndRun(jobs);
 }
 
+void MPDeviceBleImpl::storeCredential(const BleCredential &cred, MessageHandlerCb cb)
+{
+    auto *jobs = new AsyncJobs(QString("Store Credential"), this);
+
+    jobs->append(new MPCommandJob(mpDev, MPCmd::STORE_CREDENTIAL, createStoreCredMessage(cred),
+                            [this, cb](const QByteArray &data, bool &)
+                            {
+                                if (MSG_SUCCESS == bleProt->getFirstPayloadByte(data))
+                                {
+                                    qDebug() << "Credential stored successfully";
+                                    cb(true, "");
+                                }
+                                else
+                                {
+                                    qWarning() << "Credential store failed";
+                                    cb(false, "Credential store failed");
+                                }
+                                return true;
+                            }));
+
+    dequeueAndRun(jobs);
+}
+
 void MPDeviceBleImpl::getCredential(QString service, QString login)
 {
     auto *jobs = new AsyncJobs(QString("Get Credential"), this);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -36,7 +36,13 @@ public:
     void sendResetFlipBit();
     void flipMessageBit(QByteArray &msg);
 
+    /**
+     * @brief storeCredential
+     * Only for testing without the callback
+     */
+    //TODO: Only for testing
     void storeCredential(const BleCredential &cred);
+    void storeCredential(const BleCredential &cred, MessageHandlerCb cb);
     /**
      * @brief getCredential
      * Only for testing without the callback

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -46,7 +46,7 @@ QVector<QByteArray> MessageProtocolBLE::createPackets(const QByteArray &data, MP
 Common::MPStatus MessageProtocolBLE::getStatus(const QByteArray &data)
 {
     Q_UNUSED(data);
-    return Common::UnknownStatus;
+    return Common::Unlocked;
 }
 
 quint16 MessageProtocolBLE::getMessageSize(const QByteArray &data)

--- a/src/ParseDomain.h
+++ b/src/ParseDomain.h
@@ -53,7 +53,7 @@ public:
     QString getFullDomain() const { return _domain + _tld + (port() != -1 ? ":" + QString::number(port()) : ""); }
 
     // Subdomain with domain and top-level domain ("subdomain.domain.tld")
-    QString getFullSubdomain() const { return _subdomain + "." + getFullDomain(); }
+    QString getFullSubdomain() const { return _subdomain + (_subdomain.isEmpty() ? "":".") + getFullDomain(); }
 
     int port() const { return _url.port(); }
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1319,7 +1319,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
         }
         else
         {
-            o["service"] = url.getFullDomain();
+            o["service"] = url.getFullSubdomain();
         }
 
         const QJsonDocument credDetectedDoc(QJsonObject{{ "msg", "credential_detected" }});

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -96,6 +96,8 @@ private:
     void processParametersSet(const QJsonObject &data);
     void sendFailedJson(QJsonObject obj, QString errstr = QString(), int errCode = -999);
     QString getRequestId(const QJsonValue &v);
+    void processMessageMini(QJsonObject root, const MPDeviceProgressCb &cbProgress);
+    void processMessageBLE(QJsonObject root, const MPDeviceProgressCb &cbProgress);
 };
 
 #endif // WSSERVERCON_H


### PR DESCRIPTION
### Changeset:
- Setting the **mooltipass_status** to **Unlocked** for BLE to be able to connect to the browser extension.
    - Temporary solution, until mooltipass_status message is not implemented for BLE.
- It is possible to store and get credential from browser
    - Currently only possible to use with one login per service. (Handling multiple login haven't been implemented on fw yet)
- From GUI you can save credentials on Credentials tab
     - MMM has not been implemented yet

- _WSServerCon.cpp diff looks messed up, but I only moved device dependent parts of **processMessage** to **processMessageBLE** and **processMessageMini**_