### PR TITLE
[BLE] Fetch keyboard layout and language after every BLE device connection #500

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -374,7 +374,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         {
             ui->groupBox_Information->hide();
         }
-        onDeviceConnected();
+        updateDeviceDependentUI();
     });
 
     connect(wsClient, &WSClient::fwVersionChanged, wsClient->settingsHelper(), &SettingsGuiHelper::checkKeyboardLayout);
@@ -534,6 +534,20 @@ void MainWindow::changeEvent(QEvent *event)
         retranslateUi();
     }
     QMainWindow::changeEvent(event);
+}
+
+void MainWindow::updateDeviceDependentUI()
+{
+    if (wsClient->isMPBLE())
+    {
+        ui->groupBox_UserSettings->show();
+        ui->pushButtonFiles->hide();
+    }
+    else
+    {
+        ui->groupBox_UserSettings->hide();
+        ui->pushButtonFiles->show();
+    }
 }
 
 void MainWindow::updateBackupControlsVisibility(bool visible)
@@ -1627,14 +1641,8 @@ void MainWindow::onDeviceConnected()
     if (wsClient->isMPBLE())
     {
         wsClient->sendUserSettingsRequest();
-        ui->groupBox_UserSettings->show();
-        ui->pushButtonFiles->hide();
     }
-    else
-    {
-        ui->groupBox_UserSettings->hide();
-        ui->pushButtonFiles->show();
-    }
+    updateDeviceDependentUI();
 }
 
 void MainWindow::onDeviceDisconnected()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -166,6 +166,8 @@ private:
     virtual void closeEvent(QCloseEvent *event);
     virtual void changeEvent(QEvent *event);
 
+    void updateDeviceDependentUI();
+
     void checkAutoStart();
     
     void checkSubdomainSelection();

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -56,10 +56,5 @@ void SettingsGuiBLE::updateUI()
 
 void SettingsGuiBLE::setupKeyboardLayout()
 {
-    if (ui->comboBoxUsbLayout->count() > 0)
-    {
-        //Combobox for BLE layouts is filled
-        return;
-    }
     m_mw->wsClient->requestBleKeyboardLayout();
 }


### PR DESCRIPTION
Removed the check where requestBleKeyboardLayout was only sent when the layout combobox is empty.
Also made sure `requestBleKeyboardLayout` only sent once on device connection.