### PR TITLE
[BLE] Add Knock detection setting #551

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -489,7 +489,7 @@ void MPDeviceBleImpl::readUserSettings(const QByteArray& settings)
         set_storagePrompt(d&STORAGE_PROMPT);
         set_advancedMenu(d&ADVANCED_MENU);
         set_bluetoothEnabled(d&BLUETOOTH_ENABLED);
-        set_credentialDisplayPrompt(d&CREDENTIAL_PROMPT);
+        set_knockDisabled(d&KNOCK_DISABLED);
         m_currentUserSettings = d;
         sendUserSettings();
     }
@@ -503,7 +503,7 @@ void MPDeviceBleImpl::sendUserSettings()
     settingJson["storage_prompt"] = get_storagePrompt();
     settingJson["advanced_menu"] = get_advancedMenu();
     settingJson["bluetooth_enabled"] = get_bluetoothEnabled();
-    settingJson["credential_prompt"] = get_credentialDisplayPrompt();
+    settingJson["knock_disabled"] = get_knockDisabled();
     emit userSettingsChanged(settingJson);
 }
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -23,7 +23,7 @@ class MPDeviceBleImpl: public QObject
     QT_WRITABLE_PROPERTY(bool, storagePrompt, false)
     QT_WRITABLE_PROPERTY(bool, advancedMenu, false)
     QT_WRITABLE_PROPERTY(bool, bluetoothEnabled, false)
-    QT_WRITABLE_PROPERTY(bool, credentialDisplayPrompt, false)
+    QT_WRITABLE_PROPERTY(bool, knockDisabled, false)
 
     enum UserSettingsMask : quint8
     {
@@ -32,7 +32,7 @@ class MPDeviceBleImpl: public QObject
         STORAGE_PROMPT    = 0x04,
         ADVANCED_MENU     = 0x08,
         BLUETOOTH_ENABLED = 0x10,
-        CREDENTIAL_PROMPT = 0x20
+        KNOCK_DISABLED    = 0x20
     };
 
     struct FreeAddressInfo

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -170,7 +170,6 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     connect(wsClient, &WSClient::statusChanged, [this](Common::MPStatus status)
     {
-        this->enableKnockSettings(status == Common::NoCardInserted);
         if (status == Common::UnkownSmartcad)
             ui->stackedWidget->setCurrentWidget(ui->pageSync);
 
@@ -193,6 +192,10 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
             {
                 wsClient->sendLoadParams();
             }
+        }
+        else
+        {
+            enableKnockSettings(status == Common::NoCardInserted);
         }
     });
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -330,7 +330,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->cbStoragePrompt->setDisabled(true);
     ui->cbAdvancedMenu->setDisabled(true);
     ui->cbBluetoothEnabled->setDisabled(true);
-    ui->cbCredentialPrompt->setDisabled(true);
+    ui->cbKnockDisabled->setDisabled(true);
 
     connect(wsClient, &WSClient::advancedMenuChanged,
             &DeviceDetector::instance(), &DeviceDetector::onAdvancedModeChanged);
@@ -344,7 +344,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
                 ui->cbAdvancedMenu->setChecked(advancedMenu);
                 wsClient->set_advancedMenu(advancedMenu);
                 ui->cbBluetoothEnabled->setChecked(settings["bluetooth_enabled"].toBool());
