### PR TITLE
[BLE] Implement set user categories, add User Security Settings

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -187,6 +187,7 @@ void CredentialsManagement::setWsClient(WSClient *c)
     connect(wsClient, &WSClient::passwordUnlocked, this, &CredentialsManagement::onPasswordUnlocked);
     connect(wsClient, &WSClient::mpHwVersionChanged, this, &CredentialsManagement::checkDeviceType);
     connect(wsClient, &WSClient::memMgmtModeChanged, this, &CredentialsManagement::checkDeviceType);
+    connect(wsClient, &WSClient::advancedMenuChanged, this, &CredentialsManagement::checkDeviceType);
     connect(wsClient, &WSClient::displayUserCategories, this,
              [this](const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4)
                 {
@@ -943,7 +944,7 @@ void CredentialsManagement::credentialDataChanged()
 
 void CredentialsManagement::checkDeviceType()
 {
-    if (wsClient->isMPBLE() && !wsClient->get_memMgmtMode() /*&& checkAdvancedMode*/)
+    if (wsClient->isMPBLE() && !wsClient->get_memMgmtMode() && wsClient->get_advancedMenu())
     {
         ui->label_UserCategories->show();
         ui->widget_UserCategories->show();

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -70,6 +70,17 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->toolButtonEditService->setIcon(AppGui::qtAwesome()->icon(fa::edit));
     ui->toolButtonEditService->setToolTip(tr("Edit Service Name"));
 
+    ui->label_UserCategories->setText(tr("Set user categories"));
+    ui->labelCategory1->setText(tr("Category 1:"));
+    ui->labelCategory2->setText(tr("Category 2:"));
+    ui->labelCategory3->setText(tr("Category 3:"));
+    ui->labelCategory4->setText(tr("Category 4:"));
+    const int maxCategoryLength = 32;
+    ui->lineEditCategory1->setMaxLength(maxCategoryLength);
+    ui->lineEditCategory2->setMaxLength(maxCategoryLength);
+    ui->lineEditCategory3->setMaxLength(maxCategoryLength);
+    ui->lineEditCategory4->setMaxLength(maxCategoryLength);
+
     QAction *action = m_favMenu.addAction(tr("Not a favorite"));
     connect(action, &QAction::triggered, [this](){ changeCurrentFavorite(Common::FAV_NOT_SET); });
 
@@ -167,6 +178,16 @@ void CredentialsManagement::setWsClient(WSClient *c)
         ui->lineEditFilterCred->clear();
     });
     connect(wsClient, &WSClient::passwordUnlocked, this, &CredentialsManagement::onPasswordUnlocked);
+    connect(wsClient, &WSClient::mpHwVersionChanged, this, &CredentialsManagement::checkDeviceType);
+    connect(wsClient, &WSClient::displayUserCategories, this,
+             [this](const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4)
+                {
+                    ui->lineEditCategory1->setText(cat1);
+                    ui->lineEditCategory2->setText(cat2);
+                    ui->lineEditCategory3->setText(cat3);
+                    ui->lineEditCategory4->setText(cat4);
+                }
+    );
 }
 
 void CredentialsManagement::setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel)
@@ -901,6 +922,21 @@ void CredentialsManagement::credentialDataChanged()
     disconnect(m_pCredModel, &CredentialModel::dataChanged, this, &CredentialsManagement::credentialDataChanged);
     disconnect(m_pCredModel, &CredentialModel::rowsInserted, this, &CredentialsManagement::credentialDataChanged);
     disconnect(m_pCredModel, &CredentialModel::rowsRemoved, this, &CredentialsManagement::credentialDataChanged);
+}
+
+void CredentialsManagement::checkDeviceType()
+{
+    if (wsClient->isMPBLE() /*&& checkAdvancedMode*/)
+    {
+        ui->label_UserCategories->show();
+        ui->widget_UserCategories->show();
+        wsClient->sendGetUserCategories();
+    }
+    else
+    {
+        ui->label_UserCategories->hide();
+        ui->widget_UserCategories->hide();
+    }
 }
 
 void CredentialsManagement::changeEvent(QEvent *event)

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -196,6 +196,15 @@ void CredentialsManagement::setWsClient(WSClient *c)
                     ui->lineEditCategory4->setText(cat4);
                 }
     );
+    connect(wsClient, &WSClient::statusChanged, this,
+             [this](Common::MPStatus status)
+                {
+                    if (Common::MPStatus::Unlocked == status)
+                    {
+                        wsClient->sendGetUserCategories();
+                    }
+                }
+    );
 }
 
 void CredentialsManagement::setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel)

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -186,6 +186,7 @@ void CredentialsManagement::setWsClient(WSClient *c)
     });
     connect(wsClient, &WSClient::passwordUnlocked, this, &CredentialsManagement::onPasswordUnlocked);
     connect(wsClient, &WSClient::mpHwVersionChanged, this, &CredentialsManagement::checkDeviceType);
