### PR TITLE
[BLE] Fix Aux MCU Flash crash on Mac

### DIFF
--- a/src/MPDevice_mac.cpp
+++ b/src/MPDevice_mac.cpp
@@ -52,13 +52,14 @@ MPDevice_mac::MPDevice_mac(QObject *parent, const MPPlatformDef &platformDef):
         deviceType = DeviceType::BLE;
         isBluetooth = platformDef.isBluetooth;
     }
-    setupMessageProtocol();
     /**
       * With only one thread for the threadpool
       * the writes will keep the original order.
       */
     usbWriteThreadPool = new QThreadPool(this);
     usbWriteThreadPool->setMaxThreadCount(1);
+
+    setupMessageProtocol();
 
     IOReturn ret = IOHIDDeviceOpen(hidref, kIOHIDOptionsTypeSeizeDevice);
     if (ret != kIOReturnSuccess)


### PR DESCRIPTION
After Aux MCU Flash a cancel user request message is written directly to the device:
https://github.com/mooltipass/moolticute/blob/master/src/MPDevice.cpp#L162
This one is called from setupMessageProtocol, which was called before initializing the QThreadPool.