### PR TITLE
Remove EVIOCGRAB from MPDevice_linux

### DIFF
--- a/src/MPDevice_linux.cpp
+++ b/src/MPDevice_linux.cpp
@@ -48,11 +48,6 @@ MPDevice_linux::MPDevice_linux(QObject *parent, const MPPlatformDef &platformDef
     }
     else
     {
-        grabbed = ioctl(devfd, EVIOCGRAB, ExclusiveAccess::GRAB);
-        if (INVALID_VALUE == grabbed)
-        {
-            qWarning() << "Exclusive device grab wasn't successful: " << strerror(errno);
-        }
         sockNotifRead = new QSocketNotifier(devfd, QSocketNotifier::Read);
         sockNotifRead->setEnabled(true);
         connect(sockNotifRead, &QSocketNotifier::activated, this, &MPDevice_linux::readyRead);
@@ -64,11 +59,6 @@ MPDevice_linux::MPDevice_linux(QObject *parent, const MPPlatformDef &platformDef
 
 MPDevice_linux::~MPDevice_linux()
 {
-    if (INVALID_VALUE != grabbed)
-    {
-        ioctl(devfd, EVIOCGRAB, ExclusiveAccess::RELEASE);
-    }
-
     delete sockNotifRead;
     delete sockNotifWrite;
 

--- a/src/MPDevice_linux.h
+++ b/src/MPDevice_linux.h
@@ -38,12 +38,6 @@ inline bool operator!=(const MPPlatformDef &lhs, const MPPlatformDef &rhs) { ret
 
 class MPDevice_linux: public MPDevice
 {
-    enum class ExclusiveAccess
-    {
-        RELEASE = 0,
-        GRAB = 1
-    };
-
     Q_OBJECT
 public:
     MPDevice_linux(QObject *parent, const MPPlatformDef &platformDef);
@@ -74,8 +68,6 @@ private:
     int devfd = 0; //device fd
     QSocketNotifier *sockNotifRead = nullptr;
     QSocketNotifier *sockNotifWrite = nullptr;
-
-    int grabbed = INVALID_VALUE;
 
     //Bufferize the data sent by sending 64bytes packet at a time
     QQueue<QByteArray> sendBuffer;


### PR DESCRIPTION
Removing EVIOCGRAB according to comments in #434.