### PR TITLE
[BLE] #621 Non-initialized password support

### DIFF
--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -223,6 +223,7 @@ void CredentialModel::load(const QJsonArray &json)
                 pLoginItem->setCategory(cnode["category"].toVariant().toInt());
                 pLoginItem->setkeyAfterLogin(cnode["key_after_login"].toVariant().toInt());
                 pLoginItem->setkeyAfterPwd(cnode["key_after_pwd"].toVariant().toInt());
+                pLoginItem->setPwdBlankFlag(cnode["pwd_blank_flag"].toVariant().toInt());
             }
 
             QJsonArray a = cnode["address"].toArray();

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -664,6 +664,11 @@ void CredentialsManagement::updateSaveDiscardState(const QModelIndex &proxyIndex
                 ui->pushButtonCancel->hide();
                 ui->pushButtonConfirm->hide();
 
+                if (wsClient->isMPBLE() && 0x00 != pLoginItem->pwdBlankFlag() && "" != pLoginItem->password())
+                {
+                    pLoginItem->setPwdBlankFlag(0);
+                }
+
                 enableNonCredentialEditWidgets();
             }
         }
@@ -840,6 +845,7 @@ void CredentialsManagement::updateLoginDescription(LoginItem *pLoginItem)
             ui->credDisplayPasswordInput->setLocked(pLoginItem->passwordLocked());
             if (wsClient->isMPBLE())
             {
+                ui->credDisplayPasswordInput->checkPwdBlankFlag(pLoginItem->pwdBlankFlag());
                 ui->credDisplayCategoryInput->setCurrentIndex(pLoginItem->category());
                 auto keyAfterLoginIdx = ui->credDisplayKeyAfterLoginInput->findData(pLoginItem->keyAfterLogin());
                 ui->credDisplayKeyAfterLoginInput->setCurrentIndex(keyAfterLoginIdx);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -664,7 +664,7 @@ void CredentialsManagement::updateSaveDiscardState(const QModelIndex &proxyIndex
                 ui->pushButtonCancel->hide();
                 ui->pushButtonConfirm->hide();
 
-                if (wsClient->isMPBLE() && 0x00 != pLoginItem->pwdBlankFlag() && "" != pLoginItem->password())
+                if (wsClient->isMPBLE() && pLoginItem->hasBlankPwdChanged())
                 {
                     pLoginItem->setPwdBlankFlag(0);
                 }

--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -97,6 +97,11 @@ bool LoginItem::passwordLocked() const
     return m_bPasswordLocked;
 }
 
+bool LoginItem::hasBlankPwdChanged() const
+{
+    return 0x00 != m_iPwdBlankFlag && !m_sPassword.isEmpty();
+}
+
 TreeItem::TreeType LoginItem::treeType() const
 {
     return Login;

--- a/src/LoginItem.h
+++ b/src/LoginItem.h
@@ -24,6 +24,7 @@ public:
     QJsonObject toJson() const;
     void setPasswordLocked(bool bVisible);
     bool passwordLocked() const;
+    bool hasBlankPwdChanged() const;
     virtual TreeType treeType()  const Q_DECL_OVERRIDE;
 private:    
     QByteArray m_bAddress;

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6616,6 +6616,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                     bleImpl->setNodeCategory(newNodePt, category);
                     bleImpl->setNodeKeyAfterLogin(newNodePt, keyAfterLogin);
                     bleImpl->setNodeKeyAfterPwd(newNodePt, keyAfterPwd);
+                    bleImpl->setNodePwdBlankFlag(newNodePt);
                 }
                 addChildToDB(parentPtr, newNodePt);
                 packet_send_needed = true;

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -658,6 +658,18 @@ void MPDeviceBleImpl::setNodeKeyAfterPwd(MPNode *node, int key)
     }
 }
 
+void MPDeviceBleImpl::setNodePwdBlankFlag(MPNode *node)
+{
+    if (auto* nodeBle = dynamic_cast<MPNodeBLE*>(node))
+    {
+        if (AppDaemon::isDebugDev())
+        {
+            qDebug() << "Setting password blank flag";
+        }
+        nodeBle->setPwdBlankFlag();
+    }
+}
+
 QList<QByteArray> MPDeviceBleImpl::getFavorites(const QByteArray &data)
 {
     QList<QByteArray> res;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -101,6 +101,7 @@ public:
     void setNodeCategory(MPNode* node, int category);
     void setNodeKeyAfterLogin(MPNode* node, int key);
     void setNodeKeyAfterPwd(MPNode* node, int key);
+    void setNodePwdBlankFlag(MPNode* node);
 
     QList<QByteArray> getFavorites(const QByteArray& data);
 

--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -446,6 +446,7 @@ QJsonObject MPNode::toJson() const
             obj["category"] = QString::number(bleNode->getCategory());
             obj["key_after_login"] = QString::number(bleNode->getKeyAfterLogin());
             obj["key_after_pwd"] = QString::number(bleNode->getKeyAfterPwd());
+            obj["pwd_blank_flag"] = QString::number(bleNode->getPwdBlankFlag());
         }
     }
     else if (getType() == NodeChildData)

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -209,6 +209,6 @@ void MPNodeBLE::setPwdBlankFlag()
 {
     if (isValid())
     {
-        data[PWD_BLANK_FLAG] = static_cast<char>(0x01);
+        data[PWD_BLANK_FLAG] = static_cast<char>(BLANK_CHAR);
     }
 }

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -198,3 +198,11 @@ void MPNodeBLE::setKeyAfterPwd(int key)
         data[KEY_AFTER_PWD_ADDR_START+1] = keyArray[1];
     }
 }