+    connect(wsClient, &WSClient::memMgmtModeChanged, this, &CredentialsManagement::checkDeviceType);
     connect(wsClient, &WSClient::displayUserCategories, this,
              [this](const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4)
                 {
@@ -933,7 +934,7 @@ void CredentialsManagement::credentialDataChanged()
 
 void CredentialsManagement::checkDeviceType()
 {
-    if (wsClient->isMPBLE() /*&& checkAdvancedMode*/)
+    if (wsClient->isMPBLE() && !wsClient->get_memMgmtMode() /*&& checkAdvancedMode*/)
     {
         ui->label_UserCategories->show();
         ui->widget_UserCategories->show();
@@ -974,10 +975,15 @@ void CredentialsManagement::on_pushButtonSaveCategories_clicked()
                                     ui->lineEditCategory3->text(),
                                     ui->lineEditCategory4->text());
     ui->pushButtonSaveCategories->hide();
+    m_isSetCategoryClean = true;
 }
 
 void CredentialsManagement::onCategoryEdited(const QString &edited)
 {
     Q_UNUSED(edited);
-    ui->pushButtonSaveCategories->show();
+    if (m_isSetCategoryClean)
+    {
+        ui->pushButtonSaveCategories->show();
+        m_isSetCategoryClean = false;
+    }
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -80,6 +80,13 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->lineEditCategory2->setMaxLength(maxCategoryLength);
     ui->lineEditCategory3->setMaxLength(maxCategoryLength);
     ui->lineEditCategory4->setMaxLength(maxCategoryLength);
+    ui->pushButtonSaveCategories->setStyleSheet(CSS_BLUE_BUTTON);
+    ui->pushButtonSaveCategories->setText(tr("Save"));
+    ui->pushButtonSaveCategories->hide();
+    connect(ui->lineEditCategory1, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
+    connect(ui->lineEditCategory2, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
+    connect(ui->lineEditCategory3, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
+    connect(ui->lineEditCategory4, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
 
     QAction *action = m_favMenu.addAction(tr("Not a favorite"));
     connect(action, &QAction::triggered, [this](){ changeCurrentFavorite(Common::FAV_NOT_SET); });
@@ -958,4 +965,19 @@ void CredentialsManagement::on_toolButtonEditService_clicked()
     ui->credDisplayServiceInput->setReadOnly(false);
     ui->credDisplayServiceInput->setFrame(true);
     ui->credDisplayServiceInput->setFocus();
+}
+
+void CredentialsManagement::on_pushButtonSaveCategories_clicked()
+{
+    wsClient->sendSetUserCategories(ui->lineEditCategory1->text(),
+                                    ui->lineEditCategory2->text(),
+                                    ui->lineEditCategory3->text(),
+                                    ui->lineEditCategory4->text());
+    ui->pushButtonSaveCategories->hide();
+}
+
+void CredentialsManagement::onCategoryEdited(const QString &edited)
+{
+    Q_UNUSED(edited);
+    ui->pushButtonSaveCategories->show();
 }

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -84,6 +84,9 @@ private slots:
 
     void on_toolButtonEditService_clicked();
 
+    void on_pushButtonSaveCategories_clicked();
+    void onCategoryEdited(const QString& edited);
+
 private:
     void updateLoginDescription(const QModelIndex &srcIndex);
     void updateLoginDescription(LoginItem *pLoginItem);

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -78,6 +78,7 @@ private slots:
     void onSelectLoginTimerTimeOut();
     void updateFavMenu();
     void credentialDataChanged();
+    void checkDeviceType();
 
     void on_toolButtonFavFilter_clicked();
 

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -115,6 +115,7 @@ private:
     QJsonArray m_loadedModelSerialiation;
     bool m_selectionCanceled;
     bool m_isClean = true;
+    bool m_isSetCategoryClean = true;
 
     void saveCredential(const QModelIndex currentSelectionIndex);
 

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -885,6 +885,13 @@ border-right: none;
         <item row="1" column="3">
          <widget class="QLineEdit" name="lineEditCategory4"/>
         </item>
+		<item row="2" column="3">
+         <widget class="QPushButton" name="pushButtonSaveCategories">
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>827</width>
-    <height>568</height>
+    <width>835</width>
+    <height>704</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -805,6 +805,89 @@ border-right: none;
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_UserCategories">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Set category names</string>
+     </property>
+     <property name="class" stdset="0">
+      <string>FrameTitle</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_UserCategories" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <property name="leftMargin">
+       <number>75</number>
+      </property>
+      <property name="rightMargin">
+       <number>75</number>
+      </property>
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="3">
+         <widget class="QLabel" name="labelCategory4">
+          <property name="text">
+           <string>Category 4:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="labelCategory3">
+          <property name="text">
+           <string>Category 3:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="labelCategory2">
+          <property name="text">
+           <string>Category 2:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelCategory1">
+          <property name="text">
+           <string>Category 1:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLineEdit" name="lineEditCategory1"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="lineEditCategory2"/>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="lineEditCategory3"/>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLineEdit" name="lineEditCategory4"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -603,6 +603,7 @@ void MPDevice::loadParameters()
                         }
         ));
         jobsQueue.enqueue(jobs);
+        bleImpl->readUserSettings();
         runAndDequeueJobs();
         return;
     }

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -128,22 +128,6 @@ void MPDevice::setupMessageProtocol()
 #ifndef Q_OS_WIN
     sendInitMessages();
 #endif
-
-    //For testing storeCredential and getCredential
-    //TODO: Only for testing
-//    QTimer::singleShot(2000, [this](){
-//        if (isBLE())
-//        {
-//            bleImpl->storeCredential(BleCredential{"test", "user", "desc", "3rd", "pwd"});
-//        }
-//    });
-
-//    QTimer::singleShot(20000, [this](){
-//        if (isBLE())
-//        {
-//            bleImpl->getCredential("test", "user");
-//        }
-    //    });
 }
 
 void MPDevice::sendInitMessages()

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -48,6 +48,11 @@ MPDevice::MPDevice(QObject *parent):
             Common::MPStatus s = pMesProt->getStatus(data);
             Common::MPStatus prevStatus = get_status();
 
+            if (isBLE())
+            {
+                bleImpl->readUserSettings(pMesProt->getPayloadBytes(data, 2, 4));
+            }
+
             /* Trigger on status change */
             if (s != prevStatus)
             {
@@ -603,7 +608,6 @@ void MPDevice::loadParameters()
                         }
         ));
         jobsQueue.enqueue(jobs);
