### PR TITLE
Remove category from LoginItem JsonObject for Mini

### DIFF
--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -75,8 +75,7 @@ QJsonObject LoginItem::toJson() const
                        { "password", p },
                        { "description", m_sDescription },
                        { "address", addr },
-                       { "favorite", m_iFavorite },
-                       { "category", m_iCategory }
+                       { "favorite", m_iFavorite }
                };
 
     if (DeviceDetector::instance().isBle())


### PR DESCRIPTION
Remained during #482, causing invalid json size for Mini.