### PR TITLE
[BLE] Check if bundle file is readable at the start of the upload bundle process

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -104,6 +104,12 @@ void MPDeviceBleImpl::flashMCU(const MessageHandlerCb &cb)
 
 void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress)
 {
+    if (!isBundleFileReadable(filePath))
+    {
+        qCritical() << "Error opening bundle file: " << filePath;
+        cb(false, "Bundle file is not readable");
+        return;
+    }
     QElapsedTimer *timer = new QElapsedTimer{};
     timer->start();
     auto *jobs = new AsyncJobs(QString("Upload bundle file"), this);
@@ -828,4 +834,9 @@ void MPDeviceBleImpl::writeFetchData(QFile *file, MPCmd::Command cmd)
                         }
                         return true;
     });
+}
+
+bool MPDeviceBleImpl::isBundleFileReadable(const QString &filePath)
+{
+    return QFile{filePath}.open(QIODevice::ReadOnly);
 }

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -111,6 +111,7 @@ private:
     void checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress);
     void sendBundleToDevice(QString filePath, AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress);
     void writeFetchData(QFile *file, MPCmd::Command cmd);
+    inline bool isBundleFileReadable(const QString& filePath);
 
     QByteArray createStoreCredMessage(const BleCredential &cred);
     QByteArray createGetCredMessage(QString service, QString login);


### PR DESCRIPTION
Fix for #556 
Bundle file was only opened after erasing flash. If opening was not successfull device remained in incorrect state.