### PR TITLE
[BLE] #522 Send device related informations to GUI on flashMbSize change too

### DIFF
--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -410,6 +410,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
     connect(mpdevice, SIGNAL(uidChanged(qint64)), this, SLOT(sendDeviceUID()));
     connect(mpdevice, SIGNAL(hwVersionChanged(QString)), this, SLOT(sendVersion()));
     connect(mpdevice, SIGNAL(serialNumberChanged(quint32)), this, SLOT(sendVersion()));
+    connect(mpdevice, SIGNAL(flashMbSize(QString)), this, SLOT(sendVersion()));
 
     connect(mpdevice, &MPDevice::filesCacheChanged, this, &WSServerCon::sendFilesCache);
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -410,7 +410,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
     connect(mpdevice, SIGNAL(uidChanged(qint64)), this, SLOT(sendDeviceUID()));
     connect(mpdevice, SIGNAL(hwVersionChanged(QString)), this, SLOT(sendVersion()));
     connect(mpdevice, SIGNAL(serialNumberChanged(quint32)), this, SLOT(sendVersion()));
-    connect(mpdevice, SIGNAL(flashMbSize(QString)), this, SLOT(sendVersion()));
+    connect(mpdevice, SIGNAL(flashMbSizeChanged(int)), this, SLOT(sendVersion()));
 
     connect(mpdevice, &MPDevice::filesCacheChanged, this, &WSServerCon::sendFilesCache);
 


### PR DESCRIPTION
On startup device memory is not received from the device when sendVersion is called.
Calling sendVersion when flashMbSize is set fixes the issue.