-        bleImpl->readUserSettings();
         runAndDequeueJobs();
         return;
     }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -190,27 +190,6 @@ void MPDeviceBleImpl::fetchData(QString filePath, MPCmd::Command cmd)
     dequeueAndRun(jobs);
 }
 
-void MPDeviceBleImpl::storeCredential(const BleCredential &cred)
-{
-    auto *jobs = new AsyncJobs(QString("Store Credential"), this);
-
-    jobs->append(new MPCommandJob(mpDev, MPCmd::STORE_CREDENTIAL, createStoreCredMessage(cred),
-                            [this](const QByteArray &data, bool &)
-                            {
-                                if (MSG_SUCCESS == bleProt->getFirstPayloadByte(data))
-                                {
-                                    qDebug() << "Credential stored successfully";
-                                }
-                                else
-                                {
-                                    qWarning() << "Credential store failed";
-                                }
-                                return true;
-                            }));
-
-    dequeueAndRun(jobs);
-}
-
 void MPDeviceBleImpl::storeCredential(const BleCredential &cred, MessageHandlerCb cb)
 {
     auto *jobs = new AsyncJobs(QString("Store Credential"), this);
@@ -244,28 +223,6 @@ void MPDeviceBleImpl::storeCredential(const BleCredential &cred, MessageHandlerC
                             return true;
                         }
                ));
-
-    dequeueAndRun(jobs);
-}
-
-void MPDeviceBleImpl::getCredential(QString service, QString login)
-{
-    auto *jobs = new AsyncJobs(QString("Get Credential"), this);
-
-        jobs->append(new MPCommandJob(mpDev, MPCmd::GET_CREDENTIAL, createGetCredMessage(service, login),
-                                [this, service, login](const QByteArray &data, bool &)
-                                {
-                                    if (MSG_FAILED == bleProt->getMessageSize(data))
-                                    {
-                                        qWarning() << "Credential get failed";
-                                        return true;
-                                    }
-                                    qDebug() << "Credential got successfully";
-                                    QByteArray response = bleProt->getFullPayload(data);
-                                    qDebug() << response.toHex();
-                                    BleCredential cred = retrieveCredentialFromResponse(response, service, login);
-                                    return true;
-                                }));
 
     dequeueAndRun(jobs);
 }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -420,29 +420,19 @@ QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categorie
     return data;
 }
 
