### PR TITLE
[BLE] Fix category related issues

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -224,9 +224,18 @@ void CredentialsManagement::setWsClient(WSClient *c)
     connect(wsClient, &WSClient::statusChanged, this,
              [this](Common::MPStatus status)
                 {
+                    if (!wsClient->isMPBLE())
+                    {
+                        return;
+                    }
+
                     if (Common::MPStatus::Unlocked == status && wsClient->get_advancedMenu())
                     {
                         sendGetUserCategories();
+                    }
+                    else if (Common::MPStatus::NoCardInserted == status)
+                    {
+                        m_pCredModel->setUserCategoryClean(false);
                     }
                 }
     );

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5188,7 +5188,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             /* Read webauthn child nodes */
             readExportNodes(dataArray[EXPORT_WEBAUTHN_CHILD_NODES_INDEX].toArray(), EXPORT_WEBAUTHN_CHILD_NODES_INDEX);
 
-            bleImpl->updateUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES_INDEX].toObject());
+            bleImpl->setImportUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES_INDEX].toObject());
         }
     }
 
@@ -5316,6 +5316,7 @@ void MPDevice::startImportFileMerging(const MPDeviceProgressCb &cbProgress, Mess
                 qCritical() << "Login import failed";
                 return;
             }
+            bleImpl->importUserCategories();
         }
 
         /// Same but for data nodes

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -116,6 +116,8 @@ void MPDevice::sendInitMessages()
             writeCancelRequest();
         }
         bleImpl->getPlatInfo();
+        //Fetch category if it was not requested from Gui
+        QTimer::singleShot(CATEGORY_FETCH_DELAY, [this](){ bleImpl->fetchCategories(); });
     }
 
     exitMemMgmtMode(false);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -464,6 +464,7 @@ protected:
     static constexpr int RESET_SEND_DELAY = 300;
     static constexpr int INIT_STARTING_DELAY = RESET_SEND_DELAY + 150;
     static constexpr int STATUS_STARTING_DELAY = RESET_SEND_DELAY + 500;
+    static constexpr int CATEGORY_FETCH_DELAY = 5000;
 };
 
 #endif // MPDEVICE_H

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -485,6 +485,22 @@ void MPDeviceBleImpl::fillGetCategory(const QByteArray& data, QJsonObject &categ
         categories[catName] = defaultCat ? catName : category;
     }
     m_categories = categories;
+    m_categoriesFetched = true;
+}
+
+void MPDeviceBleImpl::fetchCategories()
+{
+    if (!m_categoriesFetched)
+    {
+        getUserCategories([this](bool success, QString, QByteArray data)
+                         {
+                             if (success)
+                             {
+                                QJsonObject ores;
+                                fillGetCategory(data, ores);
+                             }
+                         });
+    }
 }
 
 QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categories)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -590,6 +590,22 @@ bool MPDeviceBleImpl::isUserCategoriesChanged(const QJsonObject &categories) con
     return false;
 }
 
+void MPDeviceBleImpl::setImportUserCategories(const QJsonObject &categories)
+{
+    m_categoriesToImport = categories;
+}
+
+void MPDeviceBleImpl::importUserCategories()
+{
+    if (m_categoriesToImport.empty())
+    {
+        qCritical() << "Cannot import empty categories";
+        return;
+    }
+    updateUserCategories(m_categoriesToImport);
+    m_categoriesToImport = QJsonObject();
+}
+
 void MPDeviceBleImpl::setNodeCategory(MPNode* node, int category)
 {
     if (auto* nodeBle = dynamic_cast<MPNodeBLE*>(node))

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -82,6 +82,7 @@ public:
     void getUserCategories(const MessageHandlerCbData &cb);
     void setUserCategories(const QJsonObject &categories, const MessageHandlerCbData &cb);
     void fillGetCategory(const QByteArray& data, QJsonObject &categories);
+    void fetchCategories();
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
 
     void readUserSettings(const QByteArray& settings);
@@ -92,7 +93,7 @@ public:
 
     void updateChangeNumbers(AsyncJobs *jobs, quint8 flags);
 
-    QJsonObject getUserCategories() const { return m_categories; };
+    QJsonObject getUserCategories() const { return m_categories; }
     void updateUserCategories(const QJsonObject &categories);
     bool isUserCategoriesChanged(const QJsonObject &categories) const;
     void setImportUserCategories(const QJsonObject &categories);
@@ -145,6 +146,7 @@ private:
     MPBLEFreeAddressProvider freeAddressProv;
     QJsonObject m_categories;
     QJsonObject m_categoriesToImport;
+    bool m_categoriesFetched = false;
     QJsonObject m_deviceLanguages;
     QJsonObject m_keyboardLayouts;
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -95,6 +95,8 @@ public:
     QJsonObject getUserCategories() const { return m_categories; };
     void updateUserCategories(const QJsonObject &categories);
     bool isUserCategoriesChanged(const QJsonObject &categories) const;
+    void setImportUserCategories(const QJsonObject &categories);
+    void importUserCategories();
     void setNodeCategory(MPNode* node, int category);
     void setNodeKeyAfterLogin(MPNode* node, int key);
     void setNodeKeyAfterPwd(MPNode* node, int key);
@@ -142,6 +144,7 @@ private:
 
     MPBLEFreeAddressProvider freeAddressProv;
     QJsonObject m_categories;
+    QJsonObject m_categoriesToImport;
     QJsonObject m_deviceLanguages;
     QJsonObject m_keyboardLayouts;
 


### PR DESCRIPTION
Fix for #605
Issues fixed:
- Fetch categories when smart card is inserted and unlocked
- During import move set categories after MMM is started
    - Set categories is not prompted in this case
- Fetch categories in daemon if it was not requested from Gui