### PR TITLE
[BLE] Handle invalid number of layout and language sent

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -648,6 +648,11 @@ void MPDeviceBleImpl::readLanguages()
                         const auto payload = bleProt->getFullPayload(data);
                         const int langNum = bleProt->toIntFromLittleEndian(payload[0], payload[1]);
                         qDebug() << "Language number: " << langNum;
+                        if (INVALID_LAYOUT_LANG_SIZE == langNum)
+                        {
+                            qCritical() << "Invalid number of languages";
+                            return false;
+                        }
                         for (int i = 0; i < langNum; ++i)
                         {
                             jobs->append(new MPCommandJob(mpDev,
@@ -679,6 +684,11 @@ void MPDeviceBleImpl::readLanguages()
                         const auto payload = bleProt->getFullPayload(data);
                         const auto layoutNum = bleProt->toIntFromLittleEndian(payload[0], payload[1]);
                         qDebug() << "Keyboard layout number: " << layoutNum;
+                        if (INVALID_LAYOUT_LANG_SIZE == layoutNum)
+                        {
+                            qCritical() << "Invalid number of keyboard layouts";
+                            return false;
+                        }
                         for (int i = 0; i < layoutNum; ++i)
                         {
                             jobs->append(new MPCommandJob(mpDev,

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -143,6 +143,7 @@ private:
     static constexpr int FAV_NUMBER = 50;
     static constexpr int LONG_MESSAGE_TIMEOUT_MS = 2000;
     static constexpr int FIRST_PACKET_PAYLOAD_SIZE = 58;
+    static constexpr int INVALID_LAYOUT_LANG_SIZE = 0xFFFF;
     const QString AFTER_AUX_FLASH_SETTING = "settings/after_aux_flash";
 };
 


### PR DESCRIPTION
When there is no bundle on the device 0xFFFF (65536) returned from the device for `0x0019: Get Number of Languages` and `0x001A: Get Number of Keyboard Layouts` messages.