### PR TITLE
Make sure init messages are called first with a TimerJob

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -165,16 +165,6 @@ void MPDevice::sendInitMessages()
     }
 
     exitMemMgmtMode(false);
-    //TODO Remove when GET_MOOLTIPASS_PARM implemented for BLE
-    /**
-      * Temporary solution until GET_MOOLTIPASS_PARM
-      * is not implemented for the ble device we do not
-      * get if BLE is detected.
-      */
-    if (isBLE())
-    {
-        flashMbSizeChanged(0);
-    }
 }
 
 void MPDevice::sendData(MPCmd::Command c, const QByteArray &data, quint32 timeout, MPCommandCb cb, bool checkReturn)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -232,6 +232,7 @@ private:
     /* Platform function for writing data, should be implemented in platform class */
     virtual void platformWrite(const QByteArray &data) { Q_UNUSED(data); }
 
+    void addTimerJob(int msec);
     void loadLoginNode(AsyncJobs *jobs, const QByteArray &address,
                        const MPDeviceProgressCb &cbProgress);
     void loadLoginChildNode(AsyncJobs *jobs, MPNode *parent, MPNode *parentClone, const QByteArray &address);
@@ -433,6 +434,8 @@ protected:
         EXPORT_IS_BLE_INDEX = 14,
         EXPORT_BLE_USER_CATEGORIES_INDEX = 15
     };
+    static constexpr int STATUS_STARTING_DELAY = 500;
+    static constexpr int INIT_STARTING_DELAY = 300;
 };
 
 #endif // MPDEVICE_H


### PR DESCRIPTION
Originally with the `QTimer::singleShot` delay, it was not guaranteed the init messages are called first, because during the 100 msec delay it was possible the GUI is requesting some data (e.g.: user category, language/layout related commands) and those were sent earlier causing a stuck in communication.
So I added a `TimerJob` first with a higher (300 msec) timeout, so there won't be any job added to the commandqueue before the init messages. However reset flip bit is written directly to the device without using the commandqueue, hence for reset flip bit a lower delay (150 msec) is still necessary.