-void MPDeviceBleImpl::readUserSettings()
+void MPDeviceBleImpl::readUserSettings(const QByteArray& settings)
 {
-    AsyncJobs *jobs = new AsyncJobs("Get User Settings", this);
-
-    jobs->append(new MPCommandJob(mpDev, MPCmd::GET_USER_SETTINGS,
-                            [this](const QByteArray &data, bool &)
-                            {
-                                if (MSG_FAILED == bleProt->getMessageSize(data))
-                                {
-                                    qWarning() << "Get user settings failed";
-                                    return true;
-                                }
-                                quint8 d = bleProt->getFullPayload(data)[0];
-                                set_loginPrompt(d&LOGIN_PROMPT);
-                                set_PINforMMM(d&PIN_FROM_MMM);
-                                set_storagePrompt(d&STORAGE_PROMPT);
-                                set_advancedMenu(d&ADVANCED_MENU);
-                                set_bluetoothEnabled(d&BLUETOOTH_ENABLED);
-                                set_credentialDisplayPrompt(d&CREDENTIAL_PROMPT);
-                                qDebug() << "Got user settings successfully";
-                                return true;
-                            }));
-    dequeueAndRun(jobs);
+    quint8 d = settings[0];
+    if (d != m_currentUserSettings)
+    {
+        set_loginPrompt(d&LOGIN_PROMPT);
+        set_PINforMMM(d&PIN_FROM_MMM);
+        set_storagePrompt(d&STORAGE_PROMPT);
+        set_advancedMenu(d&ADVANCED_MENU);
+        set_bluetoothEnabled(d&BLUETOOTH_ENABLED);
+        set_credentialDisplayPrompt(d&CREDENTIAL_PROMPT);
+        m_currentUserSettings = d;
+    }
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -347,7 +347,7 @@ void MPDeviceBleImpl::getUserCategories(const MessageHandlerCbData &cb)
     jobs->append(new MPCommandJob(mpDev, MPCmd::GET_USER_CATEGORIES,
                             [this, cb](const QByteArray &data, bool &)
                             {
-                                if (0x01 == bleProt->getMessageSize(data))
+                                if (MSG_SUCCESS == bleProt->getMessageSize(data))
                                 {
                                     qWarning() << "Get user categories failed";
                                     cb(false, "Get user categories failed", QByteArray{});

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -426,7 +426,7 @@ void MPDeviceBleImpl::readUserSettings(const QByteArray& settings)
     if (d != m_currentUserSettings)
     {
         set_loginPrompt(d&LOGIN_PROMPT);
-        set_PINforMMM(d&PIN_FROM_MMM);
+        set_PINforMMM(d&PIN_FOR_MMM);
         set_storagePrompt(d&STORAGE_PROMPT);
         set_advancedMenu(d&ADVANCED_MENU);
         set_bluetoothEnabled(d&BLUETOOTH_ENABLED);
@@ -443,7 +443,7 @@ void MPDeviceBleImpl::sendUserSettings()
     settingJson["pin_for_mmm"] = get_PINforMMM();
     settingJson["storage_prompt"] = get_storagePrompt();
     settingJson["advanced_menu"] = get_advancedMenu();
-    settingJson["blutooth_enabled"] = get_bluetoothEnabled();
+    settingJson["bluetooth_enabled"] = get_bluetoothEnabled();
     settingJson["credential_prompt"] = get_credentialDisplayPrompt();
     emit userSettingsChanged(settingJson);
 }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -432,7 +432,20 @@ void MPDeviceBleImpl::readUserSettings(const QByteArray& settings)
         set_bluetoothEnabled(d&BLUETOOTH_ENABLED);
         set_credentialDisplayPrompt(d&CREDENTIAL_PROMPT);
         m_currentUserSettings = d;
+        sendUserSettings();
     }
+}
+
+void MPDeviceBleImpl::sendUserSettings()
+{
+    QJsonObject settingJson;
+    settingJson["login_prompt"] = get_loginPrompt();
+    settingJson["pin_for_mmm"] = get_PINforMMM();
+    settingJson["storage_prompt"] = get_storagePrompt();
+    settingJson["advanced_menu"] = get_advancedMenu();
+    settingJson["blutooth_enabled"] = get_bluetoothEnabled();
+    settingJson["credential_prompt"] = get_credentialDisplayPrompt();
+    emit userSettingsChanged(settingJson);
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -17,6 +17,22 @@ class MPDeviceBleImpl: public QObject
 
     QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
     QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
+    QT_WRITABLE_PROPERTY(bool, loginPrompt, false)
+    QT_WRITABLE_PROPERTY(bool, PINforMMM, false)
+    QT_WRITABLE_PROPERTY(bool, storagePrompt, false)
+    QT_WRITABLE_PROPERTY(bool, advancedMenu, false)
+    QT_WRITABLE_PROPERTY(bool, bluetoothEnabled, false)
+    QT_WRITABLE_PROPERTY(bool, credentialDisplayPrompt, false)
+
+    enum UserSettingsMask : quint8
+    {
+        LOGIN_PROMPT      = 0x01,
+        PIN_FROM_MMM      = 0x02,
+        STORAGE_PROMPT    = 0x04,
+        ADVANCED_MENU     = 0x08,
+        BLUETOOTH_ENABLED = 0x10,
+        CREDENTIAL_PROMPT = 0x20
+    };
 
 public:
     MPDeviceBleImpl(MessageProtocolBLE *mesProt, MPDevice *dev);
@@ -46,6 +62,8 @@ public:
     void setUserCategories(const QJsonObject &categories, const MessageHandlerCbData &cb);
     void fillGetCategory(const QByteArray& data, QJsonObject &categories);
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
+
+    void readUserSettings();
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -64,6 +64,10 @@ public:
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
 
     void readUserSettings(const QByteArray& settings);
+    void sendUserSettings();
+
+signals:
+    void userSettingsChanged(QJsonObject settings);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -58,7 +58,7 @@ public:
     void flipMessageBit(QVector<QByteArray> &msg);
     void flipMessageBit(QByteArray &msg);
 
-	bool isAfterAuxFlash();
+    bool isAfterAuxFlash();
 
     void getUserCategories(const MessageHandlerCbData &cb);
     void setUserCategories(const QJsonObject &categories, const MessageHandlerCbData &cb);
@@ -98,7 +98,7 @@ private:
     static constexpr int BUNBLE_DATA_WRITE_SIZE = 256;
     static constexpr int BUNBLE_DATA_ADDRESS_SIZE = 4;
     static constexpr int USER_CATEGORY_COUNT = 4;
-	static constexpr int USER_CATEGORY_LENGTH = 66;
+    static constexpr int USER_CATEGORY_LENGTH = 66;
     const QString AFTER_AUX_FLASH_SETTING = "settings/after_aux_flash";
 };
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -33,19 +33,7 @@ public:
     void fetchData(QString filePath, MPCmd::Command cmd);
     inline void stopFetchData() { fetchState = Common::FetchState::STOPPED; }
 
-    /**
-     * @brief storeCredential
-     * Only for testing without the callback
-     */
-    //TODO: Only for testing
-    void storeCredential(const BleCredential &cred);
     void storeCredential(const BleCredential &cred, MessageHandlerCb cb);
-    /**
-     * @brief getCredential
-     * Only for testing without the callback
-     */
-    //TODO: Only for testing
-    void getCredential(QString service, QString login = "");
     void getCredential(const QString& service, const QString& login, const QString& reqid, const MessageHandlerCbData &cb);
     BleCredential retrieveCredentialFromResponse(QByteArray response, QString service, QString login) const;
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -63,7 +63,7 @@ public:
     void fillGetCategory(const QByteArray& data, QJsonObject &categories);
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
 
-    void readUserSettings();
+    void readUserSettings(const QByteArray& settings);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
@@ -85,6 +85,7 @@ private:
     Common::FetchState fetchState = Common::FetchState::STOPPED;
 
     quint8 m_flipBit = 0x00;
+    quint8 m_currentUserSettings = 0x00;
 
     static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -27,7 +27,7 @@ class MPDeviceBleImpl: public QObject
     enum UserSettingsMask : quint8
     {
         LOGIN_PROMPT      = 0x01,
-        PIN_FROM_MMM      = 0x02,
+        PIN_FOR_MMM       = 0x02,
         STORAGE_PROMPT    = 0x04,
         ADVANCED_MENU     = 0x08,
         BLUETOOTH_ENABLED = 0x10,

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -61,6 +61,7 @@ private:
 
     QByteArray createStoreCredMessage(const BleCredential &cred);
     QByteArray createGetCredMessage(QString service, QString login);
+    QByteArray createCheckCredMessage(const BleCredential &cred);
     QByteArray createCredentialMessage(const CredMap &credMap);
 
     void dequeueAndRun(AsyncJobs *job);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -54,6 +54,9 @@ public:
     void flipMessageBit(QVector<QByteArray> &msg);
     void flipMessageBit(QByteArray &msg);
 
+    void getUserCategories(const MessageHandlerCbData &cb);
+    void fillGetCategory(const QByteArray& data, QJsonObject &categories);
+
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
@@ -79,6 +82,8 @@ private:
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;
     static constexpr int BUNBLE_DATA_WRITE_SIZE = 256;
     static constexpr int BUNBLE_DATA_ADDRESS_SIZE = 4;
+    static constexpr int USER_CATEGORY_COUNT = 4;
+    static constexpr int USER_CATEGORY_LENGTH = 66;
 };
 
 #endif // MPDEVICEBLEIMPL_H

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -43,7 +43,9 @@ public:
     void flipMessageBit(QByteArray &msg);
 
     void getUserCategories(const MessageHandlerCbData &cb);
+    void setUserCategories(const QJsonObject &categories, const MessageHandlerCbData &cb);
     void fillGetCategory(const QByteArray& data, QJsonObject &categories);
+    QByteArray createUserCategoriesMsg(const QJsonObject &categories);
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -160,6 +160,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(wsClient, &WSClient::wsDisconnected, this, &MainWindow::updatePage);
     connect(wsClient, &WSClient::connectedChanged, this, &MainWindow::updatePage);
     connect(wsClient, &WSClient::statusChanged, this, &MainWindow::updatePage);
+    connect(wsClient, &WSClient::deviceConnacted, this, &MainWindow::onDeviceConnected);
     connect(wsClient, &WSClient::deviceDisconnected, this, &MainWindow::onDeviceDisconnected);
 
     connect(wsClient, &WSClient::memMgmtModeChanged, this, &MainWindow::enableCredentialsManagement);
@@ -382,7 +383,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
                 ui->cbLoginPrompt->setChecked(settings["login_prompt"].toBool());
                 ui->cbPinForMMM->setChecked(settings["pin_for_mmm"].toBool());
                 ui->cbStoragePrompt->setChecked(settings["storage_prompt"].toBool());
-                ui->cbAdvancedMenu->setChecked(settings["advanced_menu"].toBool());
+                bool advancedMenu = settings["advanced_menu"].toBool();
+                ui->cbAdvancedMenu->setChecked(advancedMenu);
+                wsClient->set_advancedMenu(advancedMenu);
                 ui->cbBluetoothEnabled->setChecked(settings["bluetooth_enabled"].toBool());
                 ui->cbCredentialPrompt->setChecked(settings["credential_prompt"].toBool());
             });
@@ -397,11 +400,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         {
             ui->groupBox_Information->hide();
         }
-        if (wsClient->isMPBLE())
-        {
-            wsClient->sendUserSettingsRequest();
-            ui->groupBox_UserSettings->show();
-        }
+        onDeviceConnected();
     });
 
     connect(wsClient, &WSClient::connectedChanged, this, &MainWindow::updateSerialInfos);
