### PR TITLE
[BLE] Keyboard layout and languages related fixes

### DIFF
--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -208,6 +208,8 @@ public:
     void updateFileInCache(QString fileName, int size);
     void removeFileFromCache(QString fileName);
 
+    void loadParams() { pSettings->loadParameters(); }
+
 signals:
     /* Signal emited by platform code when new data comes from MP */
     /* A signal is used for platform code that uses a dedicated thread */

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -371,15 +371,21 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(wsClient, &WSClient::updateBLEDeviceLanguage,
             [this](const QJsonObject& langs)
             {
-                updateBLEComboboxItems(ui->comboBoxDeviceLang, langs);
-                updateBLEComboboxItems(ui->comboBoxUserLanguage, langs);
+                if (shouldUpdateItems(m_languagesCache, langs))
+                {
+                    updateBLEComboboxItems(ui->comboBoxDeviceLang, langs);
+                    updateBLEComboboxItems(ui->comboBoxUserLanguage, langs);
+                }
             }
     );
     connect(wsClient, &WSClient::updateBLEKeyboardLayout,
             [this](const QJsonObject& layouts)
             {
-                updateBLEComboboxItems(ui->comboBoxUsbLayout, layouts);
-                updateBLEComboboxItems(ui->comboBoxBtLayout, layouts);
+                if (shouldUpdateItems(m_keyboardLayoutCache, layouts))
+                {
+                    updateBLEComboboxItems(ui->comboBoxUsbLayout, layouts);
+                    updateBLEComboboxItems(ui->comboBoxBtLayout, layouts);
+                }
                 wsClient->settingsHelper()->resetSettings();
             }
     );
@@ -1447,6 +1453,17 @@ void MainWindow::updateBLEComboboxItems(QComboBox *cb, const QJsonObject& items)
     cb->model()->setParent(proxy);
     cb->setModel(proxy);
     cb->model()->sort(0);
+}
+
+bool MainWindow::shouldUpdateItems(QJsonObject &cache, const QJsonObject &received)
+{
+    if (cache == received)
+    {
+        return false;
+    }
+
+    cache = received;
+    return true;
 }
 
 void MainWindow::on_toolButton_clearBackupFilePath_released()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -168,11 +168,27 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(ui->widgetFiles, &FilesManagement::wantEnterMemMode, this, &MainWindow::wantEnterCredentialManagement);
     connect(ui->widgetFiles, &FilesManagement::wantExitMemMode, this, &MainWindow::wantExitFilesManagement);
 
-    connect(wsClient, &WSClient::statusChanged, [this]()
+    connect(wsClient, &WSClient::statusChanged, [this](Common::MPStatus status)
     {
-        this->enableKnockSettings(wsClient->get_status() == Common::NoCardInserted);
-        if (wsClient->get_status() == Common::UnkownSmartcad)
+        this->enableKnockSettings(status == Common::NoCardInserted);
+        if (status == Common::UnkownSmartcad)
             ui->stackedWidget->setCurrentWidget(ui->pageSync);
+        qCritical() << "Actual status: " << Common::MPStatusString[status];
+        if (wsClient->isMPBLE())
+        {
+            if (Common::NoCardInserted == status)
+            {
+                ui->settings_user_language->hide();
+                ui->settings_bt_layout->hide();
+                ui->settings_usb_layout->hide();
+            }
+            else
+            {
+                ui->settings_user_language->show();
+                ui->settings_bt_layout->show();
+                ui->settings_usb_layout->show();
+            }
+        }
     });
 
     ui->pushButtonExportFile->setStyleSheet(CSS_BLUE_BUTTON);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -173,7 +173,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         this->enableKnockSettings(status == Common::NoCardInserted);
         if (status == Common::UnkownSmartcad)
             ui->stackedWidget->setCurrentWidget(ui->pageSync);
-        qCritical() << "Actual status: " << Common::MPStatusString[status];
+
         if (wsClient->isMPBLE())
         {
             if (Common::NoCardInserted == status)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -188,6 +188,11 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
                 ui->settings_bt_layout->show();
                 ui->settings_usb_layout->show();
             }
+
+            if (Common::Unlocked == status)
+            {
+                wsClient->sendLoadParams();
+            }
         }
     });
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -184,6 +184,8 @@ private:
 
     void updateBLEComboboxItems(QComboBox *cb, const QJsonObject& items);
 
+    bool shouldUpdateItems(QJsonObject& cache, const QJsonObject& received);
+
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 
@@ -211,6 +213,9 @@ private:
     void initHelpLabels();
 
     SystemEventHandler eventHandler;
+
+    QJsonObject m_keyboardLayoutCache;
+    QJsonObject m_languagesCache;
 
     const QString HIBP_URL = "https://haveibeenpwned.com/Passwords";
 };

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -56,10 +56,5 @@ void SettingsGuiBLE::updateUI()
 
 void SettingsGuiBLE::setupKeyboardLayout()
 {
-    if (ui->comboBoxUsbLayout->count() > 0)
-    {
-        //Combobox for BLE layouts is filled
-        return;
-    }
     m_mw->wsClient->requestBleKeyboardLayout();
 }

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -708,6 +708,11 @@ void WSClient::sendUserSettingsRequest()
     sendJsonData({{ "msg", "get_user_settings" }});
 }
 
+void WSClient::sendLoadParams()
+{
+    sendJsonData({{ "msg", "load_params" }});
+}
+
 void WSClient::requestBleKeyboardLayout()
 {
     sendJsonData({{ "msg", "request_keyboard_layout" }});

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -104,6 +104,7 @@ public:
     void sendGetUserCategories();
     void sendSetUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
     void sendUserSettingsRequest();
+    void sendLoadParams();
 
     inline bool isFw12() const { return isFwVersion(12); }
     inline bool isFw13() const { return isFwVersion(13); }

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -362,6 +362,10 @@ void WSServerCon::processMessage(const QString &message)
         },
         defaultProgressCb);
     }
+    else if (root["msg"] == "load_params")
+    {
+        mpdevice->loadParams();
+    }
     else if (mpdevice->isBLE())
     {
         processMessageBLE(root, defaultProgressCb);


### PR DESCRIPTION
### Fixes:
- #552 fixed: fetching parameters, when user is logged in
- Only display Current User Language, Bluetooth Keyboard Layout and USB Keyboard Layout, when user is logged in
- Implemented a cache mechanism for layout and language and only update the lists when a different is received