### PR TITLE
Persist user category names during export/import

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5087,7 +5087,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
         if (isBleExport)
         {
-            bleImpl->checkUserCategories(dataArray[15].toObject());
+            bleImpl->updateUserCategories(dataArray[15].toObject());
         }
     }
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4910,9 +4910,11 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     /** Mooltiapp / Chrome App save file **/
 
     const auto dataSize = dataArray.size();
-    const auto isBleExport = 16 == dataArray.size() && dataArray[14].toBool();
+    const bool isBleExport = EXPORT_BLE_DATA_SIZE == dataArray.size() && dataArray[EXPORT_IS_BLE].toBool();
+    const QString deviceVersion = dataArray[EXPORT_DEVICE_VERSION].toString();
     /* Checks */
-    if (!((dataArray[9].toString() == "mooltipass" && dataSize == 10) || (dataArray[9].toString() == "moolticute" && (dataSize == 14 || isBleExport))))
+    if (!((deviceVersion == "mooltipass" && dataSize == EXPORT_MP_DATA_SIZE)
+          || (deviceVersion == "moolticute" && (dataSize == EXPORT_MC_DATA_SIZE || isBleExport))))
     {
         qCritical() << "Invalid MooltiApp file";
         errorString = "Selected File Isn't Correct";
@@ -4920,7 +4922,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     /* Know which bundle we're dealing with */
-    if (dataArray[9].toString() == "mooltipass")
+    if (deviceVersion == "mooltipass")
     {
         isMooltiAppImportFile = true;
         qInfo() << "Dealing with MooltiApp export file";
@@ -4929,22 +4931,22 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qInfo() << "Dealing with Moolticute export file";
         isMooltiAppImportFile = false;
-        importedCredentialsDbChangeNumber = dataArray[11].toInt();
+        importedCredentialsDbChangeNumber = dataArray[EXPORT_CRED_CHANGE_NUMBER].toInt();
         qDebug() << "Imported cred change number: " << importedCredentialsDbChangeNumber;
-        importedDataDbChangeNumber = dataArray[12].toInt();
+        importedDataDbChangeNumber = dataArray[EXPORT_DATA_CHANGE_NUMBER].toInt();
         qDebug() << "Imported data change number: " << importedDataDbChangeNumber;
-        importedDbMiniSerialNumber = dataArray[13].toInt();
+        importedDbMiniSerialNumber = dataArray[EXPORT_DB_MINI_SERIAL_NUM].toInt();
         qDebug() << "Imported mini serial number: " << importedDbMiniSerialNumber;
     }
 
     /* Read CTR */
     importedCtrValue = QByteArray();
-    auto qjobject = dataArray[0].toObject();
+    auto qjobject = dataArray[EXPORT_CTR].toObject();
     for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(qjobject[QString::number(i)].toInt());}
     qDebug() << "Imported CTR: " << importedCtrValue.toHex();
 
     /* Read CPZ CTR values */
-    auto qjarray = dataArray[1].toArray();
+    auto qjarray = dataArray[EXPORT_CPZ_CTR].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -4974,18 +4976,18 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
     /* Read Starting Parent */
     importedStartNode = QByteArray();
-    qjarray = dataArray[2].toArray();
+    qjarray = dataArray[EXPORT_STARTING_PARENT].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(qjarray[i].toInt());}
     qDebug() << "Imported start node: " << importedStartNode.toHex();
 
     /* Read Data Starting Parent */
     importedStartDataNode = QByteArray();
-    qjarray = dataArray[3].toArray();
+    qjarray = dataArray[EXPORT_DATA_STARTING_PARENT].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(qjarray[i].toInt());}
     qDebug() << "Imported data start node: " << importedStartDataNode.toHex();
 
     /* Read favorites */
