### PR TITLE
Add retry logic for deviceOpen on Windows

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -33,7 +33,6 @@ MPDevice::MPDevice(QObject *parent):
     set_memMgmtMode(false); //by default device is not in MMM
 
     statusTimer = new QTimer(this);
-    statusTimer->start(500);
     connect(statusTimer, &QTimer::timeout, [this]()
     {
         //Do not interfer with any other operation by sending a MOOLTIPASS_STATUS command
@@ -126,6 +125,30 @@ void MPDevice::setupMessageProtocol()
         qDebug() << "Mooltipass Mini is connected";
     }
 
+#ifndef Q_OS_WIN
+    sendInitMessages();
+#endif
+
+    //For testing storeCredential and getCredential
+    //TODO: Only for testing
+//    QTimer::singleShot(2000, [this](){
+//        if (isBLE())
+//        {
+//            bleImpl->storeCredential(BleCredential{"test", "user", "desc", "3rd", "pwd"});
+//        }
+//    });
+
+//    QTimer::singleShot(20000, [this](){
+//        if (isBLE())
+//        {
+//            bleImpl->getCredential("test", "user");
+//        }
+    //    });
+}
+
+void MPDevice::sendInitMessages()
+{
+    statusTimer->start(500);
     QTimer::singleShot(100, [this]() {
         if (isBLE())
         {
@@ -148,22 +171,6 @@ void MPDevice::setupMessageProtocol()
             flashMbSizeChanged(0);
         }
     });
-
-    //For testing storeCredential and getCredential
-    //TODO: Only for testing
-//    QTimer::singleShot(2000, [this](){
-//        if (isBLE())
-//        {
-//            bleImpl->storeCredential(BleCredential{"test", "user", "desc", "3rd", "pwd"});
-//        }
-//    });
-
-//    QTimer::singleShot(20000, [this](){
-//        if (isBLE())
-//        {
-//            bleImpl->getCredential("test", "user");
-//        }
-//    });
 }
 
 void MPDevice::sendData(MPCmd::Command c, const QByteArray &data, quint32 timeout, MPCommandCb cb, bool checkReturn)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -126,6 +126,7 @@ public:
     };
 
     void setupMessageProtocol();
+    void sendInitMessages();
     /* Send a command with data to the device */
     void sendData(MPCmd::Command cmd, const QByteArray &data = QByteArray(), quint32 timeout = CMD_DEFAULT_TIMEOUT, MPCommandCb cb = [](bool, const QByteArray &, bool &){}, bool checkReturn = true);
     void sendData(MPCmd::Command cmd, quint32 timeout, MPCommandCb cb);

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -39,9 +39,26 @@ MPDevice_win::MPDevice_win(QObject *parent, const MPPlatformDef &p):
     setupMessageProtocol();
 
     if (!openPath())
+    {
         qWarning() << "Error opening device";
+        QTimer::singleShot(50, [this]()
+        {
+            if (openPath())
+            {
+                platformRead();
+                sendInitMessages();
+            }
+            else
+            {
+                qCritical() << "Device open failed after retry.";
+            }
+        });
+    }
     else
+    {
         platformRead();
+        sendInitMessages();
+    }
 }
 
 MPDevice_win::~MPDevice_win()


### PR DESCRIPTION
During connecting the device there was an issue a few time (around 1 in 30) when CreateFileA returned an Invalid handle for this I implemented a retry logic for deviceOpen and handled the timers as well.