### PR TITLE
#455 Replace some QByteArray append to be backward compatibilible with old…

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -377,3 +377,11 @@ void Common::updateSeed(std::vector<qint64> &newInts)
 {
     mpRngIntegers = newInts;
 }
+
+void Common::fill(QByteArray &ba, int count, char c)
+{
+    for (int i = 0; i < count; ++i)
+    {
+        ba.append(c);
+    }
+}

--- a/src/Common.h
+++ b/src/Common.h
@@ -161,6 +161,8 @@ public:
     static std::vector<qint64> getRngSeed();
     static void updateSeed(std::vector<qint64> &newInts);
 
+    static void fill(QByteArray &ba, int count, char c);
+
     typedef enum
     {
         MP_Classic = 0,

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -430,7 +430,7 @@ QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categorie
     for (int i = 0; i < USER_CATEGORY_COUNT; ++i)
     {
         QByteArray categoryArr = bleProt->toByteArray(categories["category_" + QString::number(i+1)].toString());
-        categoryArr.append(USER_CATEGORY_LENGTH - categoryArr.size(), static_cast<char>(0x00));
+        Common::fill(categoryArr, USER_CATEGORY_LENGTH - categoryArr.size(), static_cast<char>(0x00));
         data.append(categoryArr);
     }
     return data;

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -163,7 +163,7 @@ void MPDevice_win::platformWrite(const QByteArray &data)
     //resize array to fit windows requirements (at least outReportLen size)
     if (ba.size() < platformDef.outReportLen)
     {
-        ba.append(platformDef.outReportLen - ba.size(), zeroByte);
+        Common::fill(ba, platformDef.outReportLen - ba.size(), zeroByte);
     }
 
     ::ZeroMemory(&writeOverlapped, sizeof(writeOverlapped));


### PR DESCRIPTION
…er Qt versions

Fixing #455 
`QByteArray &QByteArray::append(int count, char ch)` overload was introduced in [Qt version 5.7](https://doc.qt.io/qt-5/qbytearray.html#append-2).
Changed the usage of this overload to a fill function.