### PR TITLE
[BLE] Handle when ping is received

### DIFF
--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -56,8 +56,11 @@ void WSServerCon::processMessage(const QString &message)
     QJsonParseError err;
     QJsonDocument jdoc = QJsonDocument::fromJson(message.toUtf8(), &err);
 
-    if (!message.startsWith("{\"ping"))
-        qDebug().noquote() << "JSON API recv:" << Common::maskLog(message);
+    if (message.startsWith("{\"ping"))
+    {
+        return;
+    }
+    qDebug().noquote() << "JSON API recv:" << Common::maskLog(message);
 
     if (err.error != QJsonParseError::NoError)
     {


### PR DESCRIPTION
When `ping` is received the following line was printed:
`DEBUG: (2019-12-03T19:25:06.301) WSServerCon.cpp:1165 - QJsonValue(null)  message have not implemented yet for BLE`
Because msg field is `Null` for ping message.
Also ping is not processed at all so I can return after the check.