### PR TITLE
#553 Fix empty row inserted in the grid on credential added from MMM

### DIFF
--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -264,7 +264,7 @@ ServiceItem *CredentialModel::addService(const QString &sServiceName)
 
 QModelIndex CredentialModel::getServiceIndexByName(const QString &sServiceName, int column) const
 {
-    QModelIndexList lMatches = match(index(0, column, QModelIndex()), Qt::DisplayRole, sServiceName, 1);
+    QModelIndexList lMatches = match(index(0, column, QModelIndex()), Qt::DisplayRole, sServiceName, 1, Qt::MatchExactly);
     if (!lMatches.isEmpty())
         return lMatches.first();
 


### PR DESCRIPTION
Fix for #553 
When the user entered a new credential from MMM and there was a previous credential with the same substring it found the previous first and inserted an empty row to the grid.
E.g.:
We have a credential with **'aaa'** service name and entering a new one with **'aa'**, then an empty line is inserted for 'aaa' services:
![kép](https://user-images.githubusercontent.com/11043249/71719416-97dd9800-2e1e-11ea-9173-5125a5584fb7.png)

https://doc.qt.io/qt-5/qabstractitemmodel.html#match
`The search begins from the start index, and continues until the number of matching data items equals hits, the search reaches the last row, or the search reaches start again - depending on whether MatchWrap is specified in flags. If you want to search for all matching items, use hits = -1.`

The default value for the flags is **Qt::MatchFlags(Qt::MatchStartsWith|Qt::MatchWrap)** and because of hits is 1 after finding a service which begins with the same substring match returned with that only result, which was incorrect in these cases.