### PR TITLE
Fix MacOS Mojave Dark mode display issue

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -261,6 +261,12 @@ bool AppGui::initialize()
         createMainWindow();
     });
 
+#ifdef Q_OS_MAC
+    //Workaround for Qt display issues for Dark Mode
+    this->setStyleSheet("QComboBox, QRadioButton, QCheckBox:unchecked, QCheckBox:checked, QLabel, QPushButton"
+                          "{ color: black }");
+#endif
+
     return true;
 }
 


### PR DESCRIPTION
Workaround for the following Qt issue: https://bugreports.qt.io/browse/QTBUG-68850
Most elements were invisible in MacOS Mojave, when Dark mode is activated.