@@ -1859,6 +1858,19 @@ void MainWindow::on_pushButtonHIBP_clicked()
 void MainWindow::on_pushButtonGetAvailableUsers_clicked()
 {
     wsClient->requestAvailableUserNumber();
+}
+
+void MainWindow::onDeviceConnected()
+{
+    if (wsClient->isMPBLE())
+    {
+        wsClient->sendUserSettingsRequest();
+        ui->groupBox_UserSettings->show();
+    }
+    else
+    {
+        ui->groupBox_UserSettings->hide();
+    }
 }
 
 void MainWindow::onDeviceDisconnected()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -160,6 +160,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(wsClient, &WSClient::wsDisconnected, this, &MainWindow::updatePage);
     connect(wsClient, &WSClient::connectedChanged, this, &MainWindow::updatePage);
     connect(wsClient, &WSClient::statusChanged, this, &MainWindow::updatePage);
+    connect(wsClient, &WSClient::deviceDisconnected, this, &MainWindow::onDeviceDisconnected);
 
     connect(wsClient, &WSClient::memMgmtModeChanged, this, &MainWindow::enableCredentialsManagement);
     connect(ui->widgetCredentials, &CredentialsManagement::wantEnterMemMode, this, &MainWindow::wantEnterCredentialManagement);
@@ -368,6 +369,24 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     }
     ui->comboBoxSystrayIcon->blockSignals(false);
 
