### PR TITLE
Move string translation to gui from daemon

### DIFF
--- a/src/HaveIBeenPwned.cpp
+++ b/src/HaveIBeenPwned.cpp
@@ -13,16 +13,16 @@ HaveIBeenPwned::HaveIBeenPwned(QObject *parent) :
 /**
  * @brief HaveIBeenPwned::isPasswordPwned
  * @param pwd Given password to check
- * @param formatString Formatting the response
+ * @param credInfo "service: login"
  * Calculating the SHA1 hash of the password
  * and sending the first five char to HIBP v2 API.
  */
-void HaveIBeenPwned::isPasswordPwned(const QString &pwd, const QString &formatString)
+void HaveIBeenPwned::isPasswordPwned(const QString &pwd, const QString &credInfo)
 {
     QCryptographicHash sha1Hasher(QCryptographicHash::Sha1);
     sha1Hasher.addData(pwd.toUtf8());
     hash = sha1Hasher.result().toHex().toUpper();
-    this->formatString = formatString;
+    this->credInfo = credInfo;
     req.setUrl(QUrl(HIBP_API + hash.left(HIBP_REQUEST_SHA_LENGTH)));
     hash = hash.mid(HIBP_REQUEST_SHA_LENGTH);
     networkManager->get(req);
@@ -52,7 +52,7 @@ void HaveIBeenPwned::processReply(QNetworkReply *reply)
         QString fromPwned = answer.mid(answer.indexOf(hash));
         QString pwned = fromPwned.left(fromPwned.indexOf(HASH_SEPARATOR));
         QString pwnedNum = pwned.mid(pwned.indexOf(':') + 1);
-        emit sendPwnedMessage(formatString.arg(pwnedNum));
+        emit sendPwnedMessage(credInfo, pwnedNum);
     }
     else
     {

--- a/src/HaveIBeenPwned.h
+++ b/src/HaveIBeenPwned.h
@@ -11,16 +11,17 @@ class HaveIBeenPwned : public QObject
 public:
     explicit HaveIBeenPwned(QObject *parent = nullptr);
 
-    void isPasswordPwned(const QString &pwd, const QString &formatString);
+    void isPasswordPwned(const QString &pwd, const QString &credInfo);
 
 signals:
     /**
      * @brief sendPwnedNum
-     * @param message
+     * @param credInfo "service: login"
+     * @param pwnedNum
      * Sending signal how many times the given password
      * has been compromised
      */
-    void sendPwnedMessage(QString message);
+    void sendPwnedMessage(QString credInfo, QString pwnedNum);
 
     /**
      * @brief safePassword
@@ -36,7 +37,7 @@ private:
     QNetworkRequest req;
 
     QString hash;
-    QString formatString;
+    QString credInfo;
 
     const QString HIBP_API = "https://api.pwnedpasswords.com/range/";
     const QString HASH_SEPARATOR = "\r\n";

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -143,7 +143,7 @@ void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb,
                         QVariantMap progress = {
                             {"total", 0},
                             {"current", 0},
-                            {"msg", tr("Erasing device data...") }
+                            {"msg", "Erasing device data..." }
                         };
                         cbProgress(progress);
                         return true;
@@ -413,7 +413,7 @@ void MPDeviceBleImpl::sendBundleToDevice(QString filePath, AsyncJobs *jobs, cons
                                       QVariantMap progress = QVariantMap {
                                           {"total", fileSize},
                                           {"current", curAddress},
-                                          {"msg", tr("Writing bundle data to device...") }
+                                          {"msg", "Writing bundle data to device..." }
                                       };
                                       cbProgress(progress);
 #ifdef DEV_DEBUG

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -440,7 +440,9 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if (rootobj["msg"] == "send_hibp")
     {
         QJsonObject o = rootobj["data"].toObject();
-        SystemNotification::instance().createNotification(tr("Password Compromised"), o["message"].toString());
+        QString message = o["credinfo"].toString() + HIBP_COMPROMISED_FORMAT;
+        QString pwnedNum = o["pwnednum"].toString();
+        SystemNotification::instance().createNotification(tr("Password Compromised"), message.arg(pwnedNum));
     }
 }
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -172,6 +172,7 @@ private:
     QJsonArray filesCache;
 
     QTimer *randomNumTimer = nullptr;
+    QString HIBP_COMPROMISED_FORMAT = tr("this password has been compromised %1 times.");
 };
 
 #endif // WSCLIENT_H

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
  **  Copyright (c) Raoul Hecky. All Rights Reserved.
  **
  **  Calaos is free software; you can redistribute it and/or modify
@@ -79,7 +79,7 @@ private slots:
 
     void sendCardDbMetadata();
 
-    void sendHibpNotification(QString message);
+    void sendHibpNotification(QString credInfo, QString pwnedNum);
 private:
     bool checkMemModeEnabled(const QJsonObject &root);
 
@@ -91,11 +91,10 @@ private:
 
     HaveIBeenPwned *hibp = nullptr;
 
-    QString HIBP_COMPROMISED_FORMAT = tr("this password has been compromised %1 times.");
-
     void processParametersSet(const QJsonObject &data);
     void sendFailedJson(QJsonObject obj, QString errstr = QString(), int errCode = -999);
     QString getRequestId(const QJsonValue &v);
+    void checkHaveIBeenPwned(const QString &service, const QString &login, const QString &password);
     void processMessageMini(QJsonObject root, const MPDeviceProgressCb &cbProgress);
     void processMessageBLE(QJsonObject root, const MPDeviceProgressCb &cbProgress);
 };


### PR DESCRIPTION
In #434 @raoulh mentioned translation is not working in daemon, but I used tr("") before for hibp integration too. I moved the "this password has been compromised %1 times." text to the GUI (WSClient.h) For this a few changes were required regarding emitting hibp check result.

Also there was two translation text in MPDeviceBleImpl.cpp. It is used for progress information and as I checked in MPDevice.cpp translation has not been used for progress messages. (e.g.: "Loading Favorites...", "Favorite %1 loaded").