-                ui->cbCredentialPrompt->setChecked(settings["storage_prompt"].toBool());
+                ui->cbKnockDisabled->setChecked(settings["knock_disabled"].toBool());
             });
 
     connect(wsClient, &WSClient::updateBLEDeviceLanguage,

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1232,6 +1232,13 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    </widget>
                   </item>
                   <item>
+                   <widget class="QLabel" name="label_KnockSensitivity">
+                    <property name="text">
+                     <string>Knock detection sensitivity:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QComboBox" name="comboBoxKnock"/>
                   </item>
                   <item>
@@ -1472,7 +1479,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <item>
                 <widget class="QCheckBox" name="cbKnockDisabled">
                  <property name="toolTip">
-                  <string/>
+                  <string>Knock detection can be enabled/disabled on the device.</string>
                  </property>
                  <property name="text">
                   <string>Knock Detection Disabled</string>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1463,12 +1463,12 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="cbCredentialPrompt">
+                <widget class="QCheckBox" name="cbKnockDisabled">
                  <property name="toolTip">
-                  <string>Require approval when modifying credentials in management mode. Control this setting in the settings menu of the advanced menu</string>
+                  <string/>
                  </property>
                  <property name="text">
-                  <string>Prompts for Credentials Save in Management Mode</string>
+                  <string>Knock Detection Disabled</string>
                  </property>
                 </widget>
                </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1220,6 +1220,13 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                   <item>
                    <widget class="QCheckBox" name="checkBoxKnock">
                     <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_KnockEnable">
+                    <property name="text">
                      <string>Enable knock detection with</string>
                     </property>
                    </widget>

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -33,13 +33,8 @@ void MPSettingsBLE::loadParameters()
                         set_delay_after_key(m_lastDeviceSettings.at(DeviceSettingsBLE::DELAY_BETWEEN_KEY_PRESS));
                         set_bool_animation(m_lastDeviceSettings.at(DeviceSettingsBLE::BOOT_ANIMATION_BYTE) != 0);
                         set_device_lock_usb_disc(m_lastDeviceSettings.at(DeviceSettingsBLE::DEVICE_LOCK_USB_BYTE) != 0);
-                        int v;
-                        quint8 s = m_lastDeviceSettings.at(DeviceSettingsBLE::KNOCK_DET_BYTE);
-                        if      (s >= KNOCKING_VERY_LOW) v = 0;
-                        else if (s >= KNOCKING_LOW)      v = 1;
-                        else if (s >= KNOCKING_MEDIUM)   v = 2;
-                        else v = 3;
-                        set_knock_sensitivity(v);
+                        const int knockValue = convertBackKnockValue(m_lastDeviceSettings.at(DeviceSettingsBLE::KNOCK_DET_BYTE));
+                        set_knock_sensitivity(knockValue);
                         return true;
                     }
     ));

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -33,6 +33,7 @@ void MPSettingsBLE::loadParameters()
                         set_delay_after_key(m_lastDeviceSettings.at(DeviceSettingsBLE::DELAY_BETWEEN_KEY_PRESS));
                         set_bool_animation(m_lastDeviceSettings.at(DeviceSettingsBLE::BOOT_ANIMATION_BYTE) != 0);
                         set_device_lock_usb_disc(m_lastDeviceSettings.at(DeviceSettingsBLE::DEVICE_LOCK_USB_BYTE) != 0);
+                        set_knock_sensitivity(m_lastDeviceSettings.at(DeviceSettingsBLE::KNOCK_DET_BYTE));
                         return true;
                     }
     ));

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -33,7 +33,13 @@ void MPSettingsBLE::loadParameters()
                         set_delay_after_key(m_lastDeviceSettings.at(DeviceSettingsBLE::DELAY_BETWEEN_KEY_PRESS));
                         set_bool_animation(m_lastDeviceSettings.at(DeviceSettingsBLE::BOOT_ANIMATION_BYTE) != 0);
                         set_device_lock_usb_disc(m_lastDeviceSettings.at(DeviceSettingsBLE::DEVICE_LOCK_USB_BYTE) != 0);
-                        set_knock_sensitivity(m_lastDeviceSettings.at(DeviceSettingsBLE::KNOCK_DET_BYTE));
+                        int v;
+                        quint8 s = m_lastDeviceSettings.at(DeviceSettingsBLE::KNOCK_DET_BYTE);
+                        if      (s >= KNOCKING_VERY_LOW) v = 0;
+                        else if (s >= KNOCKING_LOW)      v = 1;
+                        else if (s >= KNOCKING_MEDIUM)   v = 2;
+                        else v = 3;
+                        set_knock_sensitivity(v);
                         return true;
                     }
     ));
@@ -88,6 +94,10 @@ void MPSettingsBLE::updateParam(MPParams::Param param, int val)
 {
     if (m_bleByteMapping.contains(param))
     {
+        if (MPParams::MINI_KNOCK_THRES_PARAM == param)
+        {
+            convertKnockValue(val);
+        }
         m_lastDeviceSettings[m_bleByteMapping[param]] = static_cast<char>(val);
     }
     else

--- a/src/Mooltipass/MPSettingsMini.cpp
+++ b/src/Mooltipass/MPSettingsMini.cpp
@@ -170,18 +170,12 @@ void MPSettingsMini::loadParameters()
                                   QByteArray(1, MPParams::MINI_KNOCK_THRES_PARAM),
                                   [this](const QByteArray &data, bool &) -> bool
     {
-        const auto knockEnabled = pMesProt->getFirstPayloadByte(data);
-        qDebug() << "received knock threshold: " << knockEnabled;
+        const auto knockSensitivity = pMesProt->getFirstPayloadByte(data);
+        qDebug() << "received knock threshold: " << knockSensitivity;
 
         // The conversion of the real-device 'knock threshold' property
         // to our made-up 'knock sensitivity' property:
-        int v;
-        quint8 s = knockEnabled;
-        if      (s >= KNOCKING_VERY_LOW) v = 0;
-        else if (s >= KNOCKING_LOW)      v = 1;
-        else if (s >= KNOCKING_MEDIUM)   v = 2;
-        else v = 3;
-        set_knock_sensitivity(v);
+        set_knock_sensitivity(convertBackKnockValue(knockSensitivity));
         return true;
     }));
 

