### PR TITLE
Change message to informativeText instead of subtitle for system noti…

### DIFF
--- a/src/SystemNotifications/MacNotify.mm
+++ b/src/SystemNotifications/MacNotify.mm
@@ -87,7 +87,7 @@ void MacNotify::showNotification(const QString &title, const QString &text)
 {
     NSUserNotification *userNotification = [[NSUserNotification alloc] init];
     userNotification.title = title.toNSString();
-    userNotification.subtitle = text.toNSString();
+    userNotification.informativeText = text.toNSString();
     userNotification.soundName = NSUserNotificationDefaultSoundName;
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:userNotification];
@@ -97,7 +97,7 @@ void MacNotify::showButtonNotification(const QString &title, const QString &text
 {
     NSUserNotification *userNotification = [[NSUserNotification alloc] init];
     userNotification.title = title.toNSString();
-    userNotification.subtitle = text.toNSString();
+    userNotification.informativeText = text.toNSString();
     userNotification.soundName = NSUserNotificationDefaultSoundName;
     userNotification.hasActionButton = true;
     userNotification.actionButtonTitle = QString(tr("Choose")).toNSString();
@@ -120,7 +120,7 @@ void MacNotify::showTextBoxNotification(const QString &title, const QString &tex
 {
     NSUserNotification *userNotification = [[NSUserNotification alloc] init];
     userNotification.title = title.toNSString();
-    userNotification.subtitle = text.toNSString();
+    userNotification.informativeText = text.toNSString();
     userNotification.soundName = NSUserNotificationDefaultSoundName;
     userNotification.hasReplyButton = true;
     userNotification.responsePlaceholder = QString(tr("Type your reply here")).toNSString();


### PR DESCRIPTION
…fication on Mac

### Issue:
On Mac longer message of the system notification (e.g.: Have I been pwned notficiation) was cut:
![Screen Shot 2019-04-07 at 9 33 30 PM](https://user-images.githubusercontent.com/11043249/55688912-a32e9080-597e-11e9-9d47-67651d8f9a3e.png)

After I changed the message to informativeText it is showing the full message:
![Screen Shot 2019-04-07 at 9 38 40 PM](https://user-images.githubusercontent.com/11043249/55688924-bccfd800-597e-11e9-858b-0fe41ea813b7.png)
