### PR TITLE
[BLE] Set default category value, when service is already exist

### DIFF
--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -469,6 +469,7 @@ void CredentialModel::addCredential(QString sServiceName, const QString &sLoginN
                 pAddedLoginItem->setPasswordLocked(false);
                 pAddedLoginItem->setPassword(sPassword);
                 pAddedLoginItem->setDescription(sDescription);
+                pAddedLoginItem->setCategory(0);
                 endInsertRows();
             }
         }


### PR DESCRIPTION
fix for #541
Category was uninitialized in this case, which caused the issue, because in release build it was some garbage value.