--- a/src/Settings/DeviceSettings.cpp
+++ b/src/Settings/DeviceSettings.cpp
@@ -120,3 +120,16 @@ void DeviceSettings::fillParameterMapping()
         {MPParams::MINI_KNOCK_THRES_PARAM, "knock_sensitivity"}
     };
 }
+
+void DeviceSettings::convertKnockValue(int &val)
+{
+    switch(val)
+    {
+    case 0: val = KNOCKING_VERY_LOW; break;
+    case 1: val = KNOCKING_LOW; break;
+    case 2: val = KNOCKING_MEDIUM; break;
+    case 3: val = KNOCKING_HIGH; break;
+    default:
+        val = KNOCKING_MEDIUM;
+    }
+}

--- a/src/Settings/DeviceSettings.cpp
+++ b/src/Settings/DeviceSettings.cpp
@@ -116,6 +116,7 @@ void DeviceSettings::fillParameterMapping()
         {MPParams::KEY_AFTER_PASS_SEND_PARAM, "key_after_pass"},
         {MPParams::DELAY_AFTER_KEY_ENTRY_PARAM, "delay_after_key"},
         {MPParams::USER_INTER_TIMEOUT_PARAM, "user_interaction_timeout"},
-        {MPParams::RANDOM_INIT_PIN_PARAM, "random_starting_pin"}
+        {MPParams::RANDOM_INIT_PIN_PARAM, "random_starting_pin"},
+        {MPParams::MINI_KNOCK_THRES_PARAM, "knock_sensitivity"}
     };
 }

--- a/src/Settings/DeviceSettings.cpp
+++ b/src/Settings/DeviceSettings.cpp
@@ -133,3 +133,11 @@ void DeviceSettings::convertKnockValue(int &val)
         val = KNOCKING_MEDIUM;
     }
 }
+
+int DeviceSettings::convertBackKnockValue(int val)
+{
+    if      (val >= KNOCKING_VERY_LOW) return 0;
+    else if (val >= KNOCKING_LOW)      return 1;
+    else if (val >= KNOCKING_MEDIUM)   return 2;
+    return 3;
+}

--- a/src/Settings/DeviceSettings.h
+++ b/src/Settings/DeviceSettings.h
@@ -16,6 +16,7 @@ class DeviceSettings : public QObject
 
     QT_SETTINGS_PROPERTY(int, user_interaction_timeout, 0, MPParams::USER_INTER_TIMEOUT_PARAM)
     QT_SETTINGS_PROPERTY(bool, random_starting_pin, false, MPParams::RANDOM_INIT_PIN_PARAM)
+    QT_SETTINGS_PROPERTY(int, knock_sensitivity, 0, MPParams::MINI_KNOCK_THRES_PARAM) // 0-very low, 1-low, 2-medium, 3-high
 
 public:
     DeviceSettings(QObject *parent);

--- a/src/Settings/DeviceSettings.h
+++ b/src/Settings/DeviceSettings.h
@@ -51,6 +51,8 @@ protected:
 
     void fillParameterMapping();
 
+    void convertKnockValue(int& val);
+
     QMap<MPParams::Param, QString> m_paramMap;
 
     //flag set when loading all parameters

--- a/src/Settings/DeviceSettings.h
+++ b/src/Settings/DeviceSettings.h
@@ -52,6 +52,7 @@ protected:
     void fillParameterMapping();
 
     void convertKnockValue(int& val);
+    int convertBackKnockValue(int val);
 
     QMap<MPParams::Param, QString> m_paramMap;
 

--- a/src/Settings/DeviceSettingsBLE.cpp
+++ b/src/Settings/DeviceSettingsBLE.cpp
@@ -25,5 +25,6 @@ void DeviceSettingsBLE::fillParameterMapping()
     m_bleByteMapping[MPParams::BOOT_ANIMATION_PARAM] = BOOT_ANIMATION_BYTE;
     m_paramMap.insert(MPParams::DEVICE_LOCK_USB_DISC, "device_lock_usb_disc");
     m_bleByteMapping[MPParams::DEVICE_LOCK_USB_DISC] = DEVICE_LOCK_USB_BYTE;