-    qjarray = dataArray[4].toArray();
+    qjarray = dataArray[EXPORT_FAVORITES].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -4996,7 +4998,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     /* Read service nodes */
-    qjarray = dataArray[5].toArray();
+    qjarray = dataArray[EXPORT_SERVICE_NODES].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -5018,7 +5020,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     /* Read service child nodes */
-    qjarray = dataArray[6].toArray();
+    qjarray = dataArray[EXPORT_SERVICE_CHILD_NODES].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -5042,7 +5044,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     if (!isMooltiAppImportFile)
     {
         /* Read service nodes */
-        qjarray = dataArray[7].toArray();
+        qjarray = dataArray[EXPORT_MC_SERVICE_NODES].toArray();
         for (qint32 i = 0; i < qjarray.size(); i++)
         {
             qjobject = qjarray[i].toObject();
@@ -5064,7 +5066,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         }
 
         /* Read service child nodes */
-        qjarray = dataArray[8].toArray();
+        qjarray = dataArray[EXPORT_MC_SERVICE_CHILD_NODES].toArray();
         for (qint32 i = 0; i < qjarray.size(); i++)
         {
             qjobject = qjarray[i].toObject();
@@ -5087,7 +5089,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
         if (isBleExport)
         {
-            bleImpl->updateUserCategories(dataArray[15].toObject());
+            bleImpl->updateUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES].toObject());
         }
     }
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4910,11 +4910,11 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     /** Mooltiapp / Chrome App save file **/
 
     const auto dataSize = dataArray.size();
-    const bool isBleExport = EXPORT_BLE_DATA_SIZE == dataArray.size() && dataArray[EXPORT_IS_BLE].toBool();
-    const QString deviceVersion = dataArray[EXPORT_DEVICE_VERSION].toString();
+    const bool isBleExport = BLE_EXPORT_FIELD_NUM == dataArray.size() && dataArray[EXPORT_IS_BLE_INDEX].toBool();
+    const QString deviceVersion = dataArray[EXPORT_DEVICE_VERSION_INDEX].toString();
     /* Checks */