+    ui->cbLoginPrompt->setDisabled(true);
+    ui->cbPinForMMM->setDisabled(true);
+    ui->cbStoragePrompt->setDisabled(true);
+    ui->cbAdvancedMenu->setDisabled(true);
+    ui->cbBluetoothEnabled->setDisabled(true);
+    ui->cbCredentialPrompt->setDisabled(true);
+
+    connect(wsClient, &WSClient::updateUserSettingsOnUI,
+            [this](const QJsonObject& settings)
+            {
+                ui->cbLoginPrompt->setChecked(settings["login_prompt"].toBool());
+                ui->cbPinForMMM->setChecked(settings["pin_for_mmm"].toBool());
+                ui->cbStoragePrompt->setChecked(settings["storage_prompt"].toBool());
+                ui->cbAdvancedMenu->setChecked(settings["advanced_menu"].toBool());
+                ui->cbBluetoothEnabled->setChecked(settings["bluetooth_enabled"].toBool());
+                ui->cbCredentialPrompt->setChecked(settings["credential_prompt"].toBool());
+            });
+
     //When device has new parameters, update the GUI
     connect(wsClient, &WSClient::mpHwVersionChanged, [=]()
     {
@@ -377,6 +396,11 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         if (!wsClient->isFw12() && !wsClient->isMPBLE())
         {
             ui->groupBox_Information->hide();
+        }
+        if (wsClient->isMPBLE())
+        {
+            wsClient->sendUserSettingsRequest();
+            ui->groupBox_UserSettings->show();
         }
     });
 
@@ -1835,4 +1859,9 @@ void MainWindow::on_pushButtonHIBP_clicked()
 void MainWindow::on_pushButtonGetAvailableUsers_clicked()
 {
     wsClient->requestAvailableUserNumber();
+}
+
+void MainWindow::onDeviceDisconnected()
+{
+    ui->groupBox_UserSettings->hide();
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -130,6 +130,7 @@ private slots:
     void on_pushButtonHIBP_clicked();
 
     void on_pushButtonGetAvailableUsers_clicked();
+    void onDeviceDisconnected();
 
 private:
     void setUIDRequestInstructionsWithId(const QString &id = "XXXX");

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -130,6 +130,8 @@ private slots:
     void on_pushButtonHIBP_clicked();
 
     void on_pushButtonGetAvailableUsers_clicked();
+
+    void onDeviceConnected();
     void onDeviceDisconnected();
 
 private:

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1157,6 +1157,75 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBox_UserSettings">
+              <property name="title">
+               <string>User Security Settings (Only changeable from device)</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_30">
+               <item>
+                <widget class="QCheckBox" name="cbLoginPrompt">
+                 <property name="toolTip">
+                  <string>Confirm to output each credential. Control this setting in the settings menu of the advanced menu</string>
+                 </property>
+                 <property name="text">
+                  <string>Login Confirmation Prompt</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbPinForMMM">
+                 <property name="toolTip">
+                  <string>Require PIN to enter management mode. Control this setting in the settings menu of the advanced menu</string>
+                 </property>
+                 <property name="text">
+                  <string>PIN for Management Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbStoragePrompt">
+                 <property name="toolTip">
+                  <string>Prompt to display credentials on screen during manual recall. Control this setting in the settings menu of the advanced menu</string>
+                 </property>
+                 <property name="text">
+                  <string>Password Display on Screen Prompts</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbAdvancedMenu">
+                 <property name="toolTip">
+                  <string>Switch menu modes by a long wheel press in the main menu</string>
+                 </property>
+                 <property name="text">
+                  <string>Advanced Menu</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbBluetoothEnabled">
+                 <property name="toolTip">
+                  <string>Use Bluetooth Menu to enable/disable the Mooltipass Bluetooth interface</string>
+                 </property>
+                 <property name="text">
+                  <string>Bluetooth Status</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="cbCredentialPrompt">
+                 <property name="toolTip">
+                  <string>Require approval when modifying credentials in management mode. Control this setting in the settings menu of the advanced menu</string>
+                 </property>
+                 <property name="text">
+                  <string>Prompts for Credentials Save in Management Mode</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_3">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -1174,6 +1243,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <zorder>groupBox</zorder>
            <zorder>groupBox_2</zorder>
            <zorder>advancedSettingsGB</zorder>
+           <zorder>groupBox_UserSettings</zorder>
           </widget>
          </widget>
         </item>

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -327,6 +327,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_DEVICE_SETTINGS   , 0x000C},
         {MPCmd::GET_AVAILABLE_USERS   , 0x000F},
         {MPCmd::CHECK_CREDENTIAL      , 0x0012},
+        {MPCmd::GET_USER_SETTINGS     , 0x0013},
         {MPCmd::GET_USER_CATEGORIES   , 0x0014},
         {MPCmd::SET_USER_CATEGORIES   , 0x0015},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -327,6 +327,8 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_DEVICE_SETTINGS   , 0x000C},
         {MPCmd::GET_AVAILABLE_USERS   , 0x000F},
         {MPCmd::CHECK_CREDENTIAL      , 0x0012},
