### PR TITLE
Map Debug Message for BLE and implement printing it

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -282,9 +282,16 @@ void MPDevice::newDataRead(const QByteArray &data)
     //this should be done by the platform code
 
     QByteArray dataReceived = data;
-    if (!isBLE() && pMesProt->getCommand(data) == MPCmd::DEBUG)
+    if (m_isDebugMsg || pMesProt->getCommand(data) == MPCmd::DEBUG)
     {
-        qWarning() << data;
+        if (isBLE())
+        {
+            bleImpl->processDebugMsg(data, m_isDebugMsg);
+        }
+        else
+        {
+            qWarning() << data.toHex();
+        }
         return;
     }
 

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -399,6 +399,7 @@ private:
 
     FilesCache filesCache;
 
+    bool m_isDebugMsg = false;
     //Message Protocol
     IMessageProtocol *pMesProt = nullptr;
     MPDeviceBleImpl *bleImpl = nullptr;

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -464,6 +464,22 @@ void MPDeviceBleImpl::sendUserSettings()
     emit userSettingsChanged(settingJson);
 }
 
+void MPDeviceBleImpl::processDebugMsg(const QByteArray &data, bool &isDebugMsg)
+{
+    if (isFirstPacket(data))
+    {
+        isDebugMsg = true;
+    }
+
+    m_debugMsg += bleProt->toQString(bleProt->getFullPayload(data));
+    if (isLastPacket(data))
+    {
+        qWarning() << m_debugMsg;
+        isDebugMsg = false;
+        m_debugMsg.clear();
+    }
+}
+
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)
 {
     return createCredentialMessage(cred.getAttributes());

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -68,6 +68,8 @@ public:
     void readUserSettings(const QByteArray& settings);
     void sendUserSettings();
 
+    void processDebugMsg(const QByteArray& data, bool& isDebugMsg);
+
 signals:
     void userSettingsChanged(QJsonObject settings);
 
@@ -90,6 +92,7 @@ private:
 
     quint8 m_flipBit = 0x00;
     quint8 m_currentUserSettings = 0x00;
+    QString m_debugMsg = "";
 
     static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -262,7 +262,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::USB_KEYBOARD_PRESS    , 0x9B},
         {MPCmd::STACK_FREE            , 0x9C},
         {MPCmd::CLONE_SMARTCARD       , 0x9D},
-        {MPCmd::DEBUG                 , 0xA0},
+        {MPCmd::DEBUG                 , 0x8000},
         {MPCmd::PING                  , 0x0001},
         {MPCmd::VERSION               , 0xA2},
         {MPCmd::CONTEXT               , 0xA3},


### PR DESCRIPTION
Daemon can process debug messages received from BLE device.
E.g.:
![kép](https://user-images.githubusercontent.com/11043249/60839129-b266e980-a1cc-11e9-9f36-a69c0deb6e38.png)
