### PR TITLE
#512 Enlarge keyboard layout comboboxes for BLE

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -452,6 +452,11 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(ui->checkBoxLockDevice, &QCheckBox::toggled, this, &MainWindow::onLockDeviceSystemEventsChanged);
 
     wsClient->settingsHelper()->setMainWindow(this);
+#ifdef Q_OS_WIN
+    const auto keyboardLayoutWidth = 150;
+    ui->comboBoxBtLayout->setMinimumWidth(keyboardLayoutWidth);
+    ui->comboBoxUsbLayout->setMinimumWidth(keyboardLayoutWidth);
+#endif
 
     //Setup the confirm view
     ui->widgetSpin->setPixmap(AppGui::qtAwesome()->icon(fa::circleonotch).pixmap(QSize(80, 80)));

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -698,7 +698,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    <widget class="QComboBox" name="comboBoxBtLayout">
                     <property name="minimumSize">
                      <size>
-                      <width>120</width>
+                      <width>200</width>
                       <height>0</height>
                      </size>
                     </property>
@@ -746,7 +746,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    <widget class="QComboBox" name="comboBoxUsbLayout">
                     <property name="minimumSize">
                      <size>
-                      <width>120</width>
+                      <width>200</width>
                       <height>0</height>
                      </size>
                     </property>


### PR DESCRIPTION
Linux:
![keyboardLayout_linux](https://user-images.githubusercontent.com/11043249/69569163-5a832080-0fbd-11ea-9322-22f0f5254d9d.png)
Mac:
![keyboardLayout_mac](https://user-images.githubusercontent.com/11043249/69569172-5e16a780-0fbd-11ea-91cc-513bc28e21c4.png)
Windows:
![keyboardLayout_win](https://user-images.githubusercontent.com/11043249/69569176-61aa2e80-0fbd-11ea-9841-029603f34ea0.png)
