### PR TITLE
[BLE] Send a cancel request message to the device after aux flash...

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -156,6 +156,11 @@ void MPDevice::sendInitMessages()
             qDebug() << "Resetting flip bit for BLE";
 #endif
             bleImpl->sendResetFlipBit();
+            if (bleImpl->isAfterAuxFlash())
+            {
+                qDebug() << "Fixing communication with device after Aux Flash";
+                writeCancelRequest();
+            }
             bleImpl->getPlatInfo();
         }
 
@@ -4097,20 +4102,7 @@ void MPDevice::cancelUserRequest(const QString &reqid)
     {
         qInfo() << "request_id match current one. Cancel current request";
 
-        const auto cancelRequestCmd = MPCmd::CANCEL_USER_REQUEST;
-        QByteArray ba;
-        ba.append(pMesProt->createPackets(QByteArray{}, cancelRequestCmd)[0]);
-
-        qDebug() << "Platform send command: " << pMesProt->printCmd(cancelRequestCmd);
-#ifdef DEV_DEBUG
-        qDebug() << "Message:" << ba.toHex();
-#endif
-        qDebug() << "Platform send command: " << QString("0x%1").arg(static_cast<quint8>(ba[1]), 2, 16, QChar('0'));
-        if (isBLE())
-        {
-            bleImpl->flipMessageBit(ba);
-        }
-        platformWrite(ba);
+        writeCancelRequest();
         return;
     }
 
@@ -4126,6 +4118,24 @@ void MPDevice::cancelUserRequest(const QString &reqid)
     }
 
     qWarning() << "No request found for reqid: " << reqid;
+}
+
+void MPDevice::writeCancelRequest()
+{
+    const auto cancelRequestCmd = MPCmd::CANCEL_USER_REQUEST;
+    QByteArray ba;
+    ba.append(pMesProt->createPackets(QByteArray{}, cancelRequestCmd)[0]);
+
+    qDebug() << "Platform send command: " << pMesProt->printCmd(cancelRequestCmd);
+#ifdef DEV_DEBUG
+    qDebug() << "Message:" << ba.toHex();
+#endif
+    qDebug() << "Platform send command: " << QString("0x%1").arg(static_cast<quint8>(ba[1]), 2, 16, QChar('0'));
+    if (isBLE())
+    {
+        bleImpl->flipMessageBit(ba);
+    }
+    platformWrite(ba);
 }
 
 void MPDevice::getCredential(QString service, const QString &login, const QString &fallback_service, const QString &reqid,

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -200,6 +200,7 @@ public:
 
     //Send a cancel request to device
     void cancelUserRequest(const QString &reqid);
+    void writeCancelRequest();
 
     //Request for a raw data node from the device
     void getDataNode(QString service, const QString &fallback_service, const QString &reqid,

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -94,6 +94,11 @@ void MPDeviceBleImpl::flashMCU(QString type, const MessageHandlerCb &cb)
     auto flashJob = new MPCommandJob(mpDev, cmd, bleProt->getDefaultFuncDone());
     flashJob->setReturnCheck(false);
     jobs->append(flashJob);
+    if (isAuxFlash)
+    {
+        QSettings s;
+        s.setValue(AFTER_AUX_FLASH_SETTING, true);
+    }
 
     connect(jobs, &AsyncJobs::failed, [cb, isAuxFlash](AsyncJob *failedJob)
     {
@@ -367,6 +372,17 @@ void MPDeviceBleImpl::flipMessageBit(QByteArray &msg)
 {
     setCurrentFlipBit(msg);
     flipBit();
+}
+
+bool MPDeviceBleImpl::isAfterAuxFlash()
+{
+    QSettings s;
+    if (s.value(AFTER_AUX_FLASH_SETTING, false).toBool())
+    {
+        s.setValue(AFTER_AUX_FLASH_SETTING, false);
+        return true;
+    }
+    return false;
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -54,6 +54,7 @@ public:
     void flipMessageBit(QVector<QByteArray> &msg);
     void flipMessageBit(QByteArray &msg);
 
+    bool isAfterAuxFlash();
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
@@ -78,6 +79,7 @@ private:
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;
     static constexpr int BUNBLE_DATA_WRITE_SIZE = 256;
     static constexpr int BUNBLE_DATA_ADDRESS_SIZE = 4;
+    const QString AFTER_AUX_FLASH_SETTING = "settings/after_aux_flash";
 };
 
 #endif // MPDEVICEBLEIMPL_H


### PR DESCRIPTION
… to fix communication

Stored in QSettings, because it is possible to stop MC after Aux Flash, but a message with no response is still required after restarting MC.