### PR TITLE
Eliminate warnings from code

### DIFF
--- a/src/AnsiEscapeCodeHandler.cpp
+++ b/src/AnsiEscapeCodeHandler.cpp
@@ -63,6 +63,11 @@ static QColor ansiColor(uint code)
     return QColor(red, green, blue);
 }
 
+static QColor ansiColor(int code)
+{
+    return ansiColor(static_cast<uint>(code));
+}
+
 QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input)
 {
     enum AnsiEscapeCodes {
@@ -164,10 +169,10 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                 const int code = numbers.at(i).toInt();
 
                 if (code >= TextColorStart && code <= TextColorEnd) {
-                    charFormat.setForeground(ansiColor(static_cast<uint>(code - TextColorStart)));
+                    charFormat.setForeground(ansiColor(code - TextColorStart));
                     setFormatScope(charFormat);
                 } else if (code >= BackgroundColorStart && code <= BackgroundColorEnd) {
-                    charFormat.setBackground(ansiColor(static_cast<uint>(code - BackgroundColorStart)));
+                    charFormat.setBackground(ansiColor(code - BackgroundColorStart));
                     setFormatScope(charFormat);
                 } else {
                     switch (code) {
@@ -209,7 +214,7 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                             break;
                         case 5:
                             // 256 color mode with format: 38;5;<i>
-                            uint index = numbers.at(i + 1).toUInt();
+                            int index = numbers.at(i + 1).toInt();
 
                             QColor color;
                             if (index < 8) {
@@ -220,11 +225,11 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                                 color = ansiColor(index - 8).lighter(150);
                             } else if (index < 232) {
                                 // The next 216 colors are a 6x6x6 RGB cube.
-                                uint o = index - 16;
+                                int o = index - 16;
                                 color = QColor((o / 36) * 51, ((o / 6) % 6) * 51, (o % 6) * 51);
                             } else {
                                 // The last 24 colors are a greyscale gradient.
-                                int grey = (static_cast<int>(index) - 232) * 11;
+                                int grey = (index - 232) * 11;
                                 color = QColor(grey, grey, grey);
                             }
 

--- a/src/AnsiEscapeCodeHandler.cpp
+++ b/src/AnsiEscapeCodeHandler.cpp
@@ -164,10 +164,10 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                 const int code = numbers.at(i).toInt();
 
                 if (code >= TextColorStart && code <= TextColorEnd) {
-                    charFormat.setForeground(ansiColor(code - TextColorStart));
+                    charFormat.setForeground(ansiColor(static_cast<uint>(code - TextColorStart)));
                     setFormatScope(charFormat);
                 } else if (code >= BackgroundColorStart && code <= BackgroundColorEnd) {
-                    charFormat.setBackground(ansiColor(code - BackgroundColorStart));
+                    charFormat.setBackground(ansiColor(static_cast<uint>(code - BackgroundColorStart)));
                     setFormatScope(charFormat);
                 } else {
                     switch (code) {
@@ -209,7 +209,7 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                             break;
                         case 5:
                             // 256 color mode with format: 38;5;<i>
-                            uint index = numbers.at(i + 1).toInt();
+                            uint index = numbers.at(i + 1).toUInt();
 
                             QColor color;
                             if (index < 8) {
@@ -224,7 +224,7 @@ QList<FormattedText> AnsiEscapeCodeHandler::parseText(const FormattedText &input
                                 color = QColor((o / 36) * 51, ((o / 6) % 6) * 51, (o % 6) * 51);
                             } else {
                                 // The last 24 colors are a greyscale gradient.
-                                uint grey = (index - 232) * 11;
+                                int grey = (static_cast<int>(index) - 232) * 11;
                                 color = QColor(grey, grey, grey);
                             }
 

--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -121,7 +121,7 @@ bool AppDaemon::initialize()
     if (parser.isSet(debugHttpServer))
     {
         httpServer = new HttpServer(this);
-        if (!httpServer->start(parser.value(debugHttpServer).toInt()))
+        if (!httpServer->start(static_cast<quint16>(parser.value(debugHttpServer).toInt())))
         {
             qCritical() << "Fatal error: Failed to create HTTP server.";
             return false;

--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -121,7 +121,7 @@ bool AppDaemon::initialize()
     if (parser.isSet(debugHttpServer))
     {
         httpServer = new HttpServer(this);
-        if (!httpServer->start(static_cast<quint16>(parser.value(debugHttpServer).toInt())))
+        if (!httpServer->start(parser.value(debugHttpServer).toUShort()))
         {
             qCritical() << "Fatal error: Failed to create HTTP server.";
             return false;

--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -53,7 +53,7 @@ AppGui::AppGui(int & argc, char ** argv) :
 
 bool AppGui::initialize()
 {
-    qsrand(static_cast<uint>(time(nullptr)));
+    qsrand(time(nullptr));
 
     QCoreApplication::setOrganizationName("mooltipass");
     QCoreApplication::setOrganizationDomain("themooltipass.com");

--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -53,7 +53,7 @@ AppGui::AppGui(int & argc, char ** argv) :
 
 bool AppGui::initialize()
 {
-    qsrand(time(NULL));
+    qsrand(static_cast<uint>(time(nullptr)));
 
     QCoreApplication::setOrganizationName("mooltipass");
     QCoreApplication::setOrganizationDomain("themooltipass.com");

--- a/src/AsyncJobs.cpp
+++ b/src/AsyncJobs.cpp
@@ -27,7 +27,7 @@ void MPCommandJob::start(const QByteArray &previous_data)
         return;
     }
 
-    device->sendData((MPCmd::Command)cmd, data, timeout, [=](bool success, const QByteArray &resdata, bool &done_recv)
+    device->sendData(static_cast<MPCmd::Command>(cmd), data, timeout, [=](bool success, const QByteArray &resdata, bool &done_recv)
     {
         if (!success)
             emit error();

--- a/src/AsyncJobs.h
+++ b/src/AsyncJobs.h
@@ -157,7 +157,7 @@ public:
     {}
 
     void setReturnCheck(bool enable) { checkReturn = enable; }
-    void setTimeout(int t) { timeout = t; }
+    void setTimeout(uint t) { timeout = t; }
 
 public slots:
     virtual void start(const QByteArray &previous_data);
@@ -179,7 +179,7 @@ private:
 
     //Timeout that will be used for this command
     //and passed to MPDevice::sendData()
-    int timeout = CMD_DEFAULT_TIMEOUT;
+    uint timeout = CMD_DEFAULT_TIMEOUT;
 };
 
 class AsyncJobs: public QObject

--- a/src/AutoStartup.cpp
+++ b/src/AutoStartup.cpp
@@ -60,7 +60,7 @@ void AutoStartup::enableAutoStartup(bool en)
 
     QString autostartLocation;
     char *xgdConfigHome = getenv("XDG_CONFIG_HOME");
-    if(xgdConfigHome != NULL)
+    if(xgdConfigHome != nullptr)
         autostartLocation = QString(QString(xgdConfigHome) + "/.config/autostart");
     else
         autostartLocation = QString(QDir::homePath() + "/.config/autostart");

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -113,32 +113,31 @@ static void _messageOutput(QtMsgType type, const QMessageLogContext &context, co
 
     QString s;
     switch (type) {
-    default:
-    case QtDebugMsg:
-    {
-        s = QString(COLOR_CYAN "DEBUG" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-        break;
-    }
-    case QtInfoMsg:
-    {
-        s = QString(COLOR_GREEN "INFO" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-        break;
-    }
-    case QtWarningMsg:
-    {
-        s = QString(COLOR_YELLOW "WARNING" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-        break;
-    }
-    case QtCriticalMsg:
-    {
-        s = QString(COLOR_ORANGE "CRITICAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-        break;
-    }
-    case QtFatalMsg:
-    {
-        s = QString(COLOR_RED "FATAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-        break;
-    }
+        case QtDebugMsg:
+        {
+            s = QString(COLOR_CYAN "DEBUG" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+            break;
+        }
+        case QtInfoMsg:
+        {
+            s = QString(COLOR_GREEN "INFO" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+            break;
+        }
+        case QtWarningMsg:
+        {
+            s = QString(COLOR_YELLOW "WARNING" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+            break;
+        }
+        case QtCriticalMsg:
+        {
+            s = QString(COLOR_ORANGE "CRITICAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+            break;
+        }
+        case QtFatalMsg:
+        {
+            s = QString(COLOR_RED "FATAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+            break;
+        }
     }
 
     if (!s.isEmpty())
@@ -192,9 +191,9 @@ void Common::installMessageOutputHandler(QLocalServer *logServer, GuiLogCallback
 QDate Common::bytesToDate(const QByteArray &data)
 {
     //reminder date is uint16_t : yyyy yyym mmmd dddd with year from 2010
-    int y = (((quint8)data[0] >> 1) & 0x7F) + 2010;
-    int m = (((quint8)data[0] & 0x01) << 3) | (((quint8)data[1] >> 5) & 0x07);
-    int d = ((quint8)data[1] & 0x1F);
+    int y = ((static_cast<quint8>(data[0]) >> 1) & 0x7F) + 2010;
+    int m = (static_cast<quint8>(data[0] & 0x01) << 3) | ((static_cast<quint8>(data[1]) >> 5) & 0x07);
+    int d = (static_cast<quint8>(data[1]) & 0x1F);
 
     return QDate(y, m+1, d);
 }
@@ -220,7 +219,9 @@ QJsonArray Common::bytesToJson(const QByteArray &data)
 {
     QJsonArray arr;
     for (int i = 0;i < data.size();i++)
-        arr.append((quint8)data.at(i));
+    {
+        arr.append(static_cast<quint8>(data.at(i)));
+    }
     return arr;
 }
 
@@ -229,7 +230,7 @@ QJsonObject Common::bytesToJsonObjectArray(const QByteArray &data)
     QJsonObject returnObject;
     for (qint32 i = 0; i < data.size(); i++)
     {
-        returnObject[QString::number(i)] = QJsonValue((quint8)data[i]);
+        returnObject[QString::number(i)] = QJsonValue(static_cast<quint8>(data[i]));
     }
     return returnObject;
 }
@@ -239,7 +240,7 @@ bool Common::isProcessRunning(qint64 pid)
 {
     if (pid == 0) return false;
 #if defined(Q_OS_WIN)
-    HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, pid);
+    HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid));
     if (!process) return false;
     DWORD ret = WaitForSingleObject(process, 0);
     CloseHandle(process);
@@ -276,7 +277,7 @@ QJsonObject Common::readSharedMemory(QSharedMemory &sh)
     }
 
     QJsonParseError jerr;
-    QJsonDocument jdoc = QJsonDocument::fromJson((const char *)sh.constData(), &jerr);
+    QJsonDocument jdoc = QJsonDocument::fromJson(static_cast<const char*>(sh.constData()), &jerr);
 
     if (jerr.error != QJsonParseError::NoError)
     {
@@ -303,7 +304,7 @@ bool Common::writeSharedMemory(QSharedMemory &sh, const QJsonObject &o)
 
     QJsonDocument jdoc(o);
     QByteArray ba = jdoc.toJson(QJsonDocument::Compact);
-    memcpy(sh.data(), ba.constData(), ba.size());
+    memcpy(sh.data(), ba.constData(), static_cast<size_t>(ba.size()));
 
     sh.unlock();
 
@@ -318,7 +319,7 @@ QString Common::createUid(QString prefix)
     if (!commonUidInit)
     {
         commonUidInit = true;
-        qsrand(time(NULL));
+        qsrand(static_cast<uint>(time(nullptr)));
     }
 
     //try to generate a unique id based on

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -193,7 +193,7 @@ QDate Common::bytesToDate(const QByteArray &data)
 {
     //reminder date is uint16_t : yyyy yyym mmmd dddd with year from 2010
     int y = ((static_cast<quint8>(data[0]) >> 1) & 0x7F) + 2010;
-    int m = (static_cast<quint8>(data[0] & 0x01) << 3) | ((static_cast<quint8>(data[1]) >> 5) & 0x07);
+    int m = ((static_cast<quint8>(data[0]) & 0x01) << 3) | ((static_cast<quint8>(data[1]) >> 5) & 0x07);
     int d = (static_cast<quint8>(data[1]) & 0x1F);
 
     return QDate(y, m+1, d);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -114,31 +114,31 @@ static void _messageOutput(QtMsgType type, const QMessageLogContext &context, co
 
     QString s;
     switch (type) {
-        case QtDebugMsg:
-        {
-            s = QString(COLOR_CYAN "DEBUG" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-            break;
-        }
-        case QtInfoMsg:
-        {
-            s = QString(COLOR_GREEN "INFO" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-            break;
-        }
-        case QtWarningMsg:
-        {
-            s = QString(COLOR_YELLOW "WARNING" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-            break;
-        }
-        case QtCriticalMsg:
-        {
-            s = QString(COLOR_ORANGE "CRITICAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-            break;
-        }
-        case QtFatalMsg:
-        {
-            s = QString(COLOR_RED "FATAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
-            break;
-        }
+    case QtDebugMsg:
+    {
+        s = QString(COLOR_CYAN "DEBUG" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+        break;
+    }
+    case QtInfoMsg:
+    {
+        s = QString(COLOR_GREEN "INFO" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+        break;
+    }
+    case QtWarningMsg:
+    {
+        s = QString(COLOR_YELLOW "WARNING" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+        break;
+    }
+    case QtCriticalMsg:
+    {
+        s = QString(COLOR_ORANGE "CRITICAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+        break;
+    }
+    case QtFatalMsg:
+    {
+        s = QString(COLOR_RED "FATAL" COLOR_RESET ": %1:%2 - %3\n").arg(fname).arg(context.line).arg(msg);
+        break;
+    }
     }
 
     if (!s.isEmpty())
@@ -241,7 +241,7 @@ bool Common::isProcessRunning(qint64 pid)
 {
     if (pid == 0) return false;
 #if defined(Q_OS_WIN)
-    HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid));
+    HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, pid);
     if (!process) return false;
     DWORD ret = WaitForSingleObject(process, 0);
     CloseHandle(process);
@@ -305,7 +305,7 @@ bool Common::writeSharedMemory(QSharedMemory &sh, const QJsonObject &o)
 
     QJsonDocument jdoc(o);
     QByteArray ba = jdoc.toJson(QJsonDocument::Compact);
-    memcpy(sh.data(), ba.constData(), static_cast<size_t>(ba.size()));
+    memcpy(sh.data(), ba.constData(), ba.size());
 
     sh.unlock();
 
@@ -320,7 +320,7 @@ QString Common::createUid(QString prefix)
     if (!commonUidInit)
     {
         commonUidInit = true;
-        qsrand(static_cast<uint>(time(nullptr)));
+        qsrand(time(nullptr));
     }
 
     //try to generate a unique id based on

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -249,10 +249,10 @@ bool Common::isProcessRunning(qint64 pid)
 #else
     /* This code is portable on linux and macos (not tested on *BSD) */
 
-    pid_t p = (pid_t)pid;
+    pid_t p = static_cast<pid_t>(pid);
 
     //Wait for defunct process to end
-    while(waitpid(-1, 0, WNOHANG) > 0)
+    while(waitpid(-1, nullptr, WNOHANG) > 0)
     { /* wait for defunct... */ }
 
     if (kill(p, 0) == 0)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -93,10 +93,11 @@ QHash<Common::MPStatus, QString> Common::MPStatusString = {
 
 Common::MPStatus Common::statusFromString(const QString &st)
 {
-    for (auto it = MPStatusString.begin();it != MPStatusString.end();it++)
+    const auto it = std::find_if(std::begin(MPStatusString), std::end(MPStatusString),
+                                 [&st](const QString& val){ return val == st;});
+    if (it != std::end(MPStatusString))
     {
-        if (it.value() == st)
-            return it.key();
+        return it.key();
     }
 
     qWarning() << "Unable to find value from enum for status" << st;

--- a/src/Common.h
+++ b/src/Common.h
@@ -161,6 +161,12 @@ public:
     static std::vector<qint64> getRngSeed();
     static void updateSeed(std::vector<qint64> &newInts);
 
+    template <typename Enumeration>
+    static typename std::underlying_type<Enumeration>::type getEnumValue(Enumeration const value)
+    {
+        return static_cast<typename std::underlying_type<Enumeration>::type>(value);
+    }
+
     typedef enum
     {
         MP_Classic = 0,

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -102,7 +102,7 @@ Qt::ItemFlags CredentialModel::flags(const QModelIndex &idx) const
 {
     if (!idx.isValid())
     {
-        return nullptr;
+        return Qt::NoItemFlags;
     }
     return QAbstractItemModel::flags(idx);
 }
@@ -295,66 +295,66 @@ void CredentialModel::updateLoginItem(const QModelIndex &idx, const ItemRole &ro
     bool bChanged = false;
     switch (role)
     {
-        case ItemNameRole:
+    case ItemNameRole:
+    {
+        QString sName = vValue.toString();
+        if (sName != pLoginItem->name())
         {
-            QString sName = vValue.toString();
-            if (sName != pLoginItem->name())
-            {
-                pLoginItem->setName(sName);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setName(sName);
+            bChanged = true;
         }
-        case PasswordRole:
+        break;
+    }
+    case PasswordRole:
+    {
+        QString sPassword = vValue.toString();
+        if (sPassword != pLoginItem->password())
         {
-            QString sPassword = vValue.toString();
-            if (sPassword != pLoginItem->password())
-            {
-                pLoginItem->setPassword(sPassword);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setPassword(sPassword);
+            bChanged = true;
         }
-        case DescriptionRole:
+        break;
+    }
+    case DescriptionRole:
+    {
+        QString sDescription = vValue.toString();
+        if (sDescription != pLoginItem->description())
         {
-            QString sDescription = vValue.toString();
-            if (sDescription != pLoginItem->description())
-            {
-                pLoginItem->setDescription(sDescription);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setDescription(sDescription);
+            bChanged = true;
         }
-        case DateUpdatedRole:
+        break;
+    }
+    case DateUpdatedRole:
+    {
+        QDate dDate = vValue.toDate();
+        if (dDate != pLoginItem->updatedDate())
         {
-            QDate dDate = vValue.toDate();
-            if (dDate != pLoginItem->updatedDate())
-            {
-                pLoginItem->setUpdatedDate(dDate);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setUpdatedDate(dDate);
+            bChanged = true;
         }
-        case DateAccessedRole:
+        break;
+    }
+    case DateAccessedRole:
+    {
+        QDate dDate = vValue.toDate();
+        if (dDate != pLoginItem->accessedDate())
         {
-            QDate dDate = vValue.toDate();
-            if (dDate != pLoginItem->accessedDate())
-            {
-                pLoginItem->setAccessedDate(dDate);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setAccessedDate(dDate);
+            bChanged = true;
         }
-        case FavoriteRole:
+        break;
+    }
+    case FavoriteRole:
+    {
+        qint8 iFavorite = static_cast<qint8>(vValue.toInt());
+        if (iFavorite != pLoginItem->favorite())
         {
-            qint8 iFavorite = static_cast<qint8>(vValue.toInt());
-            if (iFavorite != pLoginItem->favorite())
-            {
-                pLoginItem->setFavorite(iFavorite);
-                bChanged = true;
-            }
-            break;
+            pLoginItem->setFavorite(iFavorite);
+            bChanged = true;
         }
+        break;
+    }
     }
     if (bChanged)
         emit dataChanged(idx, idx);

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -232,7 +232,7 @@ void CredentialModel::load(const QJsonArray &json)
 
             // Update login favorite
             int iFavorite = cnode["favorite"].toInt();
-            pLoginItem->setFavorite(static_cast<qint8>(iFavorite));
+            pLoginItem->setFavorite(iFavorite);
         }
     }
 

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -101,8 +101,9 @@ QVariant CredentialModel::headerData(int section, Qt::Orientation orientation, i
 Qt::ItemFlags CredentialModel::flags(const QModelIndex &idx) const
 {
     if (!idx.isValid())
-        return 0;
-
+    {
+        return nullptr;
+    }
     return QAbstractItemModel::flags(idx);
 }
 
@@ -223,15 +224,15 @@ void CredentialModel::load(const QJsonArray &json)
                 continue;
             }
             QByteArray bAddress;
-            bAddress.append((char)a.at(0).toInt());
-            bAddress.append((char)a.at(1).toInt());
+            bAddress.append(static_cast<char>(a.at(0).toInt()));
+            bAddress.append(static_cast<char>(a.at(1).toInt()));
 
             // Update login item address
             pLoginItem->setAddress(bAddress);
 
             // Update login favorite
             int iFavorite = cnode["favorite"].toInt();
-            pLoginItem->setFavorite(iFavorite);
+            pLoginItem->setFavorite(static_cast<qint8>(iFavorite));
         }
     }
 
@@ -294,67 +295,66 @@ void CredentialModel::updateLoginItem(const QModelIndex &idx, const ItemRole &ro
     bool bChanged = false;
     switch (role)
     {
-    case ItemNameRole:
-    {
-        QString sName = vValue.toString();
-        if (sName != pLoginItem->name())
+        case ItemNameRole:
         {
-            pLoginItem->setName(sName);
-            bChanged = true;
+            QString sName = vValue.toString();
+            if (sName != pLoginItem->name())
+            {
+                pLoginItem->setName(sName);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    case PasswordRole:
-    {
-        QString sPassword = vValue.toString();
-        if (sPassword != pLoginItem->password())
+        case PasswordRole:
         {
-            pLoginItem->setPassword(sPassword);
-            bChanged = true;
+            QString sPassword = vValue.toString();
+            if (sPassword != pLoginItem->password())
+            {
+                pLoginItem->setPassword(sPassword);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    case DescriptionRole:
-    {
-        QString sDescription = vValue.toString();
-        if (sDescription != pLoginItem->description())
+        case DescriptionRole:
         {
-            pLoginItem->setDescription(sDescription);
-            bChanged = true;
+            QString sDescription = vValue.toString();
+            if (sDescription != pLoginItem->description())
+            {
+                pLoginItem->setDescription(sDescription);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    case DateUpdatedRole:
-    {
-        QDate dDate = vValue.toDate();
-        if (dDate != pLoginItem->updatedDate())
+        case DateUpdatedRole:
         {
-            pLoginItem->setUpdatedDate(dDate);
-            bChanged = true;
+            QDate dDate = vValue.toDate();
+            if (dDate != pLoginItem->updatedDate())
+            {
+                pLoginItem->setUpdatedDate(dDate);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    case DateAccessedRole:
-    {
-        QDate dDate = vValue.toDate();
-        if (dDate != pLoginItem->accessedDate())
+        case DateAccessedRole:
         {
-            pLoginItem->setAccessedDate(dDate);
-            bChanged = true;
+            QDate dDate = vValue.toDate();
+            if (dDate != pLoginItem->accessedDate())
+            {
+                pLoginItem->setAccessedDate(dDate);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    case FavoriteRole:
-    {
-        qint8 iFavorite = (qint8)vValue.toInt();
-        if (iFavorite != pLoginItem->favorite())
+        case FavoriteRole:
         {
-            pLoginItem->setFavorite(iFavorite);
-            bChanged = true;
+            qint8 iFavorite = static_cast<qint8>(vValue.toInt());
+            if (iFavorite != pLoginItem->favorite())
+            {
+                pLoginItem->setFavorite(iFavorite);
+                bChanged = true;
+            }
+            break;
         }
-        break;
-    }
-    default: break;
     }
     if (bChanged)
         emit dataChanged(idx, idx);

--- a/src/CredentialModelFilter.h
+++ b/src/CredentialModelFilter.h
@@ -13,7 +13,7 @@ class CredentialModelFilter : public QSortFilterProxyModel
 
 public:
     CredentialModelFilter(QObject *parent = nullptr);
-    ~CredentialModelFilter();
+    ~CredentialModelFilter() override;
     void setFilter(const QString &sFilter);
     bool switchFavFilter();
     TreeItem *getItemByProxyIndex(const QModelIndex &proxyIndex);

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -155,7 +155,7 @@ void CredentialView::setModel(QAbstractItemModel *model)
 {
     QTreeView::setModel(model);
 
-    setColumnWidth(0, geometry().width()*columnBreakRatio);
+    setColumnWidth(0, static_cast<int>(geometry().width()*columnBreakRatio));
     connect(model, &QAbstractItemModel::layoutAboutToBeChanged
             , this, &CredentialView::onLayoutAboutToBeChanged);
     connect(model, &QAbstractItemModel::layoutChanged, this
@@ -165,7 +165,7 @@ void CredentialView::setModel(QAbstractItemModel *model)
 void CredentialView::resizeEvent(QResizeEvent *event)
 {
     QTreeView::resizeEvent(event);
-    setColumnWidth(0, geometry().width()*columnBreakRatio);
+    setColumnWidth(0, static_cast<int>(geometry().width()*columnBreakRatio));
 }
 
 void CredentialView::onLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents

--- a/src/CredentialView.cpp
+++ b/src/CredentialView.cpp
@@ -155,7 +155,7 @@ void CredentialView::setModel(QAbstractItemModel *model)
 {
     QTreeView::setModel(model);
 
-    setColumnWidth(0, static_cast<int>(geometry().width()*columnBreakRatio));
+    setColumnWidth(0, geometry().width()*columnBreakRatio);
     connect(model, &QAbstractItemModel::layoutAboutToBeChanged
             , this, &CredentialView::onLayoutAboutToBeChanged);
     connect(model, &QAbstractItemModel::layoutChanged, this
@@ -165,7 +165,7 @@ void CredentialView::setModel(QAbstractItemModel *model)
 void CredentialView::resizeEvent(QResizeEvent *event)
 {
     QTreeView::resizeEvent(event);
-    setColumnWidth(0, static_cast<int>(geometry().width()*columnBreakRatio));
+    setColumnWidth(0, geometry().width()*columnBreakRatio);
 }
 
 void CredentialView::onLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents

--- a/src/CredentialView.h
+++ b/src/CredentialView.h
@@ -17,7 +17,7 @@ class CredentialView : public QTreeView
 
 public:
     explicit CredentialView(QWidget *parent = nullptr);
-    ~CredentialView();
+    ~CredentialView() override;
     void refreshLoginItem(const QModelIndex &srcIndex, bool bIsFavorite=false);
     virtual void setModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
     virtual void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -38,7 +38,7 @@ class CredentialsManagement : public QWidget
     Q_OBJECT
 
 public:    
-    explicit CredentialsManagement(QWidget *parent = 0);
+    explicit CredentialsManagement(QWidget *parent = nullptr);
     ~CredentialsManagement();
     void setWsClient(WSClient *c);
     void setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel);

--- a/src/DbMasterController.cpp
+++ b/src/DbMasterController.cpp
@@ -16,7 +16,7 @@ void DbMasterController::setMainWindow(MainWindow *window)
 {
     dbExportsRegistryController->setMainWindow(window);
 
-    if (! dbBackupsTrackerController && window && wsClient)
+    if (!dbBackupsTrackerController && window && wsClient)
     {
         dbBackupsTrackerController = new DbBackupsTrackerController(window, wsClient,
                                                                     AppGui::getDataDirPath() + "/dbBackupTracks.ini", this);

--- a/src/FilesCache.cpp
+++ b/src/FilesCache.cpp
@@ -71,7 +71,7 @@ QList<QVariantMap> FilesCache::load()
 
         QJsonObject jsonRoot = QJsonDocument::fromJson(rawJSon.toLocal8Bit()).object();
 
-        qint8 cacheDbChangeNumber = jsonRoot.value("db_change_number").toInt();
+        qint8 cacheDbChangeNumber = static_cast<qint8>(jsonRoot.value("db_change_number").toInt());
         if (cacheDbChangeNumber != m_dbChangeNumber)
         {
             qDebug() << "dbChangeNumber miss";
@@ -154,15 +154,12 @@ bool FilesCache::setCardCPZ(QByteArray cardCPZ)
 
     m_filePath = dataDir.absoluteFilePath(fileName);
 
-    qint64 m_key = 0;
+    quint64 m_key = 0;
     for (int i = 0;i < std::min(8, cardCPZ.size());i++)
         m_key += (static_cast<unsigned int>(cardCPZ[i]) & 0xFF) << (i * 8);
 
     m_simpleCrypt.setKey(m_key);
     m_simpleCrypt.setIntegrityProtectionMode(SimpleCrypt::ProtectionHash);
 
-    if (m_dbChangeNumberSet)
-        return true;
-    else
-        return false;
+    return m_dbChangeNumberSet;
 }

--- a/src/FilesCache.cpp
+++ b/src/FilesCache.cpp
@@ -71,7 +71,7 @@ QList<QVariantMap> FilesCache::load()
 
         QJsonObject jsonRoot = QJsonDocument::fromJson(rawJSon.toLocal8Bit()).object();
 
-        qint8 cacheDbChangeNumber = static_cast<qint8>(jsonRoot.value("db_change_number").toInt());
+        qint8 cacheDbChangeNumber = jsonRoot.value("db_change_number").toInt();
         if (cacheDbChangeNumber != m_dbChangeNumber)
         {
             qDebug() << "dbChangeNumber miss";

--- a/src/FilesCache.h
+++ b/src/FilesCache.h
@@ -32,7 +32,7 @@ private:
     QString m_filePath;
     qint64 m_key = 0;
     bool m_dbChangeNumberSet = false;
-    quint8 m_dbChangeNumber = -1;
+    quint8 m_dbChangeNumber = std::numeric_limits<quint8>::max();
     SimpleCrypt m_simpleCrypt;
     bool m_isFileCacheInSync = true;
 };

--- a/src/FilesManagement.h
+++ b/src/FilesManagement.h
@@ -30,7 +30,7 @@ class FilesFilterModel: public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    FilesFilterModel(QObject *parent = 0);
+    FilesFilterModel(QObject *parent = nullptr);
 
     void setFilter(const QString &filter_str);
 
@@ -50,7 +50,7 @@ class FilesManagement : public QWidget
     Q_OBJECT
 
 public:
-    explicit FilesManagement(QWidget *parent = 0);
+    explicit FilesManagement(QWidget *parent = nullptr);
     ~FilesManagement();
 
     void setWsClient(WSClient *c);

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -37,7 +37,7 @@ int onMessageBeginCb(http_parser *parser)
 int onUrlCb(http_parser *parser, const char *at, size_t length)
 {
     HttpClient *client = reinterpret_cast<HttpClient *>(parser->data);
-    client->m_parseUrl.append(at, static_cast<int>(length));
+    client->m_parseUrl.append(at, length);
 
     return 0;
 }
@@ -64,7 +64,7 @@ int onHeaderFieldCb(http_parser *parser, const char *at, size_t length)
     if (!client->m_hasField)
         client->m_hasField = true;
 
-    client->m_hField.append(at, static_cast<int>(length));
+    client->m_hField.append(at, length);
 
     return 0;
 }
@@ -76,7 +76,7 @@ int onHeaderValueCb(http_parser *parser, const char *at, size_t length)
     if (!client->m_hasValue)
         client->m_hasValue = true;
 
-    client->m_hValue.append(at, static_cast<int>(length));
+    client->m_hValue.append(at, length);
 
     return 0;
 }
@@ -190,8 +190,8 @@ void HttpClient::parseRequest()
     while (m_socket->bytesAvailable())
     {
         QByteArray data = m_socket->readAll();
-        auto n = http_parser_execute(m_httpParser, m_httpParserSettings, data.constData(), static_cast<size_t>(data.size()));
-        if (n != static_cast<size_t>(data.size()))
+        int n = http_parser_execute(m_httpParser, m_httpParserSettings, data.constData(), data.size());
+        if (n != data.size())
         {
             // Errro close connection
             CloseConnection();

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -24,7 +24,7 @@
 
 HttpServer::HttpServer(QObject *parent) :
     QObject(parent),
-    m_tcpServer(0)
+    m_tcpServer(nullptr)
 {
 
 }

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -30,7 +30,7 @@ class HttpServer: QObject
 {
     Q_OBJECT
 public:
-    HttpServer(QObject *parent = 0);
+    HttpServer(QObject *parent = nullptr);
     virtual ~HttpServer();
 
     bool start(quint16 port);

--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -55,8 +55,8 @@ QJsonObject LoginItem::toJson() const
     QJsonArray addr;
     if (!m_bAddress.isEmpty())
     {
-        addr.append((int)m_bAddress.at(0));
-        addr.append((int)m_bAddress.at(1));
+        addr.append(static_cast<int>(m_bAddress.at(0)));
+        addr.append(static_cast<int>(m_bAddress.at(1)));
     }
 
     QString p;

--- a/src/LoginItem.h
+++ b/src/LoginItem.h
@@ -13,7 +13,7 @@ class LoginItem : public TreeItem
 {
 public:
     LoginItem(const QString &sLoginName);
-    virtual ~LoginItem();
+    virtual ~LoginItem() override;
     const QByteArray &address() const;
     void setAddress(const QByteArray &bAddress);
     qint8 favorite() const;

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -453,11 +453,11 @@ void MPDevice::sendDataDequeue()
     for (const auto &data : currentCmd.data)
     {
 #ifdef DEV_DEBUG
-        auto toHex = [](quint16 b) -> QString { return QString("0x%1").arg((quint16)b, 2, 16, QChar('0')); };
+        auto toHex = [](quint16 b) -> QString { return QString("0x%1").arg(static_cast<quint16>(b), 2, 16, QChar('0')); };
         QString a = "[";
         for (int i = 0;i < data.size();i++)
         {
-            a += toHex((quint8)data.at(i));
+            a += toHex(static_cast<quint8>(data.at(i)));
             if (i < data.size() - 1) a += ", ";
         }
         a += "]";
@@ -932,8 +932,8 @@ void MPDevice::updateParam(MPParams::Param param, int val)
     AsyncJobs *jobs = new AsyncJobs(logInf, this);
 
     QByteArray ba;
-    ba.append(static_cast<quint8>(param));
-    ba.append(static_cast<quint8>(val));
+    ba.append(static_cast<char>(param));
+    ba.append(static_cast<char>(val));
 
     jobs->append(new MPCommandJob(this, MPCmd::SET_MOOLTIPASS_PARM, ba, pMesProt->getDefaultFuncDone()));
 
@@ -952,7 +952,7 @@ void MPDevice::updateParam(MPParams::Param param, int val)
 
 void MPDevice::updateParam(MPParams::Param param, bool en)
 {
-    updateParam(param, (int)en);
+    updateParam(param, static_cast<int>(en));
 }
 
 void MPDevice::updateKeyboardLayout(int lang)
@@ -1147,7 +1147,7 @@ void MPDevice::memMgmtModeReadFlash(AsyncJobs *jobs, bool fullScan,
     for (uint i = 0; i<MOOLTIPASS_FAV_MAX; i++)
     {
         jobs->append(new MPCommandJob(this, MPCmd::GET_FAVORITE,
-                                      QByteArray(1, static_cast<quint8>(i)),
+                                      QByteArray(1, static_cast<char>(i)),
                                       [this, i, cbProgress](const QByteArray &, QByteArray &) -> bool
         {
             if (i == 0)
@@ -1388,17 +1388,17 @@ quint16 MPDevice::getNumberOfPages(void)
 {
     if(get_flashMbSize() >= 16)
     {
-        return 256*get_flashMbSize();
+        return static_cast<quint16>(256*get_flashMbSize());
     }
     else
     {
-        return 512*get_flashMbSize();
+        return static_cast<quint16>(512*get_flashMbSize());
     }
 }
 
 quint16 MPDevice::getFlashPageFromAddress(const QByteArray &address)
 {
-    return (((quint16)address[1] << 5) & 0x1FE0) | (((quint16)address[0] >> 3) & 0x001F);
+    return (static_cast<quint16>(address[1] << 5) & 0x1FE0) | (static_cast<quint16>(address[0] >> 3) & 0x001F);
 }
 
 QByteArray MPDevice::getNextNodeAddressInMemory(const QByteArray &address)
@@ -1416,8 +1416,8 @@ QByteArray MPDevice::getNextNodeAddressInMemory(const QByteArray &address)
 
     // Reconstruct the address
     QByteArray return_data(address);
-    return_data[0] = curNodeInPage | (((quint8)(curPage << 3)) & 0xF8);
-    return_data[1] = (quint8)(curPage >> 5);
+    return_data[0] = static_cast<char>(curNodeInPage | (static_cast<quint8>(curPage << 3) & 0xF8));
+    return_data[1] = static_cast<char>(curPage >> 5);
     return return_data;
 }
 
@@ -1593,7 +1593,7 @@ void MPDevice::loadLoginNode(AsyncJobs *jobs, const QByteArray &address, const M
                         currentFirstCharVal = 'z';
                     if (currentFirstCharVal < 'a')
                         currentFirstCharVal = 'a';
-                    progressCurrent = ((double)(currentFirstCharVal - 'a') / (double)('z' - 'a')) * 100;
+                    progressCurrent = static_cast<int>((static_cast<double>(currentFirstCharVal - 'a')) / static_cast<double>(('z' - 'a')) * 100);
                     progressCurrent += MOOLTIPASS_FAV_MAX;
                 }
 
@@ -2075,7 +2075,7 @@ bool MPDevice::tagFavoriteNodes(void)
                             if (favoritesAddrs[i] == curParentChildFavAddr)
                             {
                                 qDebug() << tempChildNodePt->getLogin() << " is favorite #" << i;
-                                tempChildNodePt->setFavoriteProperty((quint8)i);
+                                tempChildNodePt->setFavoriteProperty(static_cast<char>(i));
                             }
                         }
                     }
@@ -3560,8 +3560,8 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             qDebug() << "Cred DB: " << get_credentialsDbChangeNumber() << " clone: " << credentialsDbChangeNumberClone;
             qDebug() << "Data cred DB: " << get_dataDbChangeNumber() << " clone: " << dataDbChangeNumberClone;
             QByteArray updateChangeNumbersPacket = QByteArray();
-            updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
-            updateChangeNumbersPacket.append(get_dataDbChangeNumber());
+            updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
+            updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
             jobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
         }
     }
@@ -3676,7 +3676,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted service" << nodelist_iterator->getService();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, 0xFF), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3689,7 +3689,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted login" << nodelist_iterator->getLogin();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, 0xFF), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3703,7 +3703,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
                 qDebug() << "Generating favorite" << i << "update packet";
                 diagSavePacketsGenerated = true;
                 QByteArray updateFavPacket = QByteArray();
-                updateFavPacket.append(i);
+                updateFavPacket.append(static_cast<char>(i));
                 updateFavPacket.append(favoritesAddrs[i]);
                 jobs->append(new MPCommandJob(this, MPCmd::SET_FAVORITE, updateFavPacket, pMesProt->getDefaultFuncDone()));
             }
@@ -3727,7 +3727,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted data service" << nodelist_iterator->getService();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, 0xFF), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3740,7 +3740,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted data child node";
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, 0xFF), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3837,8 +3837,8 @@ void MPDevice::setCurrentDate()
         data_to_send.append(Common::dateToBytes(QDate::currentDate()));
 
         qDebug() << "Sending current date: " <<
-                    QString("0x%1").arg((quint8)data_to_send[0], 2, 16, QChar('0')) <<
-                    QString("0x%1").arg((quint8)data_to_send[1], 2, 16, QChar('0'));
+                    QString("0x%1").arg(static_cast<quint8>(data_to_send[0]), 2, 16, QChar('0')) <<
+                    QString("0x%1").arg(static_cast<quint8>(data_to_send[1]), 2, 16, QChar('0'));
 
         return true;
     },
@@ -3874,7 +3874,7 @@ void MPDevice::getUID(const QByteArray & key)
         data_to_send.clear();
         data_to_send.resize(16);
         for(int i = 0; i < 16; i++) {
-            data_to_send[i] = key.mid(2*i, 2).toUInt(&ok, 16);
+            data_to_send[i] = static_cast<char>(key.mid(2*i, 2).toUInt(&ok, 16));
             if(!ok)
                 return false;
         }
@@ -3892,7 +3892,7 @@ void MPDevice::getUID(const QByteArray & key)
 
         bool ok;
         quint64 uid = pMesProt->getFullPayload(data).toHex().toULongLong(&ok, 16);
-        set_uid(ok ? uid : - 1);
+        set_uid(ok ? static_cast<qint64>(uid) : - 1);
         return ok;
     }));
 
@@ -4020,7 +4020,7 @@ void MPDevice::cancelUserRequest(const QString &reqid)
         qInfo() << "request_id match current one. Cancel current request";
 
         QByteArray ba;
-        ba.append(static_cast<char>(0));
+        ba.append(NULL_CHAR);
         ba.append(static_cast<char>(pMesProt->getDeviceMappedCommandId(MPCmd::CANCEL_USER_REQUEST)));
 
         qDebug() << "Platform send command: " << QString("0x%1").arg(static_cast<quint8>(ba[1]), 2, 16, QChar('0'));
@@ -4058,7 +4058,7 @@ void MPDevice::getCredential(QString service, const QString &login, const QStrin
         jobs = new AsyncJobs(logInf, reqid, this);
 
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, MPCmd::CONTEXT,
                                   sdata,
@@ -4069,7 +4069,7 @@ void MPDevice::getCredential(QString service, const QString &login, const QStrin
             if (!fallback_service.isEmpty())
             {
                 QByteArray fsdata = pMesProt->toByteArray(fallback_service);
-                fsdata.append((char)0);
+                fsdata.append(NULL_CHAR);
                 jobs->prepend(new MPCommandJob(this, MPCmd::CONTEXT,
                                               fsdata,
                                               [this, jobs, fallback_service](const QByteArray &data, bool &) -> bool
@@ -4102,7 +4102,7 @@ void MPDevice::getCredential(QString service, const QString &login, const QStrin
 
     QByteArray ldata = pMesProt->toByteArray(login);
     if (!ldata.isEmpty())
-        ldata.append((char)0);
+        ldata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, MPCmd::GET_LOGIN,
                                   ldata,
@@ -4274,7 +4274,7 @@ void MPDevice::getRandomNumber(std::function<void(bool success, QString errstr, 
 void MPDevice::createJobAddContext(const QString &service, AsyncJobs *jobs, bool isDataNode)
 {
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     quint8 cmdAddCtx = isDataNode?MPCmd::ADD_DATA_SERVICE:MPCmd::ADD_CONTEXT;
     quint8 cmdSelectCtx = isDataNode?MPCmd::SET_DATA_SERVICE:MPCmd::CONTEXT;
@@ -4331,7 +4331,7 @@ void MPDevice::setCredential(QString service, const QString &login,
     AsyncJobs *jobs = new AsyncJobs(logInf, this);
 
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     //First query if context exist
     jobs->append(new MPCommandJob(this, MPCmd::CONTEXT,
@@ -4350,7 +4350,7 @@ void MPDevice::setCredential(QString service, const QString &login,
     }));
 
     QByteArray ldata = pMesProt->toByteArray(login);
-    ldata.append((char)0);
+    ldata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, MPCmd::SET_LOGIN,
                                   ldata,
@@ -4369,7 +4369,7 @@ void MPDevice::setCredential(QString service, const QString &login,
     if (isFw12() && setDesc && description != "None")
     {
         QByteArray ddata = pMesProt->toByteArray(description);
-        ddata.append((char)0);
+        ddata.append(NULL_CHAR);
 
         //Set description should be done right after set login
         jobs->append(new MPCommandJob(this, MPCmd::SET_DESCRIPTION,
@@ -4396,7 +4396,7 @@ void MPDevice::setCredential(QString service, const QString &login,
     }
 
     QByteArray pdata = pMesProt->toByteArray(pass);
-    pdata.append((char)0);
+    pdata.append(NULL_CHAR);
 
     if(!pass.isEmpty()) {
         jobs->append(new MPCommandJob(this, MPCmd::CHECK_PASSWORD,
@@ -4485,11 +4485,11 @@ bool MPDevice::getDataNodeCb(AsyncJobs *jobs,
         if (ba.isEmpty())
         {
             ba.append(pMesProt->getFullPayload(data));
-            quint32 sz = qFromBigEndian<quint32>((quint8 *)ba.data());
+            quint32 sz = qFromBigEndian<quint32>(ba.data());
             m["progress_total"] = sz;
             // TODO: send a more significative message
             QVariantMap data = {
-                {"total", (int)sz},
+                {"total", static_cast<int>(sz)},
                 {"current", ba.size() - 4},
                 {"msg", "WORKING on getDataNodeCb" }
             };
@@ -4545,7 +4545,7 @@ void MPDevice::getDataNode(QString service, const QString &fallback_service, con
         jobs = new AsyncJobs(logInf, reqid, this);
 
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, MPCmd::SET_DATA_SERVICE,
                                   sdata,
@@ -4556,7 +4556,7 @@ void MPDevice::getDataNode(QString service, const QString &fallback_service, con
             if (!fallback_service.isEmpty())
             {
                 QByteArray fsdata = pMesProt->toByteArray(fallback_service);
-                fsdata.append((char)0);
+                fsdata.append(NULL_CHAR);
                 jobs->prepend(new MPCommandJob(this, MPCmd::SET_DATA_SERVICE,
                                               fsdata,
                                               [this, jobs, fallback_service](const QByteArray &data, bool &) -> bool
@@ -4604,10 +4604,10 @@ void MPDevice::getDataNode(QString service, const QString &fallback_service, con
         QByteArray ndata = m["data"].toByteArray();
 
         //check data size
-        quint32 sz = qFromBigEndian<quint32>((quint8 *)ndata.data());
+        quint32 sz = qFromBigEndian<quint32>(ndata.data());
         qDebug() << "Data size: " << sz;
 
-        cb(true, QString(), m["service"].toString(), ndata.mid(4, sz));
+        cb(true, QString(), m["service"].toString(), ndata.mid(4, static_cast<int>(sz)));
     });
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
@@ -4685,7 +4685,7 @@ void MPDevice::setDataNode(QString service, const QByteArray &nodeData,
     AsyncJobs *jobs = new AsyncJobs(logInf, this);
 
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, MPCmd::SET_DATA_SERVICE,
                                   sdata,
@@ -4705,7 +4705,7 @@ void MPDevice::setDataNode(QString service, const QByteArray &nodeData,
     //set size of data
     currentDataNode = QByteArray();
     currentDataNode.resize(MP_DATA_HEADER_SIZE);
-    qToBigEndian(nodeData.size(), (quint8 *)currentDataNode.data());
+    qToBigEndian(nodeData.size(), currentDataNode.data());
     currentDataNode.append(nodeData);
 
     //first packet
@@ -4852,8 +4852,8 @@ void  MPDevice::deleteDataNodesAndLeave(QStringList services,
                 dataDbChangeNumberClone = get_dataDbChangeNumber();
                 filesCache.setDbChangeNumber(get_dataDbChangeNumber());
                 QByteArray updateChangeNumbersPacket = QByteArray();
-                updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
-                updateChangeNumbersPacket.append(get_dataDbChangeNumber());
+                updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
+                updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
                 saveJobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
                 emit dbChangeNumbersChanged(get_credentialsDbChangeNumber(), get_dataDbChangeNumber());
             }
@@ -4887,50 +4887,52 @@ void MPDevice::changeVirtualAddressesToFreeAddresses(void)
 {
     if (virtualStartNode != 0)
     {
-        qDebug() << "Setting start node to " << freeAddresses[virtualStartNode].toHex();
-        startNode = freeAddresses[virtualStartNode];
+        qDebug() << "Setting start node to " << freeAddresses[static_cast<int>(virtualStartNode)].toHex();
+        startNode = freeAddresses[static_cast<int>(virtualStartNode)];
     }
     if (virtualDataStartNode != 0)
     {
-        qDebug() << "Setting data start node to " << freeAddresses[virtualDataStartNode].toHex();
-        startDataNode = freeAddresses[virtualDataStartNode];
+        qDebug() << "Setting data start node to " << freeAddresses[static_cast<int>(virtualDataStartNode)].toHex();
+        startDataNode = freeAddresses[static_cast<int>(virtualDataStartNode)];
     }
     qDebug() << "Replacing virtual addresses for login nodes...";
     for (auto &i: loginNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
-        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[i->getNextParentVirtualAddress()]);
-        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[i->getPreviousParentVirtualAddress()]);
-        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[i->getStartChildVirtualAddress()]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
+        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[static_cast<int>(i->getNextParentVirtualAddress())]);
+        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[static_cast<int>(i->getPreviousParentVirtualAddress())]);
+        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[static_cast<int>(i->getStartChildVirtualAddress())]);
     }
     qDebug() << "Replacing virtual addresses for child nodes...";
     for (auto &i: loginChildNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
-        if (i->getNextChildAddress().isNull()) i->setNextChildAddress(freeAddresses[i->getNextChildVirtualAddress()]);
-        if (i->getPreviousChildAddress().isNull()) i->setPreviousChildAddress(freeAddresses[i->getPreviousChildVirtualAddress()]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
+        if (i->getNextChildAddress().isNull()) i->setNextChildAddress(freeAddresses[static_cast<int>(i->getNextChildVirtualAddress())]);
+        if (i->getPreviousChildAddress().isNull()) i->setPreviousChildAddress(freeAddresses[static_cast<int>(i->getPreviousChildVirtualAddress())]);
     }
     qDebug() << "Replacing virtual addresses for data nodes...";
     for (auto &i: dataNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
-        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[i->getNextParentVirtualAddress()]);
-        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[i->getPreviousParentVirtualAddress()]);
-        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[i->getStartChildVirtualAddress()]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
+        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[static_cast<int>(i->getNextParentVirtualAddress())]);
+        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[static_cast<int>(i->getPreviousParentVirtualAddress())]);
+        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[static_cast<int>(i->getStartChildVirtualAddress())]);
     }
     qDebug() << "Replacing virtual addresses for data child nodes...";
     for (auto &i: dataChildNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
-        if (i->getNextChildDataAddress().isNull()) i->setNextChildDataAddress(freeAddresses[i->getNextChildVirtualAddress()]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
+        if (i->getNextChildDataAddress().isNull()) i->setNextChildDataAddress(freeAddresses[static_cast<int>(i->getNextChildVirtualAddress())]);
     }
 }
 
 quint64 MPDevice::getUInt64EncryptionKey()
 {
-    qint64 key = 0;
+    quint64 key = 0;
     for (int i = 0; i < std::min(8, m_cardCPZ.size()) ; i ++)
+    {
         key += (static_cast<unsigned int>(m_cardCPZ[i]) & 0xFF) << (i*8);
+    }
 
     return key;
 }
@@ -5194,16 +5196,16 @@ QByteArray MPDevice::generateExportFileData(const QString &encryption)
     exportTopArray.append(QJsonValue(QString("moolticute")));
 
     /* bundle version */
-    exportTopArray.append(QJsonValue((qint64)1));
+    exportTopArray.append(QJsonValue(static_cast<qint64>(1)));
 
     /* Credential change number */
-    exportTopArray.append(QJsonValue((quint8)get_credentialsDbChangeNumber()));
+    exportTopArray.append(QJsonValue(static_cast<qint8>(get_credentialsDbChangeNumber())));
 
     /* Data change number */
-    exportTopArray.append(QJsonValue((quint8)get_dataDbChangeNumber()));
+    exportTopArray.append(QJsonValue(static_cast<qint8>(get_dataDbChangeNumber())));
 
     /* Mooltipass serial */
-    exportTopArray.append(QJsonValue((qint64)get_serialNumber()));
+    exportTopArray.append(QJsonValue(static_cast<qint64>(get_serialNumber())));
 
     /* Generate file payload */
     QJsonDocument payloadDoc(exportTopArray);
@@ -5228,8 +5230,8 @@ QByteArray MPDevice::generateExportFileData(const QString &encryption)
         exportTopObject.insert("payload", QString(payload));
     }
 
-    exportTopObject.insert("dataDbChangeNumber", QJsonValue((quint8)get_dataDbChangeNumber()));
-    exportTopObject.insert("credentialsDbChangeNumber", QJsonValue((quint8)get_credentialsDbChangeNumber()));
+    exportTopObject.insert("dataDbChangeNumber", QJsonValue(static_cast<qint8>(get_dataDbChangeNumber())));
+    exportTopObject.insert("credentialsDbChangeNumber", QJsonValue(static_cast<qint8>(get_credentialsDbChangeNumber())));
 
     QJsonDocument fileContentDoc(exportTopObject);
     payload = fileContentDoc.toJson();
@@ -5345,18 +5347,18 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qInfo() << "Dealing with Moolticute export file";
         isMooltiAppImportFile = false;
-        importedCredentialsDbChangeNumber = dataArray[11].toInt();
+        importedCredentialsDbChangeNumber = static_cast<quint8>(dataArray[11].toInt());
         qDebug() << "Imported cred change number: " << importedCredentialsDbChangeNumber;
-        importedDataDbChangeNumber = dataArray[12].toInt();
+        importedDataDbChangeNumber = static_cast<quint8>(dataArray[12].toInt());
         qDebug() << "Imported data change number: " << importedDataDbChangeNumber;
-        importedDbMiniSerialNumber = dataArray[13].toInt();
+        importedDbMiniSerialNumber = static_cast<quint8>(dataArray[13].toInt());
         qDebug() << "Imported mini serial number: " << importedDbMiniSerialNumber;
     }
 
     /* Read CTR */
     importedCtrValue = QByteArray();
     auto qjobject = dataArray[0].toObject();
-    for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(qjobject[QString::number(i)].toInt());}
+    for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(static_cast<char>(qjobject[QString::number(i)].toInt()));}
     qDebug() << "Imported CTR: " << importedCtrValue.toHex();
 
     /* Read CPZ CTR values */
@@ -5365,7 +5367,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qjobject = qjarray[i].toObject();
         QByteArray qbarray = QByteArray();
-        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(qjobject[QString::number(j)].toInt());}
+        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(static_cast<char>(qjobject[QString::number(j)].toInt()));}
         qDebug() << "Imported CPZ/CTR value : " << qbarray.toHex();
         importedCpzCtrValue.append(qbarray);
     }
@@ -5391,13 +5393,13 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     /* Read Starting Parent */
     importedStartNode = QByteArray();
     qjarray = dataArray[2].toArray();
-    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(qjarray[i].toInt());}
+    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(static_cast<char>(qjarray[i].toInt()));}
     qDebug() << "Imported start node: " << importedStartNode.toHex();
 
     /* Read Data Starting Parent */
     importedStartDataNode = QByteArray();
     qjarray = dataArray[3].toArray();
-    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(qjarray[i].toInt());}
+    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(static_cast<char>(qjarray[i].toInt()));}
     qDebug() << "Imported data start node: " << importedStartDataNode.toHex();
 
     /* Read favorites */
@@ -5406,7 +5408,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qjobject = qjarray[i].toObject();
         QByteArray qbarray = QByteArray();
-        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(qjobject[QString::number(j)].toInt());}
+        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(static_cast<char>(qjobject[QString::number(j)].toInt()));}
         qDebug() << "Imported favorite " << i << " : " << qbarray.toHex();
         importedFavoritesAddrs.append(qbarray);
     }
@@ -5420,12 +5422,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         /* Fetch address */
         QJsonArray serviceAddrArr = qjobject["address"].toArray();
         QByteArray serviceAddr = QByteArray();
-        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
+        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
 
         /* Fetch core data */
         QJsonObject dataObj = qjobject["data"].toObject();
         QByteArray dataCore = QByteArray();
-        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
+        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
 
         /* Recreate node and add it to the list of imported nodes */
         MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5442,12 +5444,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         /* Fetch address */
         QJsonArray serviceAddrArr = qjobject["address"].toArray();
         QByteArray serviceAddr = QByteArray();
-        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
+        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
 
         /* Fetch core data */
         QJsonObject dataObj = qjobject["data"].toObject();
         QByteArray dataCore = QByteArray();
-        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
+        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
 
         /* Recreate node and add it to the list of imported nodes */
         MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5466,12 +5468,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             /* Fetch address */
             QJsonArray serviceAddrArr = qjobject["address"].toArray();
             QByteArray serviceAddr = QByteArray();
-            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
+            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
 
             /* Fetch core data */
             QJsonObject dataObj = qjobject["data"].toObject();
             QByteArray dataCore = QByteArray();
-            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
+            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
 
             /* Recreate node and add it to the list of imported nodes */
             MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5488,12 +5490,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             /* Fetch address */
             QJsonArray serviceAddrArr = qjobject["address"].toArray();
             QByteArray serviceAddr = QByteArray();
-            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
+            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
 
             /* Fetch core data */
             QJsonObject dataObj = qjobject["data"].toObject();
             QByteArray dataCore = QByteArray();
-            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
+            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
 
             /* Recreate node and add it to the list of imported nodes */
             MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5597,8 +5599,8 @@ void MPDevice::startImportFileMerging(const MPDeviceProgressCb &cbProgress, Mess
         }
 
         /// Check CTR value
-        quint32 cur_ctr = ((quint8)ctrValue[0])*256*256 + ((quint8)ctrValue[1])*256 + ((quint8)ctrValue[2]);
-        quint32 imported_ctr = ((quint8)importedCtrValue[0])*256*256 + ((quint8)importedCtrValue[1]*256) + ((quint8)importedCtrValue[2]);
+        quint32 cur_ctr = static_cast<quint8>(ctrValue[0])*256*256 + static_cast<quint8>(ctrValue[1])*256 + static_cast<quint8>(ctrValue[2]);
+        quint32 imported_ctr = static_cast<quint8>(importedCtrValue[0])*256*256 + static_cast<quint8>(importedCtrValue[1]*256) + static_cast<quint8>(importedCtrValue[2]);
         if (imported_ctr > cur_ctr)
         {
             qDebug() << "CTR value mismatch: " << ctrValue.toHex() << " instead of " << importedCtrValue.toHex();
@@ -6394,7 +6396,7 @@ void MPDevice::loadFreeAddresses(AsyncJobs *jobs, const QByteArray &addressFrom,
         else
         {
             /* Add the free addresses to our buffer */
-            for (quint32 i = 0; i < nb_free_addresses_received; i++)
+            for (int i = 0; i < static_cast<int>(nb_free_addresses_received); i++)
             {
                 if (discardFirstAddr)
                 {
@@ -6550,7 +6552,7 @@ void MPDevice::serviceExists(bool isDatanode, QString service, const QString &re
         jobs = new AsyncJobs(logInf, reqid, this);
 
     QByteArray sdata = pMesProt->toByteArray(service);
-    sdata.append((char)0);
+    sdata.append(NULL_CHAR);
 
     jobs->append(new MPCommandJob(this, isDatanode? MPCmd::SET_DATA_SERVICE : MPCmd::CONTEXT,
                                   sdata,
@@ -6745,12 +6747,12 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
             /* Credential data */
             QByteArray nodeAddr;
             QString login = qjobject["login"].toString();
-            qint32 favorite = qjobject["favorite"].toInt();
+            qint8 favorite = static_cast<qint8>(qjobject["favorite"].toInt());
             QString service = qjobject["service"].toString().toLower();
             QString password = qjobject["password"].toString();
             QString description = qjobject["description"].toString();
             QJsonArray addrArray = qjobject["address"].toArray();
-            for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(addrArray[j].toInt()); }
+            for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(static_cast<char>(addrArray[j].toInt())); }
             qDebug() << "MMM Save: tackling " << login << " for service " << service << " at address " << nodeAddr.toHex();
 
             /* Find node in our list */
@@ -6992,8 +6994,8 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
         set_credentialsDbChangeNumber(get_credentialsDbChangeNumber() + 1);
         credentialsDbChangeNumberClone = get_credentialsDbChangeNumber();
         QByteArray updateChangeNumbersPacket = QByteArray();
-        updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
-        updateChangeNumbersPacket.append(get_dataDbChangeNumber());
+        updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
+        updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
         jobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
     }
 
@@ -7047,7 +7049,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 for (qint32 i = 0; i < mmmPasswordChangeArray.size(); i++)
                 {
                     QByteArray sdata = pMesProt->toByteArray(mmmPasswordChangeArray[i][0]);
-                    sdata.append((char)0);
+                    sdata.append(NULL_CHAR);
 
                     //First query if context exist
                     pwdChangeJobs->append(new MPCommandJob(this, MPCmd::CONTEXT,
@@ -7075,7 +7077,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                     }));
 
                     QByteArray ldata = pMesProt->toByteArray(mmmPasswordChangeArray[i][1]);
-                    ldata.append((char)0);
+                    ldata.append(NULL_CHAR);
 
                     pwdChangeJobs->append(new MPCommandJob(this, MPCmd::SET_LOGIN,
                                                   ldata,
@@ -7095,7 +7097,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                     }));
 
                     QByteArray pdata = pMesProt->toByteArray(mmmPasswordChangeArray[i][2]);
-                    pdata.append((char)0);
+                    pdata.append(NULL_CHAR);
 
                     pwdChangeJobs->append(new MPCommandJob(this, MPCmd::SET_PASSWORD,
                                                    pdata,

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -1398,7 +1398,7 @@ quint16 MPDevice::getNumberOfPages(void)
 
 quint16 MPDevice::getFlashPageFromAddress(const QByteArray &address)
 {
-    return (static_cast<quint16>(address[1] << 5) & 0x1FE0) | (static_cast<quint16>(address[0] >> 3) & 0x001F);
+    return ((static_cast<quint16>(address[1]) << 5) & 0x1FE0) | ((static_cast<quint16>(address[0]) >> 3) & 0x001F);
 }
 
 QByteArray MPDevice::getNextNodeAddressInMemory(const QByteArray &address)
@@ -1593,7 +1593,7 @@ void MPDevice::loadLoginNode(AsyncJobs *jobs, const QByteArray &address, const M
                         currentFirstCharVal = 'z';
                     if (currentFirstCharVal < 'a')
                         currentFirstCharVal = 'a';
-                    progressCurrent = static_cast<int>((static_cast<double>(currentFirstCharVal - 'a')) / static_cast<double>(('z' - 'a')) * 100);
+                    progressCurrent = (currentFirstCharVal - 'a') / (static_cast<double>('z' - 'a') * 100);
                     progressCurrent += MOOLTIPASS_FAV_MAX;
                 }
 
@@ -4887,42 +4887,42 @@ void MPDevice::changeVirtualAddressesToFreeAddresses(void)
 {
     if (virtualStartNode != 0)
     {
-        qDebug() << "Setting start node to " << freeAddresses[static_cast<int>(virtualStartNode)].toHex();
-        startNode = freeAddresses[static_cast<int>(virtualStartNode)];
+        qDebug() << "Setting start node to " << freeAddresses[virtualStartNode].toHex();
+        startNode = freeAddresses[virtualStartNode];
     }
     if (virtualDataStartNode != 0)
     {
-        qDebug() << "Setting data start node to " << freeAddresses[static_cast<int>(virtualDataStartNode)].toHex();
-        startDataNode = freeAddresses[static_cast<int>(virtualDataStartNode)];
+        qDebug() << "Setting data start node to " << freeAddresses[virtualDataStartNode].toHex();
+        startDataNode = freeAddresses[virtualDataStartNode];
     }
     qDebug() << "Replacing virtual addresses for login nodes...";
     for (auto &i: loginNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
-        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[static_cast<int>(i->getNextParentVirtualAddress())]);
-        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[static_cast<int>(i->getPreviousParentVirtualAddress())]);
-        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[static_cast<int>(i->getStartChildVirtualAddress())]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
+        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[i->getNextParentVirtualAddress()]);
+        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[i->getPreviousParentVirtualAddress()]);
+        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[i->getStartChildVirtualAddress()]);
     }
     qDebug() << "Replacing virtual addresses for child nodes...";
     for (auto &i: loginChildNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
-        if (i->getNextChildAddress().isNull()) i->setNextChildAddress(freeAddresses[static_cast<int>(i->getNextChildVirtualAddress())]);
-        if (i->getPreviousChildAddress().isNull()) i->setPreviousChildAddress(freeAddresses[static_cast<int>(i->getPreviousChildVirtualAddress())]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
+        if (i->getNextChildAddress().isNull()) i->setNextChildAddress(freeAddresses[i->getNextChildVirtualAddress()]);
+        if (i->getPreviousChildAddress().isNull()) i->setPreviousChildAddress(freeAddresses[i->getPreviousChildVirtualAddress()]);
     }
     qDebug() << "Replacing virtual addresses for data nodes...";
     for (auto &i: dataNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
-        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[static_cast<int>(i->getNextParentVirtualAddress())]);
-        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[static_cast<int>(i->getPreviousParentVirtualAddress())]);
-        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[static_cast<int>(i->getStartChildVirtualAddress())]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
+        if (i->getNextParentAddress().isNull()) i->setNextParentAddress(freeAddresses[i->getNextParentVirtualAddress()]);
+        if (i->getPreviousParentAddress().isNull()) i->setPreviousParentAddress(freeAddresses[i->getPreviousParentVirtualAddress()]);
+        if (i->getStartChildAddress().isNull()) i->setStartChildAddress(freeAddresses[i->getStartChildVirtualAddress()]);
     }
     qDebug() << "Replacing virtual addresses for data child nodes...";
     for (auto &i: dataChildNodes)
     {
-        if (i->getAddress().isNull()) i->setAddress(freeAddresses[static_cast<int>(i->getVirtualAddress())]);
-        if (i->getNextChildDataAddress().isNull()) i->setNextChildDataAddress(freeAddresses[static_cast<int>(i->getNextChildVirtualAddress())]);
+        if (i->getAddress().isNull()) i->setAddress(freeAddresses[i->getVirtualAddress()]);
+        if (i->getNextChildDataAddress().isNull()) i->setNextChildDataAddress(freeAddresses[i->getNextChildVirtualAddress()]);
     }
 }
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -1388,11 +1388,11 @@ quint16 MPDevice::getNumberOfPages(void)
 {
     if(get_flashMbSize() >= 16)
     {
-        return static_cast<quint16>(256*get_flashMbSize());
+        return 256*get_flashMbSize();
     }
     else
     {
-        return static_cast<quint16>(512*get_flashMbSize());
+        return 512*get_flashMbSize();
     }
 }
 
@@ -3560,8 +3560,8 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             qDebug() << "Cred DB: " << get_credentialsDbChangeNumber() << " clone: " << credentialsDbChangeNumberClone;
             qDebug() << "Data cred DB: " << get_dataDbChangeNumber() << " clone: " << dataDbChangeNumberClone;
             QByteArray updateChangeNumbersPacket = QByteArray();
-            updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
-            updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
+            updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
+            updateChangeNumbersPacket.append(get_dataDbChangeNumber());
             jobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
         }
     }
@@ -3676,7 +3676,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted service" << nodelist_iterator->getService();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, MAX_CHAR), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3689,7 +3689,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted login" << nodelist_iterator->getLogin();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, MAX_CHAR), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3703,7 +3703,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
                 qDebug() << "Generating favorite" << i << "update packet";
                 diagSavePacketsGenerated = true;
                 QByteArray updateFavPacket = QByteArray();
-                updateFavPacket.append(static_cast<char>(i));
+                updateFavPacket.append(i);
                 updateFavPacket.append(favoritesAddrs[i]);
                 jobs->append(new MPCommandJob(this, MPCmd::SET_FAVORITE, updateFavPacket, pMesProt->getDefaultFuncDone()));
             }
@@ -3727,7 +3727,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted data service" << nodelist_iterator->getService();
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, MAX_CHAR), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3740,7 +3740,7 @@ bool MPDevice::generateSavePackets(AsyncJobs *jobs, bool tackleCreds, bool tackl
             if (!temp_node_pointer)
             {
                 qDebug() << "Generating delete packet for deleted data child node";
-                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, static_cast<char>(0xFF)), dataWriteProgressCb);
+                addWriteNodePacketToJob(jobs, nodelist_iterator->getAddress(), QByteArray(MP_NODE_SIZE, MAX_CHAR), dataWriteProgressCb);
                 diagSavePacketsGenerated = true;
                 progressTotal += 3;
             }
@@ -3874,7 +3874,7 @@ void MPDevice::getUID(const QByteArray & key)
         data_to_send.clear();
         data_to_send.resize(16);
         for(int i = 0; i < 16; i++) {
-            data_to_send[i] = static_cast<char>(key.mid(2*i, 2).toUInt(&ok, 16));
+            data_to_send[i] = key.mid(2*i, 2).toUInt(&ok, 16);
             if(!ok)
                 return false;
         }
@@ -3892,7 +3892,7 @@ void MPDevice::getUID(const QByteArray & key)
 
         bool ok;
         quint64 uid = pMesProt->getFullPayload(data).toHex().toULongLong(&ok, 16);
-        set_uid(ok ? static_cast<qint64>(uid) : - 1);
+        set_uid(ok ? uid : - 1);
         return ok;
     }));
 
@@ -4607,7 +4607,7 @@ void MPDevice::getDataNode(QString service, const QString &fallback_service, con
         quint32 sz = qFromBigEndian<quint32>(ndata.data());
         qDebug() << "Data size: " << sz;
 
-        cb(true, QString(), m["service"].toString(), ndata.mid(4, static_cast<int>(sz)));
+        cb(true, QString(), m["service"].toString(), ndata.mid(4, sz));
     });
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
@@ -4852,8 +4852,8 @@ void  MPDevice::deleteDataNodesAndLeave(QStringList services,
                 dataDbChangeNumberClone = get_dataDbChangeNumber();
                 filesCache.setDbChangeNumber(get_dataDbChangeNumber());
                 QByteArray updateChangeNumbersPacket = QByteArray();
-                updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
-                updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
+                updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
+                updateChangeNumbersPacket.append(get_dataDbChangeNumber());
                 saveJobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
                 emit dbChangeNumbersChanged(get_credentialsDbChangeNumber(), get_dataDbChangeNumber());
             }
@@ -5347,18 +5347,18 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qInfo() << "Dealing with Moolticute export file";
         isMooltiAppImportFile = false;
-        importedCredentialsDbChangeNumber = static_cast<quint8>(dataArray[11].toInt());
+        importedCredentialsDbChangeNumber = dataArray[11].toInt();
         qDebug() << "Imported cred change number: " << importedCredentialsDbChangeNumber;
-        importedDataDbChangeNumber = static_cast<quint8>(dataArray[12].toInt());
+        importedDataDbChangeNumber = dataArray[12].toInt();
         qDebug() << "Imported data change number: " << importedDataDbChangeNumber;
-        importedDbMiniSerialNumber = static_cast<quint8>(dataArray[13].toInt());
+        importedDbMiniSerialNumber = dataArray[13].toInt();
         qDebug() << "Imported mini serial number: " << importedDbMiniSerialNumber;
     }
 
     /* Read CTR */
     importedCtrValue = QByteArray();
     auto qjobject = dataArray[0].toObject();
-    for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(static_cast<char>(qjobject[QString::number(i)].toInt()));}
+    for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(qjobject[QString::number(i)].toInt());}
     qDebug() << "Imported CTR: " << importedCtrValue.toHex();
 
     /* Read CPZ CTR values */
@@ -5367,7 +5367,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qjobject = qjarray[i].toObject();
         QByteArray qbarray = QByteArray();
-        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(static_cast<char>(qjobject[QString::number(j)].toInt()));}
+        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(qjobject[QString::number(j)].toInt());}
         qDebug() << "Imported CPZ/CTR value : " << qbarray.toHex();
         importedCpzCtrValue.append(qbarray);
     }
@@ -5393,13 +5393,13 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     /* Read Starting Parent */
     importedStartNode = QByteArray();
     qjarray = dataArray[2].toArray();
-    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(static_cast<char>(qjarray[i].toInt()));}
+    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(qjarray[i].toInt());}
     qDebug() << "Imported start node: " << importedStartNode.toHex();
 
     /* Read Data Starting Parent */
     importedStartDataNode = QByteArray();
     qjarray = dataArray[3].toArray();
-    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(static_cast<char>(qjarray[i].toInt()));}
+    for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(qjarray[i].toInt());}
     qDebug() << "Imported data start node: " << importedStartDataNode.toHex();
 
     /* Read favorites */
@@ -5408,7 +5408,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qjobject = qjarray[i].toObject();
         QByteArray qbarray = QByteArray();
-        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(static_cast<char>(qjobject[QString::number(j)].toInt()));}
+        for (qint32 j = 0; j < qjobject.size(); j++) {qbarray.append(qjobject[QString::number(j)].toInt());}
         qDebug() << "Imported favorite " << i << " : " << qbarray.toHex();
         importedFavoritesAddrs.append(qbarray);
     }
@@ -5422,12 +5422,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         /* Fetch address */
         QJsonArray serviceAddrArr = qjobject["address"].toArray();
         QByteArray serviceAddr = QByteArray();
-        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
+        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
 
         /* Fetch core data */
         QJsonObject dataObj = qjobject["data"].toObject();
         QByteArray dataCore = QByteArray();
-        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
+        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
 
         /* Recreate node and add it to the list of imported nodes */
         MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5444,12 +5444,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         /* Fetch address */
         QJsonArray serviceAddrArr = qjobject["address"].toArray();
         QByteArray serviceAddr = QByteArray();
-        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
+        for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
 
         /* Fetch core data */
         QJsonObject dataObj = qjobject["data"].toObject();
         QByteArray dataCore = QByteArray();
-        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
+        for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
 
         /* Recreate node and add it to the list of imported nodes */
         MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5468,12 +5468,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             /* Fetch address */
             QJsonArray serviceAddrArr = qjobject["address"].toArray();
             QByteArray serviceAddr = QByteArray();
-            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
+            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
 
             /* Fetch core data */
             QJsonObject dataObj = qjobject["data"].toObject();
             QByteArray dataCore = QByteArray();
-            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
+            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
 
             /* Recreate node and add it to the list of imported nodes */
             MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -5490,12 +5490,12 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             /* Fetch address */
             QJsonArray serviceAddrArr = qjobject["address"].toArray();
             QByteArray serviceAddr = QByteArray();
-            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(static_cast<char>(serviceAddrArr[j].toInt()));}
+            for (qint32 j = 0; j < serviceAddrArr.size(); j++) {serviceAddr.append(serviceAddrArr[j].toInt());}
 
             /* Fetch core data */
             QJsonObject dataObj = qjobject["data"].toObject();
             QByteArray dataCore = QByteArray();
-            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(static_cast<char>(dataObj[QString::number(j)].toInt()));}
+            for (qint32 j = 0; j < dataObj.size(); j++) {dataCore.append(dataObj[QString::number(j)].toInt());}
 
             /* Recreate node and add it to the list of imported nodes */
             MPNode* importedNode = new MPNode(dataCore, this, serviceAddr, 0);
@@ -6752,7 +6752,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
             QString password = qjobject["password"].toString();
             QString description = qjobject["description"].toString();
             QJsonArray addrArray = qjobject["address"].toArray();
-            for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(static_cast<char>(addrArray[j].toInt())); }
+            for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(addrArray[j].toInt()); }
             qDebug() << "MMM Save: tackling " << login << " for service " << service << " at address " << nodeAddr.toHex();
 
             /* Find node in our list */
@@ -6994,8 +6994,8 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
         set_credentialsDbChangeNumber(get_credentialsDbChangeNumber() + 1);
         credentialsDbChangeNumberClone = get_credentialsDbChangeNumber();
         QByteArray updateChangeNumbersPacket = QByteArray();
-        updateChangeNumbersPacket.append(static_cast<char>(get_credentialsDbChangeNumber()));
-        updateChangeNumbersPacket.append(static_cast<char>(get_dataDbChangeNumber()));
+        updateChangeNumbersPacket.append(get_credentialsDbChangeNumber());
+        updateChangeNumbersPacket.append(get_dataDbChangeNumber());
         jobs->append(new MPCommandJob(this, MPCmd::SET_USER_CHANGE_NB, updateChangeNumbersPacket, pMesProt->getDefaultFuncDone()));
     }
 

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -464,6 +464,7 @@ private:
 protected:
     DeviceType deviceType = DeviceType::MOOLTIPASS;
     const char NULL_CHAR = static_cast<char>(0);
+    const char MAX_CHAR = static_cast<char>(0xFF);
 };
 
 #endif // MPDEVICE_H

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -461,9 +461,9 @@ private:
     //Message Protocol
     IMessageProtocol *pMesProt = nullptr;
     MPDeviceBleImpl *bleImpl = nullptr;
-
 protected:
     DeviceType deviceType = DeviceType::MOOLTIPASS;
+    const char NULL_CHAR = static_cast<char>(0);
 };
 
 #endif // MPDEVICE_H

--- a/src/MPDevice_emul.cpp
+++ b/src/MPDevice_emul.cpp
@@ -19,7 +19,7 @@
 #include "MPDevice_emul.h"
 #include "MooltipassCmds.h"
 
-#define CLEAN_MEMORY_QBYTEARRAY(d) do {for (int i = 0; i < d.size(); i++){d[i] = qrand() % 256;}} while(0);
+#define CLEAN_MEMORY_QBYTEARRAY(d) do {for (int i = 0; i < d.size(); i++){d[i] = static_cast<char>(qrand() % 256);}} while(0);
 
 
 MPDevice_emul::MPDevice_emul(QObject *parent):
@@ -45,7 +45,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         d[1] = commandData;
         d[2] = 0x08;
         d.append("v1.0_emul");
-        d[0] = d.size() - 1;
+        d[0] = static_cast<char>(d.size() - 1);
         d.resize(64);
         sendReadSignal(d);
         CLEAN_MEMORY_QBYTEARRAY(d);
@@ -63,7 +63,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
     }
     case MPCmd::SET_MOOLTIPASS_PARM:
     {
-        mooltipassParam[data[2]] = data [3];
+        mooltipassParam[static_cast<unsigned char>(data[2])] = static_cast<unsigned char>(data[3]);
         QByteArray d;
         d[0] = 1;
         d[1] = commandData;
@@ -77,7 +77,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         QByteArray d;
         d[0] = 1;
         d[1] = commandData;
-        d[2] = mooltipassParam[data[2]];
+        d[2] = static_cast<char>(mooltipassParam[static_cast<unsigned char>(data[2])]);
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -87,7 +87,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         QByteArray d;
         d[0] = 0x01;
         d[1] = commandData;
-        d[2] = 0b101;
+        d[2] = 0x05;
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -109,7 +109,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         QByteArray d;
         d[0] = 1;
         d[1] = commandData;
-        d[2] = (quint8)logins.contains(context);
+        d[2] = static_cast<char>(logins.contains(context));
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -123,7 +123,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
             d.append(logins[context]);
         else
             d[2] = 0x0;
-        d[0] = d.length() - 2;
+        d[0] = static_cast<char>(d.length() - 2);
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -137,7 +137,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
             d.append(passwords[context]);
         else
             d[2] = 0x0;
-        d[0] = d.length() - 2;
+        d[0] = static_cast<char>(d.length() - 2);
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -207,7 +207,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
          d[0] = 32;
          d[1] = commandData;
          for (int i = 0; i < 32; i++)
-             d[2 + i] = qrand() % 255;
+             d[2 + i] = static_cast<char>(qrand() % 255);
          d.resize(64);
          sendReadSignal(d);
          break;
@@ -230,7 +230,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         d[0] = 8;
         d[1] = commandData;
         for (int i = 2; i < 10; i++)
-            d[i] = 0xFF;
+            d[i] = static_cast<char>(0xFF);
 
         d.resize(64);
         sendReadSignal(d);
@@ -239,7 +239,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
     case MPCmd::READ_FLASH_NODE: /* 0xC5 */
     {
         QByteArray d(134, 0x00);
-        d[0] = d.size() - 2;
+        d[0] = static_cast<char>(d.size() - 2);
         d[1] = commandData;
         d.resize(64);
         sendReadSignal(d);

--- a/src/MPDevice_emul.cpp
+++ b/src/MPDevice_emul.cpp
@@ -45,7 +45,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         d[1] = commandData;
         d[2] = 0x08;
         d.append("v1.0_emul");
-        d[0] = static_cast<char>(d.size() - 1);
+        d[0] = d.size() - 1;
         d.resize(64);
         sendReadSignal(d);
         CLEAN_MEMORY_QBYTEARRAY(d);
@@ -63,7 +63,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
     }
     case MPCmd::SET_MOOLTIPASS_PARM:
     {
-        mooltipassParam[static_cast<unsigned char>(data[2])] = static_cast<unsigned char>(data[3]);
+        mooltipassParam[data[2]] = data[3];
         QByteArray d;
         d[0] = 1;
         d[1] = commandData;
@@ -77,7 +77,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         QByteArray d;
         d[0] = 1;
         d[1] = commandData;
-        d[2] = static_cast<char>(mooltipassParam[static_cast<unsigned char>(data[2])]);
+        d[2] = mooltipassParam[data[2]];
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -123,7 +123,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
             d.append(logins[context]);
         else
             d[2] = 0x0;
-        d[0] = static_cast<char>(d.length() - 2);
+        d[0] = d.length() - 2;
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -137,7 +137,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
             d.append(passwords[context]);
         else
             d[2] = 0x0;
-        d[0] = static_cast<char>(d.length() - 2);
+        d[0] = d.length() - 2;
         d.resize(64);
         sendReadSignal(d);
         break;
@@ -207,7 +207,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
          d[0] = 32;
          d[1] = commandData;
          for (int i = 0; i < 32; i++)
-             d[2 + i] = static_cast<char>(qrand() % 255);
+             d[2 + i] = qrand() % 255;
          d.resize(64);
          sendReadSignal(d);
          break;
@@ -230,7 +230,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
         d[0] = 8;
         d[1] = commandData;
         for (int i = 2; i < 10; i++)
-            d[i] = static_cast<char>(0xFF);
+            d[i] = MAX_CHAR;
 
         d.resize(64);
         sendReadSignal(d);
@@ -239,7 +239,7 @@ void MPDevice_emul::platformWrite(const QByteArray &data)
     case MPCmd::READ_FLASH_NODE: /* 0xC5 */
     {
         QByteArray d(134, 0x00);
-        d[0] = static_cast<char>(d.size() - 2);
+        d[0] = d.size() - 2;
         d[1] = commandData;
         d.resize(64);
         sendReadSignal(d);

--- a/src/MPDevice_mac.cpp
+++ b/src/MPDevice_mac.cpp
@@ -34,7 +34,7 @@ void _read_report_callback(void *context,
     Q_UNUSED(report_id);
 
     MPDevice_mac *dev = reinterpret_cast<MPDevice_mac *>(context);
-    QByteArray data((const char *)report, report_length);
+    QByteArray data(reinterpret_cast<const char *>(report), static_cast<int>(report_length));
     emit dev->platformDataRead(data);
 }
 
@@ -65,13 +65,13 @@ MPDevice_mac::MPDevice_mac(QObject *parent, const MPPlatformDef &platformDef):
     //Get max input report length
     CFTypeRef ref = IOHIDDeviceGetProperty(hidref, CFSTR(kIOHIDMaxInputReportSizeKey));
     if (ref && CFGetTypeID(ref) == CFNumberGetTypeID())
-        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &maxInReportLen);
+        CFNumberGetValue(static_cast<CFNumberRef>(ref), kCFNumberSInt32Type, &maxInReportLen);
 
     readBuf.resize(maxInReportLen);
 
     //Attach a callback that will be triggered when data comes in
     IOHIDDeviceRegisterInputReportCallback(hidref,
-                                           (uint8_t *)readBuf.data(),
+                                           reinterpret_cast<uint8_t *>(readBuf.data()),
                                            readBuf.size(),
                                            &_read_report_callback,
                                            this);
@@ -110,7 +110,7 @@ void MPDevice_mac::platformWrite(const QByteArray &data)
         IOReturn res = IOHIDDeviceSetReport(hidref,
                                             kIOHIDReportTypeOutput,
                                             0,
-                                            (const uint8_t *)data.constData(),
+                                            reinterpret_cast<const uint8_t *>(data.constData()),
                                             data.size());
         if (res != kIOReturnSuccess)
             qWarning() << "Failed to write data to device";

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -321,7 +321,7 @@ void MPDevice_win::ovlpNotified(quint32 numberOfBytes, quint32 errorCode, OVERLA
             return;
         }
 
-        readBuffer.resize(static_cast<int>(numberOfBytes));
+        readBuffer.resize(numberOfBytes);
         emit platformDataRead(readBuffer.right(readBuffer.length() - 1));
 
         platformRead();

--- a/src/MPManager.cpp
+++ b/src/MPManager.cpp
@@ -97,10 +97,6 @@ void MPManager::usbDeviceRemoved()
 
 void MPManager::usbDeviceAdded(QString path)
 {
-#if defined(Q_OS_LINUX)
-    Q_UNUSED(path);
-    return;
-#endif
     if (!devices.contains(path))
     {
         MPDevice *device = nullptr;

--- a/src/MPNode.cpp
+++ b/src/MPNode.cpp
@@ -51,7 +51,7 @@ void MPNode::setType(const quint8 type)
 {
     if (data.size() > 1)
     {
-        data[1] = static_cast<char>(type << 6);
+        data[1] = type << 6;
     }
 }
 

--- a/src/MPNode.cpp
+++ b/src/MPNode.cpp
@@ -43,7 +43,7 @@ MPNode::MPNode(QObject *parent, const QByteArray &nodeAddress, const quint32 vir
 int MPNode::getType() const
 {
     if (data.size() > 1)
-        return ((quint8)data[1] >> 6) & 0x03;
+        return (static_cast<quint8>(data[1]) >> 6) & 0x03;
     return -1;
 }
 
@@ -51,7 +51,7 @@ void MPNode::setType(const quint8 type)
 {
     if (data.size() > 1)
     {
-        data[1] = type << 6;
+        data[1] = static_cast<char>(type << 6);
     }
 }
 
@@ -59,7 +59,7 @@ bool MPNode::isValid() const
 {
     return getType() != NodeUnknown &&
            data.size() == MP_NODE_SIZE &&
-           ((quint8)data[1] & 0x20) == 0;
+           (static_cast<quint8>(data[1]) & 0x20) == 0;
 }
 
 bool MPNode::isDataLengthValid() const

--- a/src/MacUtils.mm
+++ b/src/MacUtils.mm
@@ -59,13 +59,13 @@ LSSharedFileListItemRef FindLoginItemForCurrentBundle(CFArrayRef currentLoginIte
 {
     CFURLRef mainBundleURL = CFBundleCopyBundleURL(CFBundleGetMainBundle());
 
-    for (int i = 0, end = CFArrayGetCount(currentLoginItems);i < end;++i)
+    for (int i = 0, end = static_cast<int>(CFArrayGetCount(currentLoginItems)); i < end; ++i)
     {
         LSSharedFileListItemRef item = (LSSharedFileListItemRef)CFArrayGetValueAtIndex(currentLoginItems, i);
 
         UInt32 resolutionFlags = kLSSharedFileListNoUserInteraction | kLSSharedFileListDoNotMountVolumes;
-        CFURLRef url = NULL;
-        OSStatus err = LSSharedFileListItemResolve(item, resolutionFlags, &url, NULL);
+        CFURLRef url = nullptr;
+        OSStatus err = LSSharedFileListItemResolve(item, resolutionFlags, &url, nullptr);
 
         if (err == noErr)
         {
@@ -81,12 +81,12 @@ LSSharedFileListItemRef FindLoginItemForCurrentBundle(CFArrayRef currentLoginIte
     }
 
     CFRelease(mainBundleURL);
-    return NULL;
+    return nullptr;
 }
 
 void setAutoStartup(bool en)
 {
-    LSSharedFileListRef loginItems = LSSharedFileListCreate(NULL, kLSSharedFileListSessionLoginItems, NULL);
+    LSSharedFileListRef loginItems = LSSharedFileListCreate(nullptr, kLSSharedFileListSessionLoginItems, nullptr);
 
     if (!loginItems)
     {
@@ -98,13 +98,13 @@ void setAutoStartup(bool en)
     CFArrayRef currentLoginItems = LSSharedFileListCopySnapshot(loginItems, &seed);
     LSSharedFileListItemRef existingItem = FindLoginItemForCurrentBundle(currentLoginItems);
 
-    if (en && (existingItem == NULL))
+    if (en && (existingItem == nullptr))
     {
         CFURLRef mainBundleURL = CFBundleCopyBundleURL(CFBundleGetMainBundle());
-        LSSharedFileListInsertItemURL(loginItems, kLSSharedFileListItemBeforeFirst, NULL, NULL, mainBundleURL, NULL, NULL);
+        LSSharedFileListInsertItemURL(loginItems, kLSSharedFileListItemBeforeFirst, nullptr, nullptr, mainBundleURL, nullptr, nullptr);
         CFRelease(mainBundleURL);
     }
-    else if (!en && (existingItem != NULL))
+    else if (!en && (existingItem != nullptr))
     {
         LSSharedFileListItemRemove(loginItems, existingItem);
     }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -337,14 +337,17 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     using LF = Common::LockUnlockModeFeatureFlags;
 
-    ui->lockUnlockModeComboBox->addItem(tr("Disabled")          , (uint)LF::Disabled);
-    ui->lockUnlockModeComboBox->addItem(tr("Password Only")     , (uint)LF::Password);
-    ui->lockUnlockModeComboBox->addItem(tr("Login + Password")  , (uint)LF::Password|(uint)LF::Login);
-    ui->lockUnlockModeComboBox->addItem(tr("Enter + Password")  , (uint)LF::Password|(uint)LF::SendEnter);
-    ui->lockUnlockModeComboBox->addItem(tr("Password / Win + L")  , (uint)LF::Password|(uint)LF::SendWin_L);
-    ui->lockUnlockModeComboBox->addItem(tr("Login + Pass / Win + L"), (uint)LF::Password|(uint)LF::Login|(uint)LF::SendWin_L);
-    ui->lockUnlockModeComboBox->addItem(tr("Enter + Pass / Win + L"), (uint)LF::Password|(uint)LF::SendEnter|(uint)LF::SendWin_L);
-    ui->lockUnlockModeComboBox->addItem(tr("Ctrl + Alt + Del / Win + L"), (uint)LF::SendCtrl_Alt_Del|(uint)LF::Password|(uint)LF::SendWin_L);
+    ui->lockUnlockModeComboBox->addItem(tr("Disabled")          , static_cast<uint>(LF::Disabled));
+    ui->lockUnlockModeComboBox->addItem(tr("Password Only")     , static_cast<uint>(LF::Password));
+    ui->lockUnlockModeComboBox->addItem(tr("Login + Password")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::Login));
+    ui->lockUnlockModeComboBox->addItem(tr("Enter + Password")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendEnter));
+    ui->lockUnlockModeComboBox->addItem(tr("Password / Win + L")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Login + Pass / Win + L"), static_cast<uint>(LF::Password)|
+                                        static_cast<uint>(LF::Login)|static_cast<uint>(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Enter + Pass / Win + L"), static_cast<uint>(LF::Password)|
+                                        static_cast<uint>(LF::SendEnter)|static_cast<uint>(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Ctrl + Alt + Del / Win + L"), static_cast<uint>(LF::SendCtrl_Alt_Del)|
+                                        static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendWin_L));
     ui->lockUnlockModeComboBox->setCurrentIndex(0);
 
     ui->comboBoxSystrayIcon->blockSignals(true);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -336,18 +336,19 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 #endif
 
     using LF = Common::LockUnlockModeFeatureFlags;
+    auto value = [](LF val) {return Common::getEnumValue(val);};
 
-    ui->lockUnlockModeComboBox->addItem(tr("Disabled")          , static_cast<uint>(LF::Disabled));
-    ui->lockUnlockModeComboBox->addItem(tr("Password Only")     , static_cast<uint>(LF::Password));
-    ui->lockUnlockModeComboBox->addItem(tr("Login + Password")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::Login));
-    ui->lockUnlockModeComboBox->addItem(tr("Enter + Password")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendEnter));
-    ui->lockUnlockModeComboBox->addItem(tr("Password / Win + L")  , static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendWin_L));
-    ui->lockUnlockModeComboBox->addItem(tr("Login + Pass / Win + L"), static_cast<uint>(LF::Password)|
-                                        static_cast<uint>(LF::Login)|static_cast<uint>(LF::SendWin_L));
-    ui->lockUnlockModeComboBox->addItem(tr("Enter + Pass / Win + L"), static_cast<uint>(LF::Password)|
-                                        static_cast<uint>(LF::SendEnter)|static_cast<uint>(LF::SendWin_L));
-    ui->lockUnlockModeComboBox->addItem(tr("Ctrl + Alt + Del / Win + L"), static_cast<uint>(LF::SendCtrl_Alt_Del)|
-                                        static_cast<uint>(LF::Password)|static_cast<uint>(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Disabled")          , value(LF::Disabled));
+    ui->lockUnlockModeComboBox->addItem(tr("Password Only")     , value(LF::Password));
+    ui->lockUnlockModeComboBox->addItem(tr("Login + Password")  , value(LF::Password)|value(LF::Login));
+    ui->lockUnlockModeComboBox->addItem(tr("Enter + Password")  , value(LF::Password)|value(LF::SendEnter));
+    ui->lockUnlockModeComboBox->addItem(tr("Password / Win + L")  , value(LF::Password)|value(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Login + Pass / Win + L"), value(LF::Password)|
+                                        value(LF::Login)|value(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Enter + Pass / Win + L"), value(LF::Password)|
+                                        value(LF::SendEnter)|value(LF::SendWin_L));
+    ui->lockUnlockModeComboBox->addItem(tr("Ctrl + Alt + Del / Win + L"), value(LF::SendCtrl_Alt_Del)|
+                                        value(LF::Password)|value(LF::SendWin_L));
     ui->lockUnlockModeComboBox->setCurrentIndex(0);
 
     ui->comboBoxSystrayIcon->blockSignals(true);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -39,7 +39,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent = 0);
+    explicit MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent = nullptr);
     ~MainWindow();
 
     void daemonLogAppend(const QByteArray &logdata);

--- a/src/MessageProtocol/IMessageProtocol.h
+++ b/src/MessageProtocol/IMessageProtocol.h
@@ -129,7 +129,7 @@ public:
 
     quint16 toIntFromLittleEndian(quint8 lowerByte, quint8 upperByte)
     {
-        return (lowerByte|(upperByte<<8));
+        return static_cast<quint16>(lowerByte|(upperByte<<8));
     }
 
     QByteArray toLittleEndianFromInt(quint16 num)

--- a/src/MessageProtocol/MessageProtocolMini.cpp
+++ b/src/MessageProtocol/MessageProtocolMini.cpp
@@ -78,7 +78,7 @@ QVector<QByteArray> MessageProtocolMini::createWriteNodePackets(const QByteArray
 
         QByteArray packetToSend = QByteArray();
         packetToSend.append(address);
-        packetToSend.append(i);
+        packetToSend.append(static_cast<char>(i));
         packetToSend.append(data.mid(i*59, payload_size-3));
         createdPackets.append(packetToSend);
     }

--- a/src/MooltipassCmds.cpp
+++ b/src/MooltipassCmds.cpp
@@ -41,7 +41,7 @@ bool MPCmd::isUserRequired(Command c)
 
 QString MPCmd::toHexString(Command c)
 {
-    return QString("0x%1").arg((quint16)c, 4, 16, QChar('0'));
+    return QString("0x%1").arg(static_cast<quint16>(c), 4, 16, QChar('0'));
 }
 
 QString MPCmd::toHexString(quint16 c)

--- a/src/OutputLog.h
+++ b/src/OutputLog.h
@@ -27,7 +27,7 @@ class OutputLog : public QPlainTextEdit
 {
     Q_OBJECT
 public:
-    OutputLog(QWidget *parent = 0);
+    OutputLog(QWidget *parent = nullptr);
     ~OutputLog();
 
     void appendMessage(const QString &out, const QTextCharFormat &format = QTextCharFormat());

--- a/src/PassGenerationProfilesDialog.cpp
+++ b/src/PassGenerationProfilesDialog.cpp
@@ -69,7 +69,7 @@ PassGenerationProfilesDialog::PassGenerationProfilesDialog(QWidget *parent) :
     ui->widgetSpecialSymbols->setLayout(lay);
 
     // Generate buttons for toggling special symbols and place them in 3 rows
-    int countInRow = int(std::ceil(kSymbols.size() / (double)kRows));
+    int countInRow = int(std::ceil(kSymbols.size() / static_cast<double>(kRows)));
     QHBoxLayout *rowLayout = new QHBoxLayout;
     lay->addLayout(rowLayout);
 

--- a/src/PassGenerationProfilesDialog.h
+++ b/src/PassGenerationProfilesDialog.h
@@ -37,7 +37,7 @@ class PassGenerationProfilesDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit PassGenerationProfilesDialog(QWidget *parent = 0);
+    explicit PassGenerationProfilesDialog(QWidget *parent = nullptr);
     ~PassGenerationProfilesDialog();
 
     void setPasswordProfilesModel(PasswordProfilesModel *model);

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -316,11 +316,11 @@ void PasswordOptionsPopup::generatePassword()
     result.resize(length);
 
     // Create a distribution based on the pool size
-    std::uniform_int_distribution<char> distribution(0, static_cast<char>(pool.size() - 1));
+    std::uniform_int_distribution<char> distribution(0, pool.size() - 1);
 
     //Fill the password with random characters
     for (int i = 0; i < length; i++)
-        result[i] = pool.at(static_cast<size_t>(distribution(m_random_generator)));
+        result[i] = pool.at(distribution(m_random_generator));
 
     //Done
     m_passwordLabel->setText(result);
@@ -330,7 +330,7 @@ void PasswordOptionsPopup::generatePassword()
     if (entropy > m_strengthBar->maximum())
         entropy = m_strengthBar->maximum();
 
-    m_strengthBar->setValue(static_cast<int>(entropy));
+    m_strengthBar->setValue(entropy);
 
     QString style = QStringLiteral(PROGRESS_STYLE);
     if (entropy < 35)
@@ -373,7 +373,7 @@ std::vector<char> PasswordOptionsPopup::generateCustomPasswordPool()
         poolSize += kSymbols.size();
     }
 
-    pool.resize(static_cast<size_t>(poolSize));
+    pool.resize(poolSize);
     //Fill the pool
     auto it = std::begin(pool);
     if (m_upperCaseCB->isChecked())

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -268,7 +268,7 @@ LockedPasswordLineEdit::LockedPasswordLineEdit(QWidget* parent):
     PasswordLineEdit(parent),
     m_locked(false)
 {
-    disconnect(m_showPassword, 0, 0, 0);
+    disconnect(m_showPassword, nullptr, nullptr, nullptr);
 
     connect(m_showPassword, &QAction::triggered, [this]()
     {
@@ -316,21 +316,21 @@ void PasswordOptionsPopup::generatePassword()
     result.resize(length);
 
     // Create a distribution based on the pool size
-    std::uniform_int_distribution<char> distribution(0, pool.size() - 1);
+    std::uniform_int_distribution<char> distribution(0, static_cast<char>(pool.size() - 1));
 
     //Fill the password with random characters
     for (int i = 0; i < length; i++)
-        result[i] = pool.at(distribution(m_random_generator));
+        result[i] = pool.at(static_cast<size_t>(distribution(m_random_generator)));
 
     //Done
     m_passwordLabel->setText(result);
 
-    double entropy = ZxcvbnMatch(result, 0, 0);
+    double entropy = ZxcvbnMatch(result, nullptr, nullptr);
     m_entropy->setText(tr("Entropy: %1 bit").arg(QString::number(entropy, 'f', 2)));
     if (entropy > m_strengthBar->maximum())
         entropy = m_strengthBar->maximum();
 
-    m_strengthBar->setValue(entropy);
+    m_strengthBar->setValue(static_cast<int>(entropy));
 
     QString style = QStringLiteral(PROGRESS_STYLE);
     if (entropy < 35)
@@ -373,7 +373,7 @@ std::vector<char> PasswordOptionsPopup::generateCustomPasswordPool()
         poolSize += kSymbols.size();
     }
 
-    pool.resize(poolSize);
+    pool.resize(static_cast<size_t>(poolSize));
     //Fill the pool
     auto it = std::begin(pool);
     if (m_upperCaseCB->isChecked())

--- a/src/PasswordProfilesModel.cpp
+++ b/src/PasswordProfilesModel.cpp
@@ -441,7 +441,7 @@ void PasswordProfilesModel::removeProfile(const QString &name)
         {
             if (profile->getName() == name && profile->isEditable())
             {
-                int index = it - m_profiles.begin();
+                int index = static_cast<int>(it - m_profiles.begin());
 
                 beginRemoveRows(QModelIndex(), index, index);
                 delete *it;

--- a/src/PasswordProfilesModel.cpp
+++ b/src/PasswordProfilesModel.cpp
@@ -266,7 +266,7 @@ void PasswordProfile::init()
     if (poolSize == 0)
         return;
 
-    m_pool.resize(static_cast<size_t>(poolSize));
+    m_pool.resize(poolSize);
 
     //Fill the pool
     auto it = std::begin(m_pool);
@@ -441,7 +441,7 @@ void PasswordProfilesModel::removeProfile(const QString &name)
         {
             if (profile->getName() == name && profile->isEditable())
             {
-                int index = static_cast<int>(it - m_profiles.begin());
+                int index = it - m_profiles.begin();
 
                 beginRemoveRows(QModelIndex(), index, index);
                 delete *it;

--- a/src/PasswordProfilesModel.cpp
+++ b/src/PasswordProfilesModel.cpp
@@ -266,7 +266,7 @@ void PasswordProfile::init()
     if (poolSize == 0)
         return;
 
-    m_pool.resize(poolSize);
+    m_pool.resize(static_cast<size_t>(poolSize));
 
     //Fill the pool
     auto it = std::begin(m_pool);

--- a/src/RootItem.h
+++ b/src/RootItem.h
@@ -9,7 +9,7 @@ class RootItem : public TreeItem
 {
 public:
     RootItem();
-    virtual ~RootItem();
+    virtual ~RootItem() override;
 
     ServiceItem *addService(const QString &sServiceName);
     ServiceItem *findServiceByName(const QString &sServiceName);

--- a/src/SSHManagement.h
+++ b/src/SSHManagement.h
@@ -32,7 +32,7 @@ class SSHManagement : public QWidget
     Q_OBJECT
 
 public:
-    explicit SSHManagement(QWidget *parent = 0);
+    explicit SSHManagement(QWidget *parent = nullptr);
     ~SSHManagement();
 
     void setWsClient(WSClient *c);

--- a/src/ServiceItem.h
+++ b/src/ServiceItem.h
@@ -9,7 +9,7 @@ class ServiceItem : public TreeItem
 {
 public:
     ServiceItem(const QString &sServiceName);
-    virtual ~ServiceItem();
+    virtual ~ServiceItem() override;
 
     LoginItem *addLogin(const QString &sLoginName);
     LoginItem *findLoginByName(const QString &sLoginName);

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -148,7 +148,7 @@ bool SystemEventHandler::nativeEventFilter(const QByteArray &eventType, void *me
 #ifdef Q_OS_WIN
     if (eventType == "windows_generic_MSG" || eventType == "windows_dispatcher_MSG")
     {
-        const auto *msg = (MSG*) message;
+        const auto *msg = static_cast<MSG*>(message);
         if (msg->message == WM_ENDSESSION || msg->message == WM_QUERYENDSESSION)
         {
             if (msg->lParam == static_cast<int>(ENDSESSION_LOGOFF))

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -14,7 +14,7 @@ class SystemEventHandler : public QObject, QAbstractNativeEventFilter
 
 public:
     SystemEventHandler();
-    virtual ~SystemEventHandler();
+    virtual ~SystemEventHandler() override;
 
     void emitEvent(const SystemEvent event);
     static void triggerEvent(const int type, void *instance);

--- a/src/SystemNotifications/SystemNotificationImageUnix.cpp
+++ b/src/SystemNotifications/SystemNotificationImageUnix.cpp
@@ -8,7 +8,7 @@ int SystemNotificationImageUnix::imageHintID = qDBusRegisterMetaType<SystemNotif
 SystemNotificationImageUnix::SystemNotificationImageUnix(const QImage &img)
 {
     QImage image(img.convertToFormat(QImage::Format_ARGB32).rgbSwapped());
-    imageData = QByteArray((char *)image.bits(), image.byteCount());
+    imageData = QByteArray(reinterpret_cast<char*>(image.bits()), image.byteCount());
     width = image.width();
     height = image.height();
     rowstride = image.bytesPerLine();
@@ -20,7 +20,7 @@ SystemNotificationImageUnix::SystemNotificationImageUnix(const QImage &img)
 
 QImage SystemNotificationImageUnix::toQImage() const
 {
-    return QImage((uchar *)imageData.data(), width, height, QImage::Format_ARGB32).rgbSwapped();
+    return QImage(reinterpret_cast<const uchar*>(imageData.data()), width, height, QImage::Format_ARGB32).rgbSwapped();
 }
 
 QDBusArgument &operator<<(QDBusArgument &a, const SystemNotificationImageUnix &i)

--- a/src/UsbMonitor_mac.cpp
+++ b/src/UsbMonitor_mac.cpp
@@ -28,7 +28,7 @@ void _device_matching_callback(void *user_data,
     UsbMonitor_mac *um = reinterpret_cast<UsbMonitor_mac *>(user_data);
 
     int vendorID = 0;
-    CFNumberRef vendorNumRef = (CFNumberRef)IOHIDDeviceGetProperty(inIOHIDDeviceRef, CFSTR(kIOHIDVendorIDKey)) ;
+    CFNumberRef vendorNumRef = static_cast<CFNumberRef>(IOHIDDeviceGetProperty(inIOHIDDeviceRef, CFSTR(kIOHIDVendorIDKey))) ;
     if (vendorNumRef)
     {
         CFNumberGetValue(vendorNumRef, kCFNumberSInt32Type, &vendorID);
@@ -40,7 +40,7 @@ void _device_matching_callback(void *user_data,
 
     MPPlatformDef def;
     def.hidref = inIOHIDDeviceRef;
-    def.id = QString("%1").arg((quint64)def.hidref);
+    def.id = QString("%1").arg(reinterpret_cast<quint64>(def.hidref));
     def.isBLE = vendorID == MOOLTIPASS_BLE_VENDORID;
 
     if (!um->deviceHash.contains(def.id))
@@ -60,7 +60,7 @@ void _device_removal_callback(void *user_data,
     Q_UNUSED(inSender);
     UsbMonitor_mac *um = reinterpret_cast<UsbMonitor_mac *>(user_data);
 
-    QString hid_id = QString("%1").arg((quint64)inIOHIDDeviceRef);
+    QString hid_id = QString("%1").arg(reinterpret_cast<quint64>(inIOHIDDeviceRef));
     if (um->deviceHash.contains(hid_id))
     {
         MPPlatformDef def = um->deviceHash[hid_id];

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -196,7 +196,7 @@ void WSClient::onTextMessageReceived(const QString &message)
             set_mpHwVersion(Common::MP_Classic);
         }
         set_fwVersion(o["hw_version"].toString());
-        set_hwSerial(static_cast<quint32>(o["hw_serial"].toInt()));
+        set_hwSerial(o["hw_serial"].toInt());
         set_hwMemory(o["flash_size"].toInt());
     }
     else if (rootobj["msg"] == "request_domain")

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -158,7 +158,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     }
     else if (rootobj["msg"] == "param_changed")
     {
-        udateParameters(rootobj["data"].toObject());
+        updateParameters(rootobj["data"].toObject());
     }
     else if (rootobj["msg"] == "memorymgmt_changed")
     {
@@ -196,7 +196,7 @@ void WSClient::onTextMessageReceived(const QString &message)
             set_mpHwVersion(Common::MP_Classic);
         }
         set_fwVersion(o["hw_version"].toString());
-        set_hwSerial(o["hw_serial"].toInt());
+        set_hwSerial(static_cast<quint32>(o["hw_serial"].toInt()));
         set_hwMemory(o["flash_size"].toInt());
     }
     else if (rootobj["msg"] == "request_domain")
@@ -316,7 +316,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if (rootobj["msg"] == "device_uid")
     {
         QJsonObject o = rootobj["data"].toObject();
-        set_uid((qint64)o["uid"].toDouble());
+        set_uid(static_cast<qint64>(o["uid"].toDouble()));
     }
     else if (rootobj["msg"] == "get_data_node")
     {
@@ -444,7 +444,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     }
 }
 
-void WSClient::udateParameters(const QJsonObject &data)
+void WSClient::updateParameters(const QJsonObject &data)
 {
     QString param = data["parameter"].toString();
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -164,7 +164,7 @@ private slots:
     void onTextMessageReceived(const QString &message);
 
 private:
-    void udateParameters(const QJsonObject &data);
+    void updateParameters(const QJsonObject &data);
 
     QWebSocket *wsocket = nullptr;
 

--- a/src/WindowLog.h
+++ b/src/WindowLog.h
@@ -31,7 +31,7 @@ class WindowLog : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit WindowLog(QWidget *parent = 0);
+    explicit WindowLog(QWidget *parent = nullptr);
     ~WindowLog();
 
     void appendData(const QByteArray &logdata);

--- a/src/qwinoverlappedionotifier.cpp
+++ b/src/qwinoverlappedionotifier.cpp
@@ -222,7 +222,7 @@ protected:
                     SetEvent(hQueueDrainedEvent);
                     continue;
                 }
-                qErrnoWarning(static_cast<int>(errorCode), "GetQueuedCompletionStatus failed.");
+                qErrnoWarning(errorCode, "GetQueuedCompletionStatus failed.");
                 return;
             }
 

--- a/src/qwinoverlappedionotifier.h
+++ b/src/qwinoverlappedionotifier.h
@@ -69,7 +69,7 @@ class QWinOverlappedIoNotifier : public QObject
     Q_PRIVATE_SLOT(d_func(), void _q_notified())
     friend class QWinIoCompletionPort;
 public:
-    QWinOverlappedIoNotifier(QObject *parent = 0);
+    QWinOverlappedIoNotifier(QObject *parent = nullptr);
     ~QWinOverlappedIoNotifier();
 
     void setHandle(Qt::HANDLE h);


### PR DESCRIPTION
**Eliminated the following warnings:**
- Old style casts
- Type conversions
- Precision loss conversions
- NULL or 0 usage instead of nullptr
- Missing override specifier

Some warnings which are from 3rd party libraries remained. (e.g.:winapi)