### PR TITLE
Clear MMM UI before entering

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -248,6 +248,7 @@ void CredentialsManagement::onPasswordInputReturnPressed()
 
 void CredentialsManagement::on_pushButtonEnterMMM_clicked()
 {
+    clearMMMUi();
     wsClient->sendEnterMMRequest();
     emit wantEnterMemMode();
 }
@@ -832,6 +833,14 @@ void CredentialsManagement::setServiceInputAttributes(const QString &tooltipText
     pal.setColor(QPalette::Text, col);
     ui->credDisplayServiceInput->setPalette(pal);
     ui->credDisplayServiceInput->setToolTip(tooltipText);
+}
+
+void CredentialsManagement::clearMMMUi()
+{
+    clearLoginDescription();
+    ui->credDisplayFrame->setEnabled(false);
+    m_pCredModel->clear();
+    ui->credentialTreeView->repaint();
 }
 
 void CredentialsManagement::onItemCollapsed(const QModelIndex &proxyIndex)

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -100,6 +100,7 @@ private:
     void enableNonCredentialEditWidgets();
     bool isServiceNameExist(const QString& serviceName) const;
     void setServiceInputAttributes(const QString& tooltipText, Qt::GlobalColor col);
+    void clearMMMUi();
 
     void changeCurrentFavorite(int iFavorite);
     virtual void changeEvent(QEvent *event);


### PR DESCRIPTION
When a previous card/device with credentials entered MMM, then if we switch to an empty device the last card's credential is displayed in MMM:
![kép](https://user-images.githubusercontent.com/11043249/59222431-c3bad700-8bc9-11e9-863b-e85eeffd5e97.png)
If the previous device was disconnacted in MMM, then the credential tree view remained also.
In the fix I cleared every MMM ui element before entering.