### PR TITLE
Connecting get random number message for BLE

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4251,13 +4251,13 @@ void MPDevice::getRandomNumber(std::function<void(bool success, QString errstr, 
     cmd->setTimeout(5000);
     jobs->append(cmd);
 
-    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &data)
+    connect(jobs, &AsyncJobs::finished, [cb, this](const QByteArray &data)
     {
         //data is last result
         //all jobs finished success
 
         qInfo() << "Random numbers generated ok";
-        cb(true, QString(), data.mid(0, 32));
+        cb(true, QString(), pMesProt->getPayloadBytes(data, 0, 32));
     });
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -83,7 +83,7 @@ QByteArray MessageProtocolBLE::getFullPayload(const QByteArray &data)
 QByteArray MessageProtocolBLE::getPayloadBytes(const QByteArray &data, int fromPayload, int to)
 {
     int start = getStartingPayloadPosition(data);
-    return data.mid(fromPayload + start, (to - fromPayload) + 1);
+    return data.mid(fromPayload + start, to - fromPayload);
 }
 
 quint32 MessageProtocolBLE::getSerialNumber(const QByteArray &data)

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -161,8 +161,10 @@ void WSServerCon::processMessage(const QString &message)
 
             QJsonObject oroot = root;
             QJsonArray arr;
-            for (int i = 0;i < rndNums.size();i++)
-                arr.append(static_cast<quint8>(rndNums.at(i)));
+            for (auto num : rndNums)
+            {
+                arr.append(static_cast<quint8>(num));
+            }
             oroot["data"] = arr;
             sendJsonMessage(oroot);
         });


### PR DESCRIPTION
The `MPCmd::GET_RANDOM_NUMBER` command was already mapped to BLE message **0x0008: Get 32 Random Bytes**.
Moved `get_random_message` processing to use the same for Mini and BLE.