### PR TITLE
Fix setting flipbit, when multiple packet to send in a message

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -455,7 +455,7 @@ void MPDevice::sendDataDequeue()
 #endif
     if (isBLE())
     {
-        bleImpl->flipMessageBit(currentCmd.data[0]);
+        bleImpl->flipMessageBit(currentCmd.data);
     }
     // send data with platform code
     for (const auto &data : currentCmd.data)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -333,9 +333,23 @@ void MPDeviceBleImpl::sendResetFlipBit()
     resetFlipBit();
 }
 
-void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
+void MPDeviceBleImpl::setCurrentFlipBit(QByteArray &msg)
 {
     msg[0] = static_cast<char>((msg[0]&MESSAGE_ACK_AND_PAYLOAD_LENGTH)|m_flipBit);
+}
+
+void MPDeviceBleImpl::flipMessageBit(QVector<QByteArray>& msgVec)
+{
+    for (auto& msg : msgVec)
+    {
+        setCurrentFlipBit(msg);
+    }
+    flipBit();
+}
+
+void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
+{
+    setCurrentFlipBit(msg);
     flipBit();
 }
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -50,6 +50,8 @@ public:
     BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;
 
     void sendResetFlipBit();
+    void setCurrentFlipBit(QByteArray &msg);
+    void flipMessageBit(QVector<QByteArray> &msg);
     void flipMessageBit(QByteArray &msg);
 
 private:


### PR DESCRIPTION
Only the first packet's flipbit was set previously, which caused an error if there are multiple packet to send in a message. (e.g.: CMD_DBG_DATAFLASH_WRITE_256B during upload bundle)