### PR TITLE
[BLE] Fix resetflip crash, when device disconnected right after connection

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -99,12 +99,7 @@ void MPDevice::sendInitMessages()
           * so TimerJob has no effect, hence sending
           * it with a lower timeout.
           */
-        QTimer::singleShot(RESET_SEND_DELAY, [this]()
-        {
-            if (AppDaemon::isDebugDev())
-                qDebug() << "Resetting flip bit for BLE";
-            bleImpl->sendResetFlipBit();
-        });
+        QTimer::singleShot(RESET_SEND_DELAY, this, &MPDevice::resetFlipBit);
 
         if (bleImpl->isAfterAuxFlash())
         {
@@ -457,6 +452,13 @@ void MPDevice::runAndDequeueJobs()
     });
 
     currentJobs->start();
+}
+
+void MPDevice::resetFlipBit()
+{
+    if (AppDaemon::isDebugDev())
+        qDebug() << "Resetting flip bit for BLE";
+    bleImpl->sendResetFlipBit();
 }
 
 void MPDevice::addTimerJob(int msec)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -227,6 +227,7 @@ private slots:
     void commandFailed();
     void sendDataDequeue(); //execute commands from the command queue
     void runAndDequeueJobs(); //execute AsyncJobs from the jobs queues
+    void resetFlipBit();
 
 
 private:


### PR DESCRIPTION
With this timer singleshot, when MPDevice destructed before the delay, then the function is not called.