+        {MPCmd::GET_USER_CATEGORIES   , 0x0014},
+        {MPCmd::SET_USER_CATEGORIES   , 0x0015},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -326,6 +326,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_CREDENTIAL        , 0x0007},
         {MPCmd::GET_DEVICE_SETTINGS   , 0x000C},
         {MPCmd::GET_AVAILABLE_USERS   , 0x000F},
+        {MPCmd::CHECK_CREDENTIAL      , 0x0012},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -132,6 +132,8 @@ public:
             GET_DEVICE_SETTINGS ,
             GET_AVAILABLE_USERS ,
             CHECK_CREDENTIAL    ,
+            GET_USER_CATEGORIES ,
+            SET_USER_CATEGORIES ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -131,6 +131,7 @@ public:
             GET_CREDENTIAL      ,
             GET_DEVICE_SETTINGS ,
             GET_AVAILABLE_USERS ,
+            CHECK_CREDENTIAL    ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -132,6 +132,7 @@ public:
             GET_DEVICE_SETTINGS ,
             GET_AVAILABLE_USERS ,
             CHECK_CREDENTIAL    ,
+            GET_USER_SETTINGS   ,
             GET_USER_CATEGORIES ,
             SET_USER_CATEGORIES ,
             CMD_DBG_MESSAGE     ,

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -449,6 +449,14 @@ void WSClient::onTextMessageReceived(const QString &message)
         QJsonObject o = rootobj["data"].toObject();
         emit displayAvailableUsers(o["num"].toString());
     }
+    else if(rootobj["msg"] == "get_user_categories")
+    {
+        QJsonObject o = rootobj["data"].toObject();
+        emit displayUserCategories(o["category_1"].toString(),
+                                   o["category_2"].toString(),
+                                   o["category_3"].toString(),
+                                   o["category_4"].toString());
+    }
 }
 
 void WSClient::udateParameters(const QJsonObject &data)
@@ -685,6 +693,11 @@ void WSClient::sendFetchData(QString fileName, Common::FetchType fetchType)
 void WSClient::sendStopFetchData()
 {
     sendJsonData({{ "msg", "stop_fetch_data" }});
+}
+
+void WSClient::sendGetUserCategories()
+{
+    sendJsonData({{ "msg", "get_user_categories" }});
 }
 
 bool WSClient::isFw12()

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -150,6 +150,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     {
         set_memMgmtMode(false);
         set_connected(false);
+        emit deviceDisconnected();
     }
     else if (rootobj["msg"] == "status_changed")
     {
@@ -467,6 +468,11 @@ void WSClient::onTextMessageReceived(const QString &message)
             sendGetUserCategories();
         }
     }
+    else if(rootobj["msg"] == "send_user_settings")
+    {
+        QJsonObject o = rootobj["data"].toObject();
+        emit updateUserSettingsOnUI(o);
+    }
 }
 
 void WSClient::udateParameters(const QJsonObject &data)
@@ -719,6 +725,11 @@ void WSClient::sendSetUserCategories(const QString &cat1, const QString &cat2, c
     o["category_4"] = cat4;
     sendJsonData({{ "msg", "set_user_categories" },
                   {"data", o}});
+}
+
+void WSClient::sendUserSettingsRequest()
+{
+    sendJsonData({{ "msg", "get_user_settings" }});
 }
 
 bool WSClient::isFw12()

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -145,6 +145,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     if (rootobj["msg"] == "mp_connected")
     {
         set_connected(true);
+        emit deviceConnacted();
     }
     else if (rootobj["msg"] == "mp_disconnected")
     {

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -700,6 +700,17 @@ void WSClient::sendGetUserCategories()
     sendJsonData({{ "msg", "get_user_categories" }});
 }
 
+void WSClient::sendSetUserCategories(const QString &cat1, const QString &cat2, const QString &cat3, const QString &cat4)
+{
+    QJsonObject o;
+    o["category_1"] = cat1;
+    o["category_2"] = cat2;
+    o["category_3"] = cat3;
+    o["category_4"] = cat4;
+    sendJsonData({{ "msg", "set_user_categories" },
+                  {"data", o}});
+}
+
 bool WSClient::isFw12()
 {
     static QRegularExpression regVersion("v([0-9]+)\\.([0-9]+)(.*)");

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -457,6 +457,16 @@ void WSClient::onTextMessageReceived(const QString &message)
                                    o["category_3"].toString(),
                                    o["category_4"].toString());
     }
+    else if(rootobj["msg"] == "set_user_categories")
+    {
+        QJsonObject o = rootobj["data"].toObject();
+        bool success = !o.contains("failed") || !o.value("failed").toBool();
+        if (!success)
+        {
+            SystemNotification::instance().createNotification(tr("Error"), tr("Set user category failed."));
+            sendGetUserCategories();
+        }
+    }
 }
 
 void WSClient::udateParameters(const QJsonObject &data)

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -124,6 +124,7 @@ public:
     void sendStopFetchData();
     void sendGetUserCategories();
     void sendSetUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
+    void sendUserSettingsRequest();
 
     bool isFw12();
 
@@ -154,6 +155,8 @@ signals:
     void displayUploadBundleResult(bool success);
     void displayAvailableUsers(const QString& num);
     void displayUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
+    void updateUserSettingsOnUI(const QJsonObject& userSettings);
+    void deviceDisconnected();
     void deleteDataNodesFinished();
 
 public slots:

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -70,6 +70,7 @@ class WSClient: public QObject
 
     QT_WRITABLE_PROPERTY(QString, mainMCUVersion, QString())
     QT_WRITABLE_PROPERTY(QString, auxMCUVersion, QString())
