### PR TITLE
#479 Workaround for Mac systray menu disabled issue

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -176,6 +176,9 @@ bool AppGui::initialize()
 #else
         Q_UNUSED(this)
         Q_UNUSED(reason)
+#if QT_VERSION >= QT_VERSION_CHECK(5,12,0)
+        mainWindowShow();
+#endif
 #endif
     });
 


### PR DESCRIPTION
Implemented a workaround, wrote an analysis here:
https://github.com/mooltipass/moolticute/issues/479#issuecomment-546713609

Fix for #508 too. 