### PR TITLE
Fix backward compatibility issue with Qt5.5.1 for Xenial build

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -117,12 +117,13 @@ static QLocalServer *debugLogServer = nullptr;
 static QList<QLocalSocket *> debugLogClients;
 static Common::GuiLogCallback guiLogCallback = [](const QByteArray &) {};
 static QByteArray startingDaemonBuffer;
+const QString Common::ISODateWithMsFormat = "yyyy-MM-ddTHH:mm:ss.zzz";
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
     QString fname = context.file;
     fname = fname.section('\\', -1, -1);
-    const auto timestamp = QDateTime::currentDateTime().toString(Qt::ISODateWithMs);
+    const auto timestamp = QDateTime::currentDateTime().toString(Common::ISODateWithMsFormat);
     QString s;
     switch (type) {
     default:

--- a/src/Common.h
+++ b/src/Common.h
@@ -248,6 +248,8 @@ public:
         CRED_ADDR_IDX = 0,
         WEBAUTHN_ADDR_IDX = 1
     };
+
+    static const QString ISODateWithMsFormat;
 };
 
 enum class DeviceType


### PR DESCRIPTION
Qt::ISODateWithMs enum value was only added in Qt5.8
It is used for the timestamp in logging.
https://doc.qt.io/archives/qt-5.11/qdatetime.html#toString-1
> use the format Qt::ISODateWithMs, which corresponds to yyyy-MM-ddTHH:mm:ss.zzz