+    QT_WRITABLE_PROPERTY(bool, advancedMenu, false)
 
 public:
     explicit WSClient(QObject *parent = nullptr);
@@ -156,6 +157,7 @@ signals:
     void displayAvailableUsers(const QString& num);
     void displayUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
     void updateUserSettingsOnUI(const QJsonObject& userSettings);
+    void deviceConnacted();
     void deviceDisconnected();
     void deleteDataNodesFinished();
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -122,6 +122,7 @@ public:
     void sendUploadBundle(QString bundleFilePath);
     void sendFetchData(QString fileName, Common::FetchType fetchType);
     void sendStopFetchData();
+    void sendGetUserCategories();
 
     bool isFw12();
 
@@ -151,6 +152,7 @@ signals:
     void displayDebugPlatInfo(int auxMajor, int auxMinor, int mainMajor, int mainMinor);
     void displayUploadBundleResult(bool success);
     void displayAvailableUsers(const QString& num);
+    void displayUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
     void deleteDataNodesFinished();
 
 public slots:

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -123,6 +123,7 @@ public:
     void sendFetchData(QString fileName, Common::FetchType fetchType);
     void sendStopFetchData();
     void sendGetUserCategories();
+    void sendSetUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
 
     bool isFw12();
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1393,6 +1393,27 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
                      sendJsonMessage(oroot);
                  });
     }
+    else if (root["msg"] == "set_user_categories")
+    {
+         QJsonObject o = root["data"].toObject();
+         bleImpl->setUserCategories(o, [this, root](bool success, QString errstr, QByteArray)
+                 {
+                     if (!WSServer::Instance()->checkClientExists(this))
+                         return;
+
+                     if (!success)
+                     {
+                         sendFailedJson(root, errstr);
+                         return;
+                     }
+
+                     QJsonObject ores;
+                     QJsonObject oroot = root;
+                     ores["success"] = "true";
+                     oroot["data"] = ores;
+                     sendJsonMessage(oroot);
+                 });
+    }
     else
     {
         qDebug() << root["msg"] << " message have not implemented yet for BLE";

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -361,6 +361,10 @@ void WSServerCon::resetDevice(MPDevice *dev)
 
     connect(mpdevice, &MPDevice::dbChangeNumbersChanged, this, &WSServerCon::sendCardDbMetadata);
 
+    if (nullptr != mpdevice->ble())
+    {
+        connect(mpdevice->ble(), &MPDeviceBleImpl::userSettingsChanged, this, &WSServerCon::sendUserSettings);
+    }
 }
 
 void WSServerCon::statusChanged()
@@ -727,6 +731,13 @@ void WSServerCon::sendHibpNotification(QString credInfo, QString pwnedNum)
     {
         qDebug() << "Cannot send pwned notification to GUI: " << credInfo << ": " << pwnedNum;
     }
+}
+
+void WSServerCon::sendUserSettings(QJsonObject settings)
+{
+    QJsonObject oroot = { {"msg", "send_user_settings"} };
+    oroot["data"] = settings;
+    sendJsonMessage(oroot);
 }
 
 void WSServerCon::processParametersSet(const QJsonObject &data)
@@ -1413,6 +1424,10 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
                      oroot["data"] = ores;
                      sendJsonMessage(oroot);
                  });
+    }
+    else if (root["msg"] == "get_user_settings")
+    {
+         bleImpl->sendUserSettings();
     }
     else
     {

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1372,6 +1372,27 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
                                      sendJsonMessage(oroot);
                                  });
     }
+    else if (root["msg"] == "get_user_categories")
+    {
+         QJsonObject o = root["data"].toObject();
+         bleImpl->getUserCategories([this, root, bleImpl](bool success, QString errstr, QByteArray data)
+                 {
+                     if (!WSServer::Instance()->checkClientExists(this))
+                         return;
+
+                     if (!success)
+                     {
+                         sendFailedJson(root, errstr);
+                         return;
+                     }
+
+                     QJsonObject ores;
+                     QJsonObject oroot = root;
+                     bleImpl->fillGetCategory(data, ores);
+                     oroot["data"] = ores;
+                     sendJsonMessage(oroot);
+                 });
+    }
     else
     {
         qDebug() << root["msg"] << " message have not implemented yet for BLE";

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -80,6 +80,7 @@ private slots:
     void sendCardDbMetadata();
 
     void sendHibpNotification(QString credInfo, QString pwnedNum);
+    void sendUserSettings(QJsonObject settings);
 private:
     bool checkMemModeEnabled(const QJsonObject &root);
 


### PR DESCRIPTION
### Changeset:
- Implement 0x0012: Check Credential message
     - Added a check before adding a new credential from MC
- Implement Get/Set User Categories (0x0014/0x0015):
     - Only displaying on Credentials tab, when Advanced Mode is enabled and BLE device is connected:
      ![Screenshot from 2019-05-23 13-47-43](https://user-images.githubusercontent.com/11043249/58250311-6a495000-7d61-11e9-9393-d49ddcc0c871.png)

- Implement 0x0013: Get User Settings
     - Only displayed for BLE device
     - Read only, polling with status message
      ![bleUserSecuritySettings](https://user-images.githubusercontent.com/11043249/58250133-fc048d80-7d60-11e9-83bd-7aa1ff7bf33e.png)