+    m_bleByteMapping[MPParams::MINI_KNOCK_THRES_PARAM] = KNOCK_DET_BYTE;
 }
 

--- a/src/Settings/DeviceSettingsBLE.h
+++ b/src/Settings/DeviceSettingsBLE.h
@@ -32,7 +32,8 @@ public:
         DEFAULT_CHAR_AFTER_PASS = 6,
         DELAY_BETWEEN_KEY_PRESS = 7,
         BOOT_ANIMATION_BYTE = 8,
-        DEVICE_LOCK_USB_BYTE = 10
+        DEVICE_LOCK_USB_BYTE = 10,
+        KNOCK_DET_BYTE = 11
     };
 
     static constexpr char USB_LAYOUT_ID = 0x01;

--- a/src/Settings/DeviceSettingsMini.cpp
+++ b/src/Settings/DeviceSettingsMini.cpp
@@ -40,7 +40,6 @@ void DeviceSettingsMini::fillParameterMapping()
     m_paramMap.insert(MPParams::DELAY_AFTER_KEY_ENTRY_BOOL_PARAM, "delay_after_key_enabled");
     m_paramMap.insert(MPParams::MINI_OLED_CONTRAST_CURRENT_PARAM, "screen_brightness");
     m_paramMap.insert(MPParams::MINI_KNOCK_DETECT_ENABLE_PARAM, "knock_enabled");
-    m_paramMap.insert(MPParams::MINI_KNOCK_THRES_PARAM, "knock_sensitivity");
     m_paramMap.insert(MPParams::HASH_DISPLAY_FEATURE_PARAM, "hash_display");
     m_paramMap.insert(MPParams::LOCK_UNLOCK_FEATURE_PARAM, "lock_unlock_mode");
 }

--- a/src/Settings/DeviceSettingsMini.cpp
+++ b/src/Settings/DeviceSettingsMini.cpp
@@ -6,19 +6,6 @@ DeviceSettingsMini::DeviceSettingsMini(QObject *parent)
     fillParameterMapping();
 }
 
-void DeviceSettingsMini::convertKnockValue(int &val)
-{
-    switch(val)
-    {
-    case 0: val = KNOCKING_VERY_LOW; break;
-    case 1: val = KNOCKING_LOW; break;
-    case 2: val = KNOCKING_MEDIUM; break;
-    case 3: val = KNOCKING_HIGH; break;
-    default:
-        val = KNOCKING_MEDIUM;
-    }
-}
-
 void DeviceSettingsMini::checkTimeoutBoundaries(int &val)
 {
     if (val < 0) val = 0;

--- a/src/Settings/DeviceSettingsMini.h
+++ b/src/Settings/DeviceSettingsMini.h
@@ -32,7 +32,6 @@ public:
     virtual ~DeviceSettingsMini() {}
 
 protected:
-    void convertKnockValue(int& val);
     void checkTimeoutBoundaries(int& val);
     void fillParameterMapping();
 };

--- a/src/Settings/DeviceSettingsMini.h
+++ b/src/Settings/DeviceSettingsMini.h
@@ -24,7 +24,6 @@ class DeviceSettingsMini : public DeviceSettings
     //MP Mini only
     QT_SETTINGS_PROPERTY(int, screen_brightness, 0, MPParams::MINI_OLED_CONTRAST_CURRENT_PARAM) //51-20%, 89-35%, 128-50%, 166-65%, 204-80%, 255-100%
     QT_SETTINGS_PROPERTY(bool, knock_enabled, false, MPParams::MINI_KNOCK_DETECT_ENABLE_PARAM)
-    QT_SETTINGS_PROPERTY(int, knock_sensitivity, 0, MPParams::MINI_KNOCK_THRES_PARAM) // 0-very low, 1-low, 2-medium, 3-high
     QT_SETTINGS_PROPERTY(bool, hash_display, false, MPParams::HASH_DISPLAY_FEATURE_PARAM)
     QT_SETTINGS_PROPERTY(int, lock_unlock_mode, 0, MPParams::LOCK_UNLOCK_FEATURE_PARAM)
 

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -46,6 +46,7 @@ void SettingsGuiBLE::updateUI()
     ui->checkBoxTuto->hide();
     ui->checkBoxBoot->hide();
     ui->checkBoxKnock->hide();
