### PR TITLE
Fix export db error

### DIFF
--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -362,7 +362,7 @@ void MPNode::setLoginChildNodeData(const QByteArray &flags, const QByteArray &d)
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(LOGIN_CHILD_NODE_DATA_ADDR_START, MP_NODE_SIZE-8, d);
+        data.replace(LOGIN_CHILD_NODE_DATA_ADDR_START, MP_NODE_SIZE-6, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }

--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -345,7 +345,7 @@ void MPNode::setLoginNodeData(const QByteArray &flags, const QByteArray &d)
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(DATA_ADDR_START, MP_NODE_SIZE-8, d);
+        data.replace(DATA_ADDR_START, MP_NODE_SIZE-DATA_ADDR_START, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }
@@ -362,7 +362,7 @@ void MPNode::setLoginChildNodeData(const QByteArray &flags, const QByteArray &d)
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(LOGIN_CHILD_NODE_DATA_ADDR_START, MP_NODE_SIZE-6, d);
+        data.replace(LOGIN_CHILD_NODE_DATA_ADDR_START, MP_NODE_SIZE-LOGIN_CHILD_NODE_DATA_ADDR_START, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }
@@ -378,7 +378,7 @@ void MPNode::setDataNodeData(const QByteArray &flags, const QByteArray &d)
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(DATA_ADDR_START, MP_NODE_SIZE-8, d);
+        data.replace(DATA_ADDR_START, MP_NODE_SIZE-DATA_ADDR_START, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }
@@ -394,7 +394,7 @@ void MPNode::setDataChildNodeData(const QByteArray &flags, const QByteArray &d)
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(DATA_CHILD_DATA_ADDR_START, MP_NODE_SIZE-4, d);
+        data.replace(DATA_CHILD_DATA_ADDR_START, MP_NODE_SIZE-DATA_CHILD_DATA_ADDR_START, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }


### PR DESCRIPTION
There was an error in MPNode during implementing **EnterMMM** for BLE and accidentally overwrote replace size in `MPNode::setLoginChildNodeData` function which caused error during db export.