### PR TITLE
[BLE] Only fetch categories on daemon side when device is unlocked

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -116,8 +116,6 @@ void MPDevice::sendInitMessages()
             writeCancelRequest();
         }
         bleImpl->getPlatInfo();
-        //Fetch category if it was not requested from Gui
-        QTimer::singleShot(CATEGORY_FETCH_DELAY, bleImpl, &MPDeviceBleImpl::fetchCategories);
     }
 
     exitMemMgmtMode(false);
@@ -3622,6 +3620,11 @@ void MPDevice::handleDeviceUnlocked()
     {
         qInfo() << "Requesting change numbers";
         getChangeNumbers();
+        if (isBLE() && !bleImpl->areCategoriesFetched())
+        {
+            //Fetch category if it was not requested from Gui
+            QTimer::singleShot(CATEGORY_FETCH_DELAY, bleImpl, &MPDeviceBleImpl::fetchCategories);
+        }
     }
     else
     {

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -490,7 +490,7 @@ void MPDeviceBleImpl::fillGetCategory(const QByteArray& data, QJsonObject &categ
 
 void MPDeviceBleImpl::fetchCategories()
 {
-    if (!m_categoriesFetched)
+    if (!m_categoriesFetched && Common::Unlocked == mpDev->get_status())
     {
         getUserCategories([this](bool success, QString, QByteArray data)
                          {

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -94,6 +94,7 @@ public:
 
     QJsonObject getUserCategories() const { return m_categories; }
     void updateUserCategories(const QJsonObject &categories);
+    bool areCategoriesFetched() const { return m_categoriesFetched; }
     bool isUserCategoriesChanged(const QJsonObject &categories) const;
     void setImportUserCategories(const QJsonObject &categories);
     void importUserCategories();


### PR DESCRIPTION
Move https://github.com/mooltipass/moolticute/pull/608/commits/20a807b27b04abb0d7027dc280294d831a23b253#diff-e9a41bdf95cd0a995d2c81602f7c5c00R120 after the first status message arrived and we know that the device is unlocked.