-    if (!((deviceVersion == "mooltipass" && dataSize == EXPORT_MP_DATA_SIZE)
-          || (deviceVersion == "moolticute" && (dataSize == EXPORT_MC_DATA_SIZE || isBleExport))))
+    if (!((deviceVersion == "mooltipass" && dataSize == MP_EXPORT_FIELD_NUM)
+          || (deviceVersion == "moolticute" && (dataSize == MC_EXPORT_FIELD_NUM || isBleExport))))
     {
         qCritical() << "Invalid MooltiApp file";
         errorString = "Selected File Isn't Correct";
@@ -4931,22 +4931,22 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     {
         qInfo() << "Dealing with Moolticute export file";
         isMooltiAppImportFile = false;
-        importedCredentialsDbChangeNumber = dataArray[EXPORT_CRED_CHANGE_NUMBER].toInt();
+        importedCredentialsDbChangeNumber = dataArray[EXPORT_CRED_CHANGE_NUMBER_INDEX].toInt();
         qDebug() << "Imported cred change number: " << importedCredentialsDbChangeNumber;
-        importedDataDbChangeNumber = dataArray[EXPORT_DATA_CHANGE_NUMBER].toInt();
+        importedDataDbChangeNumber = dataArray[EXPORT_DATA_CHANGE_NUMBER_INDEX].toInt();
         qDebug() << "Imported data change number: " << importedDataDbChangeNumber;
-        importedDbMiniSerialNumber = dataArray[EXPORT_DB_MINI_SERIAL_NUM].toInt();
+        importedDbMiniSerialNumber = dataArray[EXPORT_DB_MINI_SERIAL_NUM_INDEX].toInt();
         qDebug() << "Imported mini serial number: " << importedDbMiniSerialNumber;
     }
 
     /* Read CTR */
     importedCtrValue = QByteArray();
-    auto qjobject = dataArray[EXPORT_CTR].toObject();
+    auto qjobject = dataArray[EXPORT_CTR_INDEX].toObject();
     for (qint32 i = 0; i < qjobject.size(); i++) {importedCtrValue.append(qjobject[QString::number(i)].toInt());}
     qDebug() << "Imported CTR: " << importedCtrValue.toHex();
 
     /* Read CPZ CTR values */
-    auto qjarray = dataArray[EXPORT_CPZ_CTR].toArray();
+    auto qjarray = dataArray[EXPORT_CPZ_CTR_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -4976,18 +4976,18 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
     /* Read Starting Parent */
     importedStartNode = QByteArray();
-    qjarray = dataArray[EXPORT_STARTING_PARENT].toArray();
+    qjarray = dataArray[EXPORT_STARTING_PARENT_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++) {importedStartNode.append(qjarray[i].toInt());}
     qDebug() << "Imported start node: " << importedStartNode.toHex();
 
     /* Read Data Starting Parent */
     importedStartDataNode = QByteArray();
-    qjarray = dataArray[EXPORT_DATA_STARTING_PARENT].toArray();
+    qjarray = dataArray[EXPORT_DATA_STARTING_PARENT_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++) {importedStartDataNode.append(qjarray[i].toInt());}
     qDebug() << "Imported data start node: " << importedStartDataNode.toHex();
 
     /* Read favorites */
-    qjarray = dataArray[EXPORT_FAVORITES].toArray();
+    qjarray = dataArray[EXPORT_FAVORITES_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -4998,7 +4998,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     /* Read service nodes */
-    qjarray = dataArray[EXPORT_SERVICE_NODES].toArray();
+    qjarray = dataArray[EXPORT_SERVICE_NODES_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -5020,7 +5020,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     /* Read service child nodes */
-    qjarray = dataArray[EXPORT_SERVICE_CHILD_NODES].toArray();
+    qjarray = dataArray[EXPORT_SERVICE_CHILD_NODES_INDEX].toArray();
     for (qint32 i = 0; i < qjarray.size(); i++)
     {
         qjobject = qjarray[i].toObject();
@@ -5044,7 +5044,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     if (!isMooltiAppImportFile)
     {
         /* Read service nodes */
-        qjarray = dataArray[EXPORT_MC_SERVICE_NODES].toArray();
+        qjarray = dataArray[EXPORT_MC_SERVICE_NODES_INDEX].toArray();
         for (qint32 i = 0; i < qjarray.size(); i++)
         {
             qjobject = qjarray[i].toObject();
@@ -5066,7 +5066,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         }
 
         /* Read service child nodes */
-        qjarray = dataArray[EXPORT_MC_SERVICE_CHILD_NODES].toArray();
+        qjarray = dataArray[EXPORT_MC_SERVICE_CHILD_NODES_INDEX].toArray();
         for (qint32 i = 0; i < qjarray.size(); i++)
         {
             qjobject = qjarray[i].toObject();
@@ -5089,7 +5089,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
         if (isBleExport)
         {
-            bleImpl->updateUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES].toObject());
+            bleImpl->updateUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES_INDEX].toObject());
         }
     }
 

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -408,27 +408,27 @@ protected:
     IMessageProtocol *pMesProt = nullptr;
 
     DeviceType deviceType = DeviceType::MOOLTIPASS;
-    static constexpr int EXPORT_MP_DATA_SIZE = 10;
-    static constexpr int EXPORT_MC_DATA_SIZE = 14;
-    static constexpr int EXPORT_BLE_DATA_SIZE = 16;
+    static constexpr int MP_EXPORT_FIELD_NUM = 10;
+    static constexpr int MC_EXPORT_FIELD_NUM = 14;
+    static constexpr int BLE_EXPORT_FIELD_NUM = 16;
     enum ExportPayloadData
     {
-        EXPORT_CTR = 0,
-        EXPORT_CPZ_CTR = 1,
-        EXPORT_STARTING_PARENT = 2,
-        EXPORT_DATA_STARTING_PARENT = 3,
-        EXPORT_FAVORITES = 4,
-        EXPORT_SERVICE_NODES = 5,
-        EXPORT_SERVICE_CHILD_NODES = 6,
-        EXPORT_MC_SERVICE_NODES = 7,
-        EXPORT_MC_SERVICE_CHILD_NODES = 8,
-        EXPORT_DEVICE_VERSION = 9,
-        EXPORT_BUNDLE_VERSION = 10,
-        EXPORT_CRED_CHANGE_NUMBER = 11,
-        EXPORT_DATA_CHANGE_NUMBER = 12,
-        EXPORT_DB_MINI_SERIAL_NUM = 13,
-        EXPORT_IS_BLE = 14,
-        EXPORT_BLE_USER_CATEGORIES = 15
+        EXPORT_CTR_INDEX = 0,
+        EXPORT_CPZ_CTR_INDEX = 1,
+        EXPORT_STARTING_PARENT_INDEX = 2,
+        EXPORT_DATA_STARTING_PARENT_INDEX = 3,
+        EXPORT_FAVORITES_INDEX = 4,
+        EXPORT_SERVICE_NODES_INDEX = 5,
+        EXPORT_SERVICE_CHILD_NODES_INDEX = 6,
+        EXPORT_MC_SERVICE_NODES_INDEX = 7,
+        EXPORT_MC_SERVICE_CHILD_NODES_INDEX = 8,
+        EXPORT_DEVICE_VERSION_INDEX = 9,
+        EXPORT_BUNDLE_VERSION_INDEX = 10,
+        EXPORT_CRED_CHANGE_NUMBER_INDEX = 11,
+        EXPORT_DATA_CHANGE_NUMBER_INDEX = 12,
+        EXPORT_DB_MINI_SERIAL_NUM_INDEX = 13,
+        EXPORT_IS_BLE_INDEX = 14,
+        EXPORT_BLE_USER_CATEGORIES_INDEX = 15
     };
 };
 

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -408,6 +408,28 @@ protected:
     IMessageProtocol *pMesProt = nullptr;
 
     DeviceType deviceType = DeviceType::MOOLTIPASS;
+    static constexpr int EXPORT_MP_DATA_SIZE = 10;
+    static constexpr int EXPORT_MC_DATA_SIZE = 14;
+    static constexpr int EXPORT_BLE_DATA_SIZE = 16;
+    enum ExportPayloadData
+    {
+        EXPORT_CTR = 0,
+        EXPORT_CPZ_CTR = 1,
+        EXPORT_STARTING_PARENT = 2,
+        EXPORT_DATA_STARTING_PARENT = 3,
+        EXPORT_FAVORITES = 4,
+        EXPORT_SERVICE_NODES = 5,
+        EXPORT_SERVICE_CHILD_NODES = 6,
+        EXPORT_MC_SERVICE_NODES = 7,
+        EXPORT_MC_SERVICE_CHILD_NODES = 8,
+        EXPORT_DEVICE_VERSION = 9,
+        EXPORT_BUNDLE_VERSION = 10,
+        EXPORT_CRED_CHANGE_NUMBER = 11,
+        EXPORT_DATA_CHANGE_NUMBER = 12,
+        EXPORT_DB_MINI_SERIAL_NUM = 13,
+        EXPORT_IS_BLE = 14,
+        EXPORT_BLE_USER_CATEGORIES = 15
+    };
 };
 
 #endif // MPDEVICE_H

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -500,10 +500,34 @@ void MPDeviceBleImpl::updateChangeNumbers(AsyncJobs *jobs, quint8 flags)
     }
 }
 