+    ui->labelRemoveCard->hide();
     ui->checkBoxFlash->hide();
     ui->checkBoxLockDevice->hide();
 

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -42,7 +42,12 @@ void SettingsGuiBLE::updateUI()
     ui->settings_device_language->show();
 
     // Miscellaneous groupbox
-    ui->groupBox_miscellaneous->hide();
+    ui->settings_miscellaneous_brightness->hide();
+    ui->checkBoxTuto->hide();
+    ui->checkBoxBoot->hide();
+    ui->checkBoxKnock->hide();
+    ui->checkBoxFlash->hide();
+    ui->checkBoxLockDevice->hide();
 
     ui->groupBox_BLESettings->show();
     ui->checkBoxBLEReserved->hide();

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -46,6 +46,9 @@ void SettingsGuiBLE::updateUI()
     ui->checkBoxTuto->hide();
     ui->checkBoxBoot->hide();
     ui->checkBoxKnock->hide();
+    ui->label_KnockSensitivity->show();
+    ui->label_KnockEnable->hide();
+    ui->knockSettingsSuffixLabel->hide();
     ui->labelRemoveCard->hide();
     ui->checkBoxFlash->hide();
     ui->checkBoxLockDevice->hide();

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -99,6 +99,7 @@ void SettingsGuiHelper::createSettingUIMapping()
     m_settings->setupKeyboardLayout();
     m_settings->connectSendParams(this);
     dynamic_cast<ISettingsGui*>(m_settings)->updateUI();
+    initKnockSetting();
 }
 
 bool SettingsGuiHelper::checkSettingsChanged()
@@ -243,6 +244,18 @@ void SettingsGuiHelper::sendParams(int value, int param)
         qCritical() << "Invalid widget";
     }
     m_mw->checkSettingsChanged();
+}
+
+void SettingsGuiHelper::initKnockSetting()
+{
+    if (m_wsClient->isMPBLE())
+    {
+        m_mw->enableKnockSettings(true);
+    }
+    else
+    {
+        m_mw->enableKnockSettings(m_wsClient->get_status() == Common::NoCardInserted);
+    }
 }
 
 void SettingsGuiHelper::checkKeyboardLayout()

--- a/src/Settings/SettingsGuiHelper.h
+++ b/src/Settings/SettingsGuiHelper.h
@@ -31,6 +31,8 @@ private slots:
     void sendParams(int value, int param);
 
 private:
+    void initKnockSetting();
+
     WSClient* m_wsClient = nullptr;
     DeviceSettings* m_settings = nullptr;
     MainWindow* m_mw = nullptr;

--- a/src/Settings/SettingsGuiMini.cpp
+++ b/src/Settings/SettingsGuiMini.cpp
@@ -40,7 +40,12 @@ void SettingsGuiMini::updateUI()
     ui->settings_device_language->hide();
 
     // Miscellaneous groupbox
-    ui->groupBox_miscellaneous->show();
+    ui->settings_miscellaneous_brightness->show();
+    ui->checkBoxTuto->show();
+    ui->checkBoxBoot->show();
+    ui->checkBoxKnock->show();
+    ui->checkBoxFlash->show();
+    ui->checkBoxLockDevice->show();
 
     ui->groupBox_BLESettings->hide();
 

--- a/src/Settings/SettingsGuiMini.cpp
+++ b/src/Settings/SettingsGuiMini.cpp
@@ -44,6 +44,9 @@ void SettingsGuiMini::updateUI()
     ui->checkBoxTuto->show();
     ui->checkBoxBoot->show();
     ui->checkBoxKnock->show();
+    ui->label_KnockSensitivity->hide();
+    ui->label_KnockEnable->show();
+    ui->knockSettingsSuffixLabel->show();
     ui->labelRemoveCard->show();
     ui->checkBoxFlash->show();
     ui->checkBoxLockDevice->show();

--- a/src/Settings/SettingsGuiMini.cpp
+++ b/src/Settings/SettingsGuiMini.cpp
@@ -44,6 +44,7 @@ void SettingsGuiMini::updateUI()
     ui->checkBoxTuto->show();
     ui->checkBoxBoot->show();
     ui->checkBoxKnock->show();
+    ui->labelRemoveCard->show();
     ui->checkBoxFlash->show();
     ui->checkBoxLockDevice->show();
 


### PR DESCRIPTION
- Added Knock detection settings like for Mini
- Renamed credential prompt user setting to Knock Detection Disabled

![Screen Shot 2019-12-19 at 21 44 14](https://user-images.githubusercontent.com/11043249/71208440-48895a80-22a9-11ea-8844-c4449ae691ba.png)
