### PR TITLE
#487 Handle when reset occurs

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -49,6 +49,7 @@
 #define CMD_MAX_RETRY            3 //retry sending command before dropping
 #define CMD_DEFAULT_TIMEOUT     0xFFAAFFAA
 #define CMD_DEFAULT_TIMEOUT_VAL 3000 //3seconds default timeout
+#define CMD_LONG_MSG_TIMEOUT    2000
 
 //Data node header size. It contains the size of data in 4 bytes Big endian
 #define MP_DATA_HEADER_SIZE      4

--- a/src/Common.h
+++ b/src/Common.h
@@ -49,7 +49,6 @@
 #define CMD_MAX_RETRY            3 //retry sending command before dropping
 #define CMD_DEFAULT_TIMEOUT     0xFFAAFFAA
 #define CMD_DEFAULT_TIMEOUT_VAL 3000 //3seconds default timeout
-#define CMD_LONG_MSG_TIMEOUT    2000
 
 //Data node header size. It contains the size of data in 4 bytes Big endian
 #define MP_DATA_HEADER_SIZE      4

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -66,6 +66,13 @@ public:
     void setCurrentFlipBit(QByteArray &msg);
     void flipMessageBit(QVector<QByteArray> &msg);
     void flipMessageBit(QByteArray &msg);
+    /**
+     * @brief processReceivedData
+     * @param data actual packet from the device
+     * @param dataReceived full message data
+     * @return true if data is last packet of the message
+     */
+    bool processReceivedData(const QByteArray& data, QByteArray& dataReceived);
 
     bool isAfterAuxFlash();
 
@@ -95,6 +102,9 @@ signals:
     void userSettingsChanged(QJsonObject settings);
     void bleDeviceLanguage(const QJsonObject& langs);
     void bleKeyboardLayout(const QJsonObject& layouts);
+
+private slots:
+    void handleLongMessageTimeout();
 
 private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
@@ -130,6 +140,8 @@ private:
     static constexpr int USER_CATEGORY_LENGTH = 66;
     static constexpr int FAV_DATA_SIZE = 4;
     static constexpr int FAV_NUMBER = 50;
+    static constexpr int LONG_MESSAGE_TIMEOUT_MS = 2000;
+    static constexpr int FIRST_PACKET_PAYLOAD_SIZE = 58;
     const QString AFTER_AUX_FLASH_SETTING = "settings/after_aux_flash";
 };
 


### PR DESCRIPTION
Implemented the workaround @limpkin mentioned in #487:
> 
> 
> strategy to be implemented on moolticute's side: whenever multiple packets are expected, if another packet isn't received withing 2 seconds, reset moolticute comms

I added a 2 sec timer when based on the first received packet multiple packets are expected.
If the timer expires it removes the actual command from the queue and returns the job with failure, after that the command processing is continuing.

I was not able to test it, because I have never experienced a reset. So I tested with adding random sleeps for longer messages and it fixed the communication when the timer expired.