### PR TITLE
[BLE] Handle the new status message on daemon side

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -47,6 +47,7 @@ MPDevice::MPDevice(QObject *parent):
 
             if (isBLE())
             {
+                //Only send status message request at ble connection
                 statusTimer->stop();
             }
             processStatusChange(data);
@@ -245,9 +246,9 @@ void MPDevice::newDataRead(const QByteArray &data)
 
     if (commandQueue.isEmpty())
     {
-        if (MPCmd::MOOLTIPASS_STATUS == pMesProt->getCommand(data))
+        if (isBLE() && MPCmd::MOOLTIPASS_STATUS == pMesProt->getCommand(data))
         {
-            qCritical() << "Status message received";
+            qDebug() << "Received status: " << data.toHex();
             processStatusChange(data);
             return;
         }
@@ -320,9 +321,9 @@ void MPDevice::newDataRead(const QByteArray &data)
     if (currentCmd.checkReturn &&
         dataCommand != currentCommand)
     {
-        if (MPCmd::MOOLTIPASS_STATUS == dataCommand)
+        if (isBLE() && MPCmd::MOOLTIPASS_STATUS == dataCommand)
         {
-            qCritical() << "Status message received";
+            qDebug() << "Received status: " << data.toHex();
             processStatusChange(data);
             return;
         }

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -98,6 +98,8 @@ public:
 
     void getUID(const QByteArray & key);
 
+    void processStatusChange(const QByteArray &data);
+
     //mem mgmt mode
     //cbFailure is used to propagate an error to clients when entering mmm
     void startMemMgmtMode(bool wantData,


### PR DESCRIPTION
Handle the fw changes mentioned in #562.
For BLE only sending a status message request on connection after that the device is sending a status message after every change, which is handled on daemon side.