-void MPDeviceBleImpl::checkUserCategories(const QJsonObject &categories)
+void MPDeviceBleImpl::updateUserCategories(const QJsonObject &categories)
 {
-    //TODO implement
-    qDebug() << "User category number: " << categories.size();
+    if (isUserCategoriesChanged(categories))
+    {
+        qDebug() << "Updating user category names";
+        setUserCategories(categories,
+                          [](bool success, QString errstr, QByteArray)
+                            {
+                                if (!success)
+                                {
+                                    qCritical() << "Update user categories failed: " << errstr;
+                                }
+                            }
+        );
+    }
+}
+
+bool MPDeviceBleImpl::isUserCategoriesChanged(const QJsonObject &categories) const
+{
+    for (int i = 0; i < USER_CATEGORY_COUNT; ++i)
+    {
+        QString categoryName = "category_" + QString::number(i+1);
+        if (categories[categoryName] != m_categories[categoryName])
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -391,7 +391,7 @@ void MPDeviceBleImpl::setUserCategories(const QJsonObject &categories, const Mes
 
     jobs->append(new MPCommandJob(mpDev, MPCmd::SET_USER_CATEGORIES,
                                   createUserCategoriesMsg(categories),
-                            [this, cb](const QByteArray &data, bool &)
+                            [this, cb, categories](const QByteArray &data, bool &)
                             {
                                 if (MSG_FAILED == bleProt->getFirstPayloadByte(data))
                                 {
@@ -399,6 +399,7 @@ void MPDeviceBleImpl::setUserCategories(const QJsonObject &categories, const Mes
                                     cb(false, "Set user categories failed", QByteArray{});
                                     return true;
                                 }
+                                m_categories = categories;
                                 qDebug() << "User categories set successfully";
                                 cb(true, "", QByteArray{});
                                 return true;
@@ -423,6 +424,7 @@ void MPDeviceBleImpl::fillGetCategory(const QByteArray& data, QJsonObject &categ
                                    [](const QChar& c) { return c == QChar{0xFFFF};});
         categories[catName] = defaultCat ? "" : category;
     }
+    m_categories = categories;
 }
 
 QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categories)
@@ -496,6 +498,12 @@ void MPDeviceBleImpl::updateChangeNumbers(AsyncJobs *jobs, quint8 flags)
                                       bleProt->toLittleEndianFromInt32(mpDev->get_dataDbChangeNumber()),
                                       bleProt->getDefaultFuncDone()));
     }
+}
+
+void MPDeviceBleImpl::checkUserCategories(const QJsonObject &categories)
+{
+    //TODO implement
+    qDebug() << "User category number: " << categories.size();
 }
 
 QByteArray MPDeviceBleImpl::createStoreCredMessage(const BleCredential &cred)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -82,6 +82,9 @@ public:
 
     void updateChangeNumbers(AsyncJobs *jobs, quint8 flags);
 
+    QJsonObject getUserCategories() const { return m_categories; };
+    void checkUserCategories(const QJsonObject &categories);
+
 signals:
     void userSettingsChanged(QJsonObject settings);
 
@@ -107,6 +110,7 @@ private:
     QString m_debugMsg = "";
 
     MPBLEFreeAddressProvider freeAddressProv;
+    QJsonObject m_categories;
 
     static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -83,7 +83,8 @@ public:
     void updateChangeNumbers(AsyncJobs *jobs, quint8 flags);
 
     QJsonObject getUserCategories() const { return m_categories; };
-    void checkUserCategories(const QJsonObject &categories);
+    void updateUserCategories(const QJsonObject &categories);
+    bool isUserCategoriesChanged(const QJsonObject &categories) const;
 
 signals:
     void userSettingsChanged(QJsonObject settings);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1122,10 +1122,19 @@ void MainWindow::dbImported(bool success, QString message)
 {
     ui->widgetHeader->setEnabled(true);
     disconnect(wsClient, &WSClient::dbImported, this, &MainWindow::dbImported);
-    if (!success)
-        QMessageBox::warning(this, tr("Error"), message);
-    else
+    if (success)
+    {
+        if (wsClient->isMPBLE())
+        {
+            wsClient->sendGetUserCategories();
+        }
         QMessageBox::information(this, tr("Moolticute"), tr("Successfully imported and merged database into the device."));
+    }
+    else
+    {
+        QMessageBox::warning(this, tr("Error"), message);
+    }
+
 
     ui->stackedWidget->setCurrentWidget(ui->pageSync);
 


### PR DESCRIPTION
- Persist user category names and isBle information in the exported payload
- Loading user category names during import if available
- Changed magic number in import functions