### PR TITLE
#486 Fix winapi WriteFile buffer deallocation issue

### DIFF
--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -195,6 +195,8 @@ void MPDevice_win::platformWriteToDevice(const QByteArray &data)
     const auto bufferSize = static_cast<size_t>(ba.size());
     char* buffer = new char[bufferSize];
     std::memcpy(buffer, ba.constData(), bufferSize);
+    m_writeBufferQueue.enqueue(buffer);
+
     bool ret = WriteFile(platformDef.devHandle,
                          buffer,
                          bufferSize,
@@ -401,6 +403,7 @@ void MPDevice_win::ovlpNotified(quint32 numberOfBytes, quint32 errorCode, OVERLA
 
 void MPDevice_win::writeDataFinished()
 {
+    delete[] m_writeBufferQueue.dequeue();
     if (m_writeQueue.isEmpty())
     {
         // WriteQueue is empty, platformWrite was called directly

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -19,6 +19,7 @@
 #include "MPDevice_win.h"
 #include "HIDLoader.h"
 #include "AppDaemon.h"
+#include <cstring>
 
 // Windows GUID object
 static GUID IClassGuid = {0x4d1e55b2, 0xf16f, 0x11cf, {0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30} };
@@ -191,9 +192,12 @@ void MPDevice_win::platformWriteToDevice(const QByteArray &data)
 
     ::ZeroMemory(&writeOverlapped, sizeof(writeOverlapped));
 
+    const auto bufferSize = static_cast<size_t>(ba.size());
+    char* buffer = new char[bufferSize];
+    std::memcpy(buffer, ba.constData(), bufferSize);
     bool ret = WriteFile(platformDef.devHandle,
-                         ba.constData(),
-                         ba.size(),
+                         buffer,
+                         bufferSize,
                          nullptr,
                          &writeOverlapped);
 

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -192,6 +192,11 @@ void MPDevice_win::platformWriteToDevice(const QByteArray &data)
 
     ::ZeroMemory(&writeOverlapped, sizeof(writeOverlapped));
 
+    /**
+     * Need to copy the local buffer, because WriteFile is
+     * async and it is possible using the buffer after this
+     * function returned and QByteArray was deallocated.
+     */
     const auto bufferSize = static_cast<size_t>(ba.size());
     char* buffer = new char[bufferSize];
     std::memcpy(buffer, ba.constData(), bufferSize);
@@ -211,10 +216,6 @@ void MPDevice_win::platformWriteToDevice(const QByteArray &data)
     {
         qWarning() << "Failed to write data to device! " << err;
         qWarning() << getLastError(err);
-    }
-    if (AppDaemon::isDebugDev())
-    {
-        qDebug() << "Written to device: " << ba.toHex() << ", Error: " << err;
     }
 }
 

--- a/src/MPDevice_win.h
+++ b/src/MPDevice_win.h
@@ -114,7 +114,8 @@ private:
     OVERLAPPED readOverlapped;
     QWinOverlappedIoNotifier *oNotifier;
 	
-	QQueue<QByteArray> m_writeQueue;
+    QQueue<QByteArray> m_writeQueue;
+    QQueue<char*> m_writeBufferQueue;
 
     const static QString BT_GATT_SERVICE_GUID;
     const static char ZERO_BYTE = static_cast<char>(0x00);


### PR DESCRIPTION
Analysed in https://github.com/mooltipass/moolticute/issues/486#issuecomment-557839802.

https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile#parameters

> lpBuffer
> 
> A pointer to the buffer containing the data to be written to the file or device.
> 
> **This buffer must remain valid for the duration of the write operation.** The caller must not use this buffer until the write operation is completed.

char* buffer was used from local variable `QByteArray ba`, but it is possible the write operation is not finished by the execution returns from `MPDevice_win::platformWriteToDevice` and in that case write operation is using a pointer to a deallocated buffer, which we can see in the #486 attached logs.

Copying the buffer into a new char* and deleting it when the write operation finished solves the issue.