### PR TITLE
[BLE] Add device setting "Device lock on USB disconnect"

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1396,6 +1396,13 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxDeviceLockUSBDisc">
+                 <property name="text">
+                  <string>Device Lock on USB Disconnection</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -217,7 +217,8 @@ public:
         DEVICE_LANGUAGE,
         USER_LANGUAGE,
         KEYBOARD_USB_LAYOUT,
-        KEYBOARD_BT_LAYOUT
+        KEYBOARD_BT_LAYOUT,
+        DEVICE_LOCK_USB_DISC
     };
     Q_ENUM(Param)
 };

--- a/src/Settings/DeviceSettingsBLE.cpp
+++ b/src/Settings/DeviceSettingsBLE.cpp
@@ -23,5 +23,7 @@ void DeviceSettingsBLE::fillParameterMapping()
     m_bleByteMapping[MPParams::PROMPT_ANIMATION_PARAM] = ANIMATION_DURING_PROMPT_BYTE;
     m_paramMap.insert(MPParams::BOOT_ANIMATION_PARAM, "bool_animation");
     m_bleByteMapping[MPParams::BOOT_ANIMATION_PARAM] = BOOT_ANIMATION_BYTE;
+    m_paramMap.insert(MPParams::DEVICE_LOCK_USB_DISC, "device_lock_usb_disc");
+    m_bleByteMapping[MPParams::DEVICE_LOCK_USB_DISC] = DEVICE_LOCK_USB_BYTE;
 }
 

--- a/src/Settings/DeviceSettingsBLE.h
+++ b/src/Settings/DeviceSettingsBLE.h
@@ -15,6 +15,7 @@ class DeviceSettingsBLE : public DeviceSettings
     QT_SETTINGS_PROPERTY(bool, reserved_ble, false, MPParams::RESERVED_BLE)
     QT_SETTINGS_PROPERTY(bool, prompt_animation, false, MPParams::PROMPT_ANIMATION_PARAM)
     QT_SETTINGS_PROPERTY(bool, bool_animation, false, MPParams::BOOT_ANIMATION_PARAM)
+    QT_SETTINGS_PROPERTY(bool, device_lock_usb_disc, false, MPParams::DEVICE_LOCK_USB_DISC)
 
 public:
     DeviceSettingsBLE(QObject *parent);
@@ -30,7 +31,8 @@ public:
         DEFAULT_CHAR_AFTER_LOGIN = 5,
         DEFAULT_CHAR_AFTER_PASS = 6,
         DELAY_BETWEEN_KEY_PRESS = 7,
-        BOOT_ANIMATION_BYTE = 8
+        BOOT_ANIMATION_BYTE = 8,
+        DEVICE_LOCK_USB_BYTE = 10
     };
 
     static constexpr char USB_LAYOUT_ID = 0x01;

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -49,7 +49,8 @@ void SettingsGuiHelper::setMainWindow(MainWindow *mw)
         {MPParams::USER_LANGUAGE, ui->comboBoxUserLanguage},
         {MPParams::KEYBOARD_USB_LAYOUT, ui->comboBoxUsbLayout},
         {MPParams::KEYBOARD_BT_LAYOUT, ui->comboBoxBtLayout},
-        {MPParams::BOOT_ANIMATION_PARAM, ui->checkBoxBootAnim}
+        {MPParams::BOOT_ANIMATION_PARAM, ui->checkBoxBootAnim},
+        {MPParams::DEVICE_LOCK_USB_DISC, ui->checkBoxDeviceLockUSBDisc}
     };
     //When something changed in GUI, show save/reset buttons
     for (const auto& widget : m_widgetMapping)


### PR DESCRIPTION
Added new "Device lock on USB disconnect" device setting to BLE's General Settings section:
![kép](https://user-images.githubusercontent.com/11043249/70391847-de83d200-19d9-11ea-801e-239004edc0bb.png)
