### PR TITLE
Remove unused sockNotifWrite from Linux MPDevice

### DIFF
--- a/src/MPDevice_linux.cpp
+++ b/src/MPDevice_linux.cpp
@@ -50,18 +50,13 @@ MPDevice_linux::MPDevice_linux(QObject *parent, const MPPlatformDef &platformDef
     else
     {
         sockNotifRead = new QSocketNotifier(devfd, QSocketNotifier::Read);
-        sockNotifRead->setEnabled(true);
         connect(sockNotifRead, &QSocketNotifier::activated, this, &MPDevice_linux::readyRead);
-
-        sockNotifWrite = new QSocketNotifier(devfd, QSocketNotifier::Write);
-        sockNotifWrite->setEnabled(true);
     }
 }
 
 MPDevice_linux::~MPDevice_linux()
 {
     delete sockNotifRead;
-    delete sockNotifWrite;
 
     if (devfd > 0)
     {

--- a/src/MPDevice_linux.h
+++ b/src/MPDevice_linux.h
@@ -68,7 +68,6 @@ private:
     QString devPath;
     int devfd = 0; //device fd
     QSocketNotifier *sockNotifRead = nullptr;
-    QSocketNotifier *sockNotifWrite = nullptr;
 
     //Bufferize the data sent by sending 64bytes packet at a time
     QQueue<QByteArray> sendBuffer;

--- a/src/UsbMonitor_linux.cpp
+++ b/src/UsbMonitor_linux.cpp
@@ -36,7 +36,6 @@ UsbMonitor_linux::UsbMonitor_linux()
     int fd = udev_monitor_get_fd(mon);
 
     sockMonitor = new QSocketNotifier(fd, QSocketNotifier::Read);
-    sockMonitor->setEnabled(true);
     connect(sockMonitor, &QSocketNotifier::activated, this, &UsbMonitor_linux::monitorUSB);
 }
 


### PR DESCRIPTION
Fix for #594
According to @bitgestalt https://github.com/mooltipass/moolticute/issues/594#issuecomment-589958735, removing unused `sockNotifWrite`.
It was only used for libusb implementation before #428 .

Also removed `setEnabled(true)` calls for the sockets. 
https://doc.qt.io/qt-5/qsocketnotifier.html#details
> The socket notifier is enabled by default...

