### PR TITLE
#629 Fix not saved password in MMM

### DIFF
--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -304,7 +304,11 @@ void CredentialModel::updateLoginItem(const QModelIndex &idx, const QString &sPa
     LoginItem *pLoginItem = getLoginItemByIndex(idx);
     if (pLoginItem != nullptr)
     {
-        updateLoginItem(idx, PasswordRole, sPassword);
+        if (!sPassword.isEmpty())
+        {
+            // Only update, when password is not empty (locked)
+            updateLoginItem(idx, PasswordRole, sPassword);
+        }
         updateLoginItem(idx, DescriptionRole, sDescription);
         updateLoginItem(idx, ItemNameRole, sName);
         if (DeviceDetector::instance().isBle())


### PR DESCRIPTION
When we are saving credentials in MMM, it tries to update the currently selected credential. However when the password was changed, but it is locked, then new password was not saved.
Fixed it with an extra check for empty password, which only can happen, when the password field is locked.