+
+void MPNodeBLE::setPwdBlankFlag()
+{
+    if (isValid())
+    {
+        data[PWD_BLANK_FLAG] = static_cast<char>(0x01);
+    }
+}

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -199,6 +199,12 @@ void MPNodeBLE::setKeyAfterPwd(int key)
     }
 }
 
+int MPNodeBLE::getPwdBlankFlag() const
+{
+    if (!isValid()) return 0;
+    return data[PWD_BLANK_FLAG];
+}
+
 void MPNodeBLE::setPwdBlankFlag()
 {
     if (isValid())

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -35,6 +35,7 @@ public:
     void setKeyAfterLogin(int key);
     int getKeyAfterPwd() const;
     void setKeyAfterPwd(int key);
+    int getPwdBlankFlag() const;
     void setPwdBlankFlag();
 
     static constexpr int PARENT_NODE_LENGTH = 264;

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -57,6 +57,7 @@ protected:
     static constexpr int KEY_AFTER_PWD_ADDR_START = 262;
     static constexpr int PWD_BLANK_FLAG = 266;
     static constexpr int KEY_AFTER_LENGTH = 2;
+    static constexpr char BLANK_CHAR = 0x01;
 };
 
 #endif // MPNODEBLE_H

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -35,6 +35,7 @@ public:
     void setKeyAfterLogin(int key);
     int getKeyAfterPwd() const;
     void setKeyAfterPwd(int key);
+    void setPwdBlankFlag();
 
     static constexpr int PARENT_NODE_LENGTH = 264;
     static constexpr int CHILD_NODE_LENGTH = 528;
@@ -53,6 +54,7 @@ protected:
     static constexpr int DATE_LASTUSED_ADDR_START = 10;
     static constexpr int KEY_AFTER_LOGIN_ADDR_START = 260;
     static constexpr int KEY_AFTER_PWD_ADDR_START = 262;
+    static constexpr int PWD_BLANK_FLAG = 266;
     static constexpr int KEY_AFTER_LENGTH = 2;
 };
 

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -317,6 +317,18 @@ void LockedPasswordLineEdit::setLocked(bool locked)
     this->setReadOnly(m_locked);
 }
 
+void LockedPasswordLineEdit::checkPwdBlankFlag(int flag)
+{
+    if (0x00 != flag)
+    {
+        m_locked = false;
+        setText("");
+        setPlaceholderText("Non-initialized password");
+        setPasswordVisible(true);
+        setReadOnly(m_locked);
+    }
+}
+
 
 void PasswordOptionsPopup::generatePassword()
 {

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -323,7 +323,7 @@ void LockedPasswordLineEdit::checkPwdBlankFlag(int flag)
     {
         m_locked = false;
         setText("");
-        setPlaceholderText("Non-initialized password");
+        setPlaceholderText(tr("Non-initialized password"));
         setPasswordVisible(true);
         setReadOnly(m_locked);
     }

--- a/src/PasswordLineEdit.h
+++ b/src/PasswordLineEdit.h
@@ -97,6 +97,7 @@ class LockedPasswordLineEdit : public PasswordLineEdit
 public:
     LockedPasswordLineEdit(QWidget* parent = nullptr);
     void setLocked(bool);
+    void checkPwdBlankFlag(int flag);
 
 Q_SIGNALS:
     void unlockRequested();

--- a/src/TreeItem.cpp
+++ b/src/TreeItem.cpp
@@ -135,6 +135,16 @@ void TreeItem::setkeyAfterPwd(int key)
     m_iKeyAfterPwd = key;
 }
 
+int TreeItem::pwdBlankFlag() const
+{
+    return m_iPwdBlankFlag;
+}
+
+void TreeItem::setPwdBlankFlag(int flag)
+{
+    m_iPwdBlankFlag = flag;
+}
+
 const QVector<TreeItem *> &TreeItem::childs() const
 {
     return m_vChilds;

--- a/src/TreeItem.h
+++ b/src/TreeItem.h
@@ -33,6 +33,8 @@ public:
     void setkeyAfterLogin(int key);
     int keyAfterPwd() const;
     void setkeyAfterPwd(int key);
+    int pwdBlankFlag() const;
+    void setPwdBlankFlag(int flag);
     TreeItem *child(int iIndex);
     const QVector<TreeItem *> &childs() const;
     int childCount() const;
@@ -62,6 +64,7 @@ protected:
     int m_iCategory;
     int m_iKeyAfterLogin = 0xFFFF;
     int m_iKeyAfterPwd = 0xFFFF;
+    int m_iPwdBlankFlag = 0;
 };
 
 #endif // TREEITEM_H


### PR DESCRIPTION
Implemented #621.
When `MMM Stor. Conf.` is enabled and credential is saved from MMM, but the prompt is not accepted, then a blank password is saved. After entering MMM again a **"Non-initialized password"** is shown for the credential's password field:
![kép](https://user-images.githubusercontent.com/11043249/76698363-364d6b80-66a2-11ea-81c9-d35a6e65838e.png)
