### PR TITLE
Setting flipbit only before sending the message and moving logic to M…

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -340,8 +340,6 @@ void MPDevice::newDataRead(const QByteArray &data)
                 timer->deleteLater();
                 if (isBLE())
                 {
-                    //Need to flip the bit before resend
-                    bleImpl->flipMessageBit(commandQueue.head().data[0]);
                     sendDataDequeue();
                 }
                 else
@@ -455,6 +453,10 @@ void MPDevice::sendDataDequeue()
     int i = 0;
     qDebug() << "Platform send command: " << pMesProt->printCmd(currentCmd.data[0]);
 #endif
+    if (isBLE())
+    {
+        bleImpl->flipMessageBit(currentCmd.data[0]);
+    }
     // send data with platform code
     for (const auto &data : currentCmd.data)
     {
@@ -4085,6 +4087,10 @@ void MPDevice::cancelUserRequest(const QString &reqid)
         ba.append(static_cast<char>(pMesProt->getDeviceMappedCommandId(MPCmd::CANCEL_USER_REQUEST)));
 
         qDebug() << "Platform send command: " << QString("0x%1").arg(static_cast<quint8>(ba[1]), 2, 16, QChar('0'));
+        if (isBLE())
+        {
+            bleImpl->flipMessageBit(ba);
+        }
         platformWrite(ba);
         return;
     }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -190,19 +190,6 @@ void MPDeviceBleImpl::fetchData(QString filePath, MPCmd::Command cmd)
     dequeueAndRun(jobs);
 }
 
-void MPDeviceBleImpl::sendResetFlipBit()
-{
-    QByteArray clearFlip;
-    clearFlip.fill(static_cast<char>(0xFF), 2);
-    mpDev->platformWrite(clearFlip);
-    bleProt->resetFlipBit();
-}
-
-void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
-{
-    bleProt->flipMessageBit(msg);
-}
-
 void MPDeviceBleImpl::storeCredential(const BleCredential &cred)
 {
     auto *jobs = new AsyncJobs(QString("Store Credential"), this);
@@ -326,6 +313,30 @@ BleCredential MPDeviceBleImpl::retrieveCredentialFromResponse(QByteArray respons
     }
 
     return cred;
+}
+
+void MPDeviceBleImpl::flipBit()
+{
+    m_flipBit = m_flipBit ? 0x00 : MESSAGE_FLIP_BIT;
+}
+
+void MPDeviceBleImpl::resetFlipBit()
+{
+    m_flipBit = 0x00;
+}
+
+void MPDeviceBleImpl::sendResetFlipBit()
+{
+    QByteArray clearFlip;
+    clearFlip.fill(static_cast<char>(0xFF), 2);
+    mpDev->platformWrite(clearFlip);
+    resetFlipBit();
+}
+
+void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
+{
+    msg[0] = static_cast<char>((msg[0]&MESSAGE_ACK_AND_PAYLOAD_LENGTH)|m_flipBit);
+    flipBit();
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -33,9 +33,6 @@ public:
     void fetchData(QString filePath, MPCmd::Command cmd);
     inline void stopFetchData() { fetchState = Common::FetchState::STOPPED; }
 
-    void sendResetFlipBit();
-    void flipMessageBit(QByteArray &msg);
-
     /**
      * @brief storeCredential
      * Only for testing without the callback
@@ -52,6 +49,9 @@ public:
     void getCredential(QString service, QString login, const MessageHandlerCbData &cb);
     BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;
 
+    void sendResetFlipBit();
+    void flipMessageBit(QByteArray &msg);
+
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
@@ -63,11 +63,17 @@ private:
 
     void dequeueAndRun(AsyncJobs *job);
 
+    inline void flipBit();
+    void resetFlipBit();
 
     MessageProtocolBLE *bleProt;
     MPDevice *mpDev;
     Common::FetchState fetchState = Common::FetchState::STOPPED;
 
+    quint8 m_flipBit = 0x00;
+
+    static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
+    static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;
     static constexpr int BUNBLE_DATA_WRITE_SIZE = 256;
     static constexpr int BUNBLE_DATA_ADDRESS_SIZE = 4;
 };

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -31,7 +31,7 @@ QVector<QByteArray> MessageProtocolBLE::createPackets(const QByteArray &data, MP
     {
         QByteArray packet;
         int payloadLength = remainingBytes < HID_PACKET_DATA_PAYLOAD ? remainingBytes : HID_PACKET_DATA_PAYLOAD;
-        packet.append(static_cast<char>(m_flipBit|m_ackFlag|payloadLength));
+        packet.append(static_cast<char>(m_ackFlag|payloadLength));
         packet.append(static_cast<char>((curPacketId << 4)|packetNum));
         packet.append(messagePayload.mid(curByteIndex, payloadLength));
 
@@ -40,7 +40,6 @@ QVector<QByteArray> MessageProtocolBLE::createPackets(const QByteArray &data, MP
         ++curPacketId;
         packets.append(packet);
     }
-    flipBit();
     return packets;
 }
 
@@ -157,12 +156,6 @@ void MessageProtocolBLE::setAckFlag(bool on)
     m_ackFlag = on ? ACK_FLAG_BIT : 0x00;
 }
 
-void MessageProtocolBLE::flipMessageBit(QByteArray &msg)
-{
-    flipBit();
-    msg[0] = msg[0]^MESSAGE_FLIP_BIT;
-}
-
 QByteArray MessageProtocolBLE::convertDate(const QDateTime &dateTime)
 {
     QByteArray data;
@@ -195,16 +188,6 @@ MPNode* MessageProtocolBLE::createMPNode(QByteArray &&d, QObject *parent, QByteA
 MPNode* MessageProtocolBLE::createMPNode(QObject *parent, QByteArray &&nodeAddress, const quint32 virt_addr)
 {
     return new MPNodeBLE(parent, qMove(nodeAddress), virt_addr);
-}
-
-void MessageProtocolBLE::resetFlipBit()
-{
-    m_flipBit = 0x00;
-}
-
-void MessageProtocolBLE::flipBit()
-{
-    m_flipBit = m_flipBit ? 0x00 : MESSAGE_FLIP_BIT;
 }
 
 void MessageProtocolBLE::fillCommandMapping()

--- a/src/MessageProtocol/MessageProtocolBLE.h
+++ b/src/MessageProtocol/MessageProtocolBLE.h
@@ -28,9 +28,7 @@ public:
     virtual QByteArray toByteArray(const QString &input) override;
     virtual QString toQString(const QByteArray &data) override;
 
-    void resetFlipBit();
     inline void setAckFlag(bool on);
-    void flipMessageBit(QByteArray &msg);
 
     QByteArray convertDate(const QDateTime& dateTime) override;
 
@@ -40,14 +38,11 @@ public:
     MPNode* createMPNode(QObject *parent = nullptr, QByteArray &&nodeAddress = QByteArray(2, 0), const quint32 virt_addr = 0) override;
 
 private:
-    inline void flipBit();
     virtual void fillCommandMapping() override;
     int getStartingPayloadPosition(const QByteArray &data) const;
 
     quint8 m_ackFlag = 0x00;
-    quint8 m_flipBit = 0x00;
 
-    static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
     static constexpr quint8 ACK_FLAG_BIT = 0x40;
     static constexpr int HID_PACKET_DATA_PAYLOAD = 62;
     static constexpr quint8 CMD_LOWER_BYTE = 2;


### PR DESCRIPTION
…PDeviceBleImpl

Previously flipbit was set during message creation, but it caused multiple issues when MC received PLEASE_RETRY messages from the device, hence now only setting it right before sending the message to BLE device.