### PR TITLE
[BLE] Enable MMM password inputs to accept 64 characters

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1057,11 +1057,15 @@ void CredentialsManagement::updateDeviceType(Common::MPHwVersion newDev)
     {
         ui->credDisplayCategoryInput->show();
         ui->credDisplayCategoryLabel->show();
+        ui->addCredPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
+        ui->credDisplayPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
     }
     else
     {
         ui->credDisplayCategoryInput->hide();
         ui->credDisplayCategoryLabel->hide();
+        ui->addCredPasswordInput->setMaxPasswordLength(MINI_PASSWORD_LENGTH);
+        ui->credDisplayPasswordInput->setMaxPasswordLength(MINI_PASSWORD_LENGTH);
     }
 }
 

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -131,6 +131,8 @@ private:
 
     static constexpr int MINI_FAVORITE_NUM = 14;
     static constexpr int BLE_FAVORITE_NUM = 50;
+    static constexpr int MINI_PASSWORD_LENGTH = 31;
+    static constexpr int BLE_PASSWORD_LENGTH = 64;
 
 signals:
     void wantEnterMemMode();

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -90,6 +90,11 @@ void PasswordLineEdit::setMaxPasswordLength(int length)
     if(m_passwordOptionsPopup)
     {
         m_passwordOptionsPopup->setMaxPasswordLength(length);
+        m_passwordMaxLength = INVALID_LENGTH;
+    }
+    else
+    {
+        m_passwordMaxLength = length;
     }
 }
 
@@ -99,6 +104,10 @@ void PasswordLineEdit::showPasswordOptions()
     {
         m_passwordOptionsPopup = new PasswordOptionsPopup(this);
         m_passwordOptionsPopup->setPasswordProfilesModel(m_passwordProfilesModel);
+        if (INVALID_LENGTH != m_passwordMaxLength)
+        {
+            m_passwordOptionsPopup->setMaxPasswordLength(m_passwordMaxLength);
+        }
         connect(m_passwordOptionsPopup, &PasswordOptionsPopup::passwordGenerated,
                 this, &QLineEdit::setText);
         connect(m_passwordOptionsPopup, &PasswordOptionsPopup::passwordGenerated,

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -84,6 +84,15 @@ void PasswordLineEdit::setPasswordProfilesModel(PasswordProfilesModel *passwordP
         m_passwordOptionsPopup->setPasswordProfilesModel(passwordProfilesModel);
 }
 
+void PasswordLineEdit::setMaxPasswordLength(int length)
+{
+    setMaxLength(length);
+    if(m_passwordOptionsPopup)
+    {
+        m_passwordOptionsPopup->setMaxPasswordLength(length);
+    }
+}
+
 void PasswordLineEdit::showPasswordOptions()
 {
     if (!m_passwordOptionsPopup)
@@ -235,6 +244,11 @@ PasswordOptionsPopup::PasswordOptionsPopup(QWidget* parent):
 void PasswordOptionsPopup::setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel)
 {
     m_passwordProfileCMB->setModel(passwordProfilesModel);
+}
+
+void PasswordOptionsPopup::setMaxPasswordLength(int length)
+{
+    m_lengthSlider->setMaximum(length);
 }
 
 void PasswordOptionsPopup::updatePasswordLength(int length)

--- a/src/PasswordLineEdit.h
+++ b/src/PasswordLineEdit.h
@@ -40,6 +40,7 @@ class PasswordOptionsPopup : public QFrame
 public:
     PasswordOptionsPopup(QWidget* parent);
     void setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel);
+    void setMaxPasswordLength(int length);
 
 Q_SIGNALS:
     void passwordGenerated(const QString & password);
@@ -75,6 +76,7 @@ class PasswordLineEdit : public QLineEdit
 public:
     PasswordLineEdit(QWidget* parent = nullptr);
     void setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel);
+    void setMaxPasswordLength(int length);
 
 protected:
     QAction *m_showPassword, *m_hidePassword;

--- a/src/PasswordLineEdit.h
+++ b/src/PasswordLineEdit.h
@@ -77,6 +77,7 @@ public:
     PasswordLineEdit(QWidget* parent = nullptr);
     void setPasswordProfilesModel(PasswordProfilesModel *passwordProfilesModel);
     void setMaxPasswordLength(int length);
+    static constexpr int INVALID_LENGTH = -1;
 
 protected:
     QAction *m_showPassword, *m_hidePassword;
@@ -87,6 +88,7 @@ private:
     PasswordProfilesModel *m_passwordProfilesModel;
     PasswordOptionsPopup *m_passwordOptionsPopup;
     void showPasswordOptions();
+    int m_passwordMaxLength = INVALID_LENGTH;
 };
 
 class LockedPasswordLineEdit : public PasswordLineEdit


### PR DESCRIPTION
PasswordLineEdits was limited to 31 characters, set this to 64 chars, when BLE is connected.
Also enabled to generate 64 long passwords.