### PR TITLE
[BLE] Add user datas for database import feature

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -187,7 +187,7 @@ bool AppGui::initialize()
     connect(wsClient, &WSClient::statusChanged, this, &AppGui::updateSystrayTooltip);
     connect(wsClient, &WSClient::statusChanged, [this]()
     {
-        if (wsClient->get_status() == Common::UnkownSmartcad)
+        if (wsClient->get_status() == Common::UnknownSmartcard)
            mainWindowShow();
     });
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -74,7 +74,7 @@ QHash<Common::MPStatus, QString> Common::MPStatusUserString = {
     { Common::Error6, QObject::tr("Error 6 (should not happen)") },
     { Common::Error7, QObject::tr("Error 7 (should not happen)") },
     { Common::Error8, QObject::tr("Error 8 (should not happen)") },
-    { Common::UnkownSmartcad, QObject::tr("Unknown smartcard inserted") },
+    { Common::UnknownSmartcard, QObject::tr("Unknown smartcard inserted") },
     { Common::MMMMode, QObject::tr("Device in management mode") }
 };
 
@@ -89,7 +89,7 @@ QHash<Common::MPStatus, QString> Common::MPStatusString = {
     { Common::Error6, "Error6" },
     { Common::Error7, "Error7" },
     { Common::Error8, "Error8" },
-    { Common::UnkownSmartcad, "UnkownSmartcad" },
+    { Common::UnknownSmartcard, "UnknownSmartcard" },
     { Common::MMMMode, "MMMMode" }
 };
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -118,6 +118,8 @@ static QList<QLocalSocket *> debugLogClients;
 static Common::GuiLogCallback guiLogCallback = [](const QByteArray &) {};
 static QByteArray startingDaemonBuffer;
 const QString Common::ISODateWithMsFormat = "yyyy-MM-ddTHH:mm:ss.zzz";
+const QString Common::SIMPLE_CRYPT = "SimpleCrypt";
+const QString Common::SIMPLE_CRYPT_V2 = "SimpleCryptV2";
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/Common.h
+++ b/src/Common.h
@@ -194,7 +194,7 @@ public:
         Error6 = 6,
         Error7 = 7,
         Error8 = 8,
-        UnkownSmartcad = 9,
+        UnknownSmartcard = 9,
         MMMMode = 21
     } MPStatus;
     static QHash<MPStatus, QString> MPStatusUserString, MPStatusString;

--- a/src/Common.h
+++ b/src/Common.h
@@ -288,6 +288,8 @@ public:
     };
 
     static const QString ISODateWithMsFormat;
+    static const QString SIMPLE_CRYPT;
+    static const QString SIMPLE_CRYPT_V2;
 };
 
 enum class DeviceType

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -160,7 +160,7 @@ void DbBackupsTrackerController::askForExportBackup()
 
 void DbBackupsTrackerController::exportDbBackup()
 {
-    QString format = "SimpleCrypt";
+    QString format = Common::SIMPLE_CRYPT;
 
     window->wantExportDatabase();
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5144,6 +5144,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     }
 
     bool needToAddExistingUser = isBleExport && dataArray.size() >= EXPORT_USB_LAYOUT_INDEX && Common::UnknownSmartcard == get_status();
+    //Check export file if contains user datas
     if (needToAddExistingUser)
     {
         cpzFound = true;
@@ -7088,7 +7089,7 @@ void MPDevice::importDatabase(const QByteArray &fileData, bool noDelete,
         /// We are here because the card is known by the export file and the export file is valid
 
         /* If we don't know this card, we need to add the CPZ CTR */
-        if (get_status() == Common::UnknownSmartcard)
+        if (get_status() == Common::UnknownSmartcard && !unknownCardAddPayload.isEmpty())
         {
             AsyncJobs* addcpzjobs = new AsyncJobs("Adding CPZ/CTR...", this);
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3546,7 +3546,7 @@ void MPDevice::processStatusChange(const QByteArray &data)
             QTimer::singleShot(10, this, &MPDevice::sendSetupDeviceMessages);
         }
 
-        if ((s == Common::Unlocked) || (s == Common::UnkownSmartcad))
+        if ((s == Common::Unlocked) || (s == Common::UnknownSmartcard))
         {
             QTimer::singleShot(20, this, &MPDevice::getCurrentCardCPZ);
         }
@@ -7078,7 +7078,7 @@ void MPDevice::importDatabase(const QByteArray &fileData, bool noDelete,
         /// We are here because the card is known by the export file and the export file is valid
 
         /* If we don't know this card, we need to add the CPZ CTR */
-        if (get_status() == Common::UnkownSmartcad)
+        if (get_status() == Common::UnknownSmartcard)
         {
             AsyncJobs* addcpzjobs = new AsyncJobs("Adding CPZ/CTR...", this);
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5195,6 +5195,11 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             readExportNodes(dataArray[EXPORT_WEBAUTHN_CHILD_NODES_INDEX].toArray(), EXPORT_WEBAUTHN_CHILD_NODES_INDEX);
 
             bleImpl->setImportUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES_INDEX].toObject());
+            qDebug() << "User security settings" << dataArray[EXPORT_SECURITY_SETTINGS_INDEX].toInt();
+            qDebug() << "User language: " << dataArray[EXPORT_USER_LANG_INDEX].toInt();
+            qDebug() << "Device language: " << dataArray[EXPORT_DEVICE_LANG_INDEX].toInt();
+            qDebug() << "BT layout: " << dataArray[EXPORT_BT_LAYOUT_INDEX].toInt();
+            qDebug() << "USB layout: " << dataArray[EXPORT_USB_LAYOUT_INDEX].toInt();
         }
     }
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5135,7 +5135,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     bool cpzFound = false;
     for (qint32 i = 0; i < importedCpzCtrValue.size(); i++)
     {
-        if (importedCpzCtrValue[i].mid(0, 8) == get_cardCPZ())
+        if (pMesProt->getCpzValue(importedCpzCtrValue[i]) == get_cardCPZ())
         {
             qDebug() << "Import file is a backup for current user";
             unknownCardAddPayload = importedCpzCtrValue[i];

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5142,6 +5142,17 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             cpzFound = true;
         }
     }
+
+    bool needToAddExistingUser = isBleExport && dataArray.size() >= EXPORT_USB_LAYOUT_INDEX && Common::UnknownSmartcard == get_status();
+    if (needToAddExistingUser)
+    {
+        cpzFound = true;
+    }
+    else if (isBleExport)
+    {
+        unknownCardAddPayload.clear();
+    }
+
     if (!cpzFound)
     {
         qWarning() << "Import file is not a backup for current user";
@@ -5195,11 +5206,10 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
             readExportNodes(dataArray[EXPORT_WEBAUTHN_CHILD_NODES_INDEX].toArray(), EXPORT_WEBAUTHN_CHILD_NODES_INDEX);
 
             bleImpl->setImportUserCategories(dataArray[EXPORT_BLE_USER_CATEGORIES_INDEX].toObject());
-            qDebug() << "User security settings" << dataArray[EXPORT_SECURITY_SETTINGS_INDEX].toInt();
-            qDebug() << "User language: " << dataArray[EXPORT_USER_LANG_INDEX].toInt();
-            qDebug() << "Device language: " << dataArray[EXPORT_DEVICE_LANG_INDEX].toInt();
-            qDebug() << "BT layout: " << dataArray[EXPORT_BT_LAYOUT_INDEX].toInt();
-            qDebug() << "USB layout: " << dataArray[EXPORT_USB_LAYOUT_INDEX].toInt();
+            if (needToAddExistingUser)
+            {
+                bleImpl->fillAddUnknownCard(dataArray);
+            }
         }
     }
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5115,7 +5115,7 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
     /** Mooltiapp / Chrome App save file **/
 
     const auto dataSize = dataArray.size();
-    const bool isBleExport = BLE_EXPORT_FIELD_NUM == dataArray.size() && dataArray[EXPORT_IS_BLE_INDEX].toBool();
+    const bool isBleExport = dataArray[EXPORT_IS_BLE_INDEX].toBool() && dataArray.size() >= BLE_EXPORT_FIELD_MIN_NUM;
     const QString deviceVersion = dataArray[EXPORT_DEVICE_VERSION_INDEX].toString();
     /* Checks */
     if (!((deviceVersion == "mooltipass" && dataSize == MP_EXPORT_FIELD_NUM)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -350,9 +350,11 @@ private:
     void updateChangeNumbers(AsyncJobs *jobs, quint8 flags);
 
     // Crypto
+    quint64 getUInt64EncryptionKey(const QString &encryption);
     quint64 getUInt64EncryptionKey();
-    QString encryptSimpleCrypt(const QByteArray &data);
-    QByteArray decryptSimpleCrypt(const QString &payload);
+    quint64 getUInt64EncryptionKeyOld();
+    QString encryptSimpleCrypt(const QByteArray &data, const QString &encryption);
+    QByteArray decryptSimpleCrypt(const QString &payload, const QString &encryption);
 
     // Last page scanned
     quint16 lastFlashPageScanned = 0;

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -233,9 +233,8 @@ protected:
         EXPORT_WEBAUTHN_CHILD_NODES_INDEX = 17,
         EXPORT_SECURITY_SETTINGS_INDEX = 18,
         EXPORT_USER_LANG_INDEX = 19,
-        EXPORT_DEVICE_LANG_INDEX = 20,
-        EXPORT_BT_LAYOUT_INDEX = 21,
-        EXPORT_USB_LAYOUT_INDEX = 22
+        EXPORT_BT_LAYOUT_INDEX = 20,
+        EXPORT_USB_LAYOUT_INDEX = 21
     };
 
 signals:
@@ -468,7 +467,7 @@ protected:
     DeviceType deviceType = DeviceType::MOOLTIPASS;
     static constexpr int MP_EXPORT_FIELD_NUM = 10;
     static constexpr int MC_EXPORT_FIELD_NUM = 14;
-    static constexpr int BLE_EXPORT_FIELD_NUM = 23;
+    static constexpr int BLE_EXPORT_FIELD_MIN_NUM = 18;
 
     static constexpr int RESET_SEND_DELAY = 300;
     static constexpr int INIT_STARTING_DELAY = RESET_SEND_DELAY + 150;

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -230,7 +230,12 @@ protected:
         EXPORT_IS_BLE_INDEX = 14,
         EXPORT_BLE_USER_CATEGORIES_INDEX = 15,
         EXPORT_WEBAUTHN_NODES_INDEX = 16,
-        EXPORT_WEBAUTHN_CHILD_NODES_INDEX = 17
+        EXPORT_WEBAUTHN_CHILD_NODES_INDEX = 17,
+        EXPORT_SECURITY_SETTINGS_INDEX = 18,
+        EXPORT_USER_LANG_INDEX = 19,
+        EXPORT_DEVICE_LANG_INDEX = 20,
+        EXPORT_BT_LAYOUT_INDEX = 21,
+        EXPORT_USB_LAYOUT_INDEX = 22
     };
 
 signals:
@@ -461,7 +466,7 @@ protected:
     DeviceType deviceType = DeviceType::MOOLTIPASS;
     static constexpr int MP_EXPORT_FIELD_NUM = 10;
     static constexpr int MC_EXPORT_FIELD_NUM = 14;
-    static constexpr int BLE_EXPORT_FIELD_NUM = 18;
+    static constexpr int BLE_EXPORT_FIELD_NUM = 23;
 
     static constexpr int RESET_SEND_DELAY = 300;
     static constexpr int INIT_STARTING_DELAY = RESET_SEND_DELAY + 150;

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -864,17 +864,18 @@ void MPDeviceBleImpl::generateExportData(QJsonArray &exportTopArray)
     exportTopArray.append(QJsonValue(bleSettings->get_keyboard_usb_layout()));
 }
 
+void MPDeviceBleImpl::addUnknownCardPayload(const QJsonValue &val)
+{
+    mpDev->unknownCardAddPayload.append(toChar(val));
+    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+}
+
 void MPDeviceBleImpl::fillAddUnknownCard(const QJsonArray &dataArray)
 {
-    auto toChar = [](QJsonValue val) { return static_cast<char>(val.toInt()); };
-    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_SECURITY_SETTINGS_INDEX]));
-    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
-    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_USER_LANG_INDEX]));
-    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
-    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_BT_LAYOUT_INDEX]));
-    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
-    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_USB_LAYOUT_INDEX]));
-    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+    addUnknownCardPayload(dataArray[MPDevice::EXPORT_SECURITY_SETTINGS_INDEX]);
+    addUnknownCardPayload(dataArray[MPDevice::EXPORT_USER_LANG_INDEX]);
+    addUnknownCardPayload(dataArray[MPDevice::EXPORT_BT_LAYOUT_INDEX]);
+    addUnknownCardPayload(dataArray[MPDevice::EXPORT_USB_LAYOUT_INDEX]);
 }
 
 void MPDeviceBleImpl::handleLongMessageTimeout()

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -859,7 +859,6 @@ void MPDeviceBleImpl::generateExportData(QJsonArray &exportTopArray)
     exportTopArray.append(QJsonValue(m_currentUserSettings));
     auto* bleSettings = static_cast<DeviceSettingsBLE*>(mpDev->settings());
     exportTopArray.append(QJsonValue(bleSettings->get_user_language()));
-    exportTopArray.append(QJsonValue(bleSettings->get_device_language()));
     exportTopArray.append(QJsonValue(bleSettings->get_keyboard_bt_layout()));
     exportTopArray.append(QJsonValue(bleSettings->get_keyboard_usb_layout()));
 }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -3,6 +3,7 @@
 #include "MessageProtocolBLE.h"
 #include "MPNodeBLE.h"
 #include "AppDaemon.h"
+#include "DeviceSettingsBLE.h"
 
 MPDeviceBleImpl::MPDeviceBleImpl(MessageProtocolBLE* mesProt, MPDevice *dev):
     bleProt(mesProt),
@@ -855,6 +856,12 @@ void MPDeviceBleImpl::generateExportData(QJsonArray &exportTopArray)
         nodeQJsonArray.append(QJsonValue(nodeObject));
     }
     exportTopArray.append(QJsonValue(nodeQJsonArray));
+    exportTopArray.append(QJsonValue(m_currentUserSettings));
+    auto* bleSettings = static_cast<DeviceSettingsBLE*>(mpDev->settings());
+    exportTopArray.append(QJsonValue(bleSettings->get_user_language()));
+    exportTopArray.append(QJsonValue(bleSettings->get_device_language()));
+    exportTopArray.append(QJsonValue(bleSettings->get_keyboard_bt_layout()));
+    exportTopArray.append(QJsonValue(bleSettings->get_keyboard_usb_layout()));
 }
 
 void MPDeviceBleImpl::handleLongMessageTimeout()

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -864,6 +864,19 @@ void MPDeviceBleImpl::generateExportData(QJsonArray &exportTopArray)
     exportTopArray.append(QJsonValue(bleSettings->get_keyboard_usb_layout()));
 }
 
+void MPDeviceBleImpl::fillAddUnknownCard(const QJsonArray &dataArray)
+{
+    auto toChar = [](QJsonValue val) { return static_cast<char>(val.toInt()); };
+    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_SECURITY_SETTINGS_INDEX]));
+    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_USER_LANG_INDEX]));
+    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_BT_LAYOUT_INDEX]));
+    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+    mpDev->unknownCardAddPayload.append(toChar(dataArray[MPDevice::EXPORT_USB_LAYOUT_INDEX]));
+    mpDev->unknownCardAddPayload.append(ZERO_BYTE);
+}
+
 void MPDeviceBleImpl::handleLongMessageTimeout()
 {
     qWarning() << "Timout for multiple packet expired";

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -114,6 +114,8 @@ public:
     void appendLoginChildNode(MPNode* loginChildNode, MPNode* loginChildNodeClone, Common::AddressType addrType);
     void generateExportData(QJsonArray& exportTopArray);
 
+    void fillAddUnknownCard(const QJsonArray& dataArray);
+
 signals:
     void userSettingsChanged(QJsonObject settings);
     void bleDeviceLanguage(const QJsonObject& langs);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -114,6 +114,8 @@ public:
     void appendLoginChildNode(MPNode* loginChildNode, MPNode* loginChildNodeClone, Common::AddressType addrType);
     void generateExportData(QJsonArray& exportTopArray);
 
+    static char toChar(const QJsonValue &val) { return static_cast<char>(val.toInt()); }
+    void addUnknownCardPayload(const QJsonValue &val);
     void fillAddUnknownCard(const QJsonArray& dataArray);
 
 signals:

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -171,7 +171,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     connect(wsClient, &WSClient::statusChanged, [this](Common::MPStatus status)
     {
-        if (status == Common::UnkownSmartcad)
+        if (status == Common::UnknownSmartcard)
             ui->stackedWidget->setCurrentWidget(ui->pageSync);
 
         if (wsClient->isMPBLE())
@@ -603,7 +603,7 @@ void MainWindow::updateBackupControlsVisibility(bool visible)
 
 void MainWindow::updatePage()
 {
-    bool isCardUnknown = wsClient->get_status() == Common::UnkownSmartcad;
+    bool isCardUnknown = wsClient->get_status() == Common::UnknownSmartcard;
 
     ui->label_13->setVisible(!isCardUnknown);
     ui->label_14->setVisible(!isCardUnknown);
@@ -1332,7 +1332,7 @@ void MainWindow::updateTabButtons()
         setEnabledToAllTabButtons(false);
 
     // Enable or Disable tabs according to the device status
-    if (wsClient->get_status() == Common::UnkownSmartcad)
+    if (wsClient->get_status() == Common::UnknownSmartcard)
     {
         // Enable all tab buttons
         setEnabledToAllTabButtons(true);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1129,7 +1129,7 @@ void MainWindow::on_pushButtonExportFile_clicked()
     if (ui->checkBoxExport->isChecked())
         wsClient->exportDbFile("none");
     else
-        wsClient->exportDbFile("SimpleCrypt");
+        wsClient->exportDbFile(Common::SIMPLE_CRYPT);
 
     // one-time connection, must be disconected immediately in the slot
     connect(wsClient, &WSClient::dbExported, this, &MainWindow::dbExported);

--- a/src/MessageProtocol/IMessageProtocol.h
+++ b/src/MessageProtocol/IMessageProtocol.h
@@ -191,8 +191,12 @@ public:
     virtual int getLoginMaxLength() const = 0;
     virtual int getPwdMaxLength() const = 0;
 
+    virtual QByteArray getCpzValue(const QByteArray &cpzCtr) const = 0;
+
 
     QMap<quint16,quint16> m_commandMapping;
+
+    static constexpr int CPZ_LENGTH = 8;
 };
 
 

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -295,7 +295,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::READ_CARD_PASS        , 0xB5},
         {MPCmd::SET_CARD_LOGIN        , 0xB6},
         {MPCmd::SET_CARD_PASS         , 0xB7},
-        {MPCmd::ADD_UNKNOWN_CARD      , 0xB8},
+        {MPCmd::ADD_UNKNOWN_CARD      , 0x0020},
         {MPCmd::MOOLTIPASS_STATUS     , 0x0011},
         {MPCmd::FUNCTIONAL_TEST_RES   , 0xBA},
         {MPCmd::SET_DATE              , 0x0004},

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -316,7 +316,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_STARTING_PARENT   , 0x0100},
         {MPCmd::SET_STARTING_PARENT   , 0x0105},
         {MPCmd::GET_CTRVALUE          , 0x0109},
-        {MPCmd::SET_CTRVALUE          , 0xCC},
+        {MPCmd::SET_CTRVALUE          , 0x010A},
         {MPCmd::ADD_CARD_CPZ_CTR      , 0xCD},
         {MPCmd::GET_CARD_CPZ_CTR      , 0x010E},
         {MPCmd::CARD_CPZ_CTR_PACKET   , 0xCF},

--- a/src/MessageProtocol/MessageProtocolBLE.h
+++ b/src/MessageProtocol/MessageProtocolBLE.h
@@ -53,6 +53,8 @@ public:
     int getLoginMaxLength() const override { return LOGIN_MAX_LENGTH; }
     int getPwdMaxLength() const override { return PWD_MAX_LENGTH; }
 
+    QByteArray getCpzValue(const QByteArray &cpzCtr) const override { return cpzCtr.mid(CPZ_START, CPZ_LENGTH); }
+
 private:
     virtual void fillCommandMapping() override;
     int getStartingPayloadPosition(const QByteArray &data) const;
@@ -71,6 +73,7 @@ private:
     static constexpr uint CRED_PACKAGE_SIZE = 9;
     static constexpr int PWD_MAX_LENGTH = 64;
     static constexpr int LOGIN_MAX_LENGTH = 64;
+    static constexpr int CPZ_START = 2;
 };
 
 #endif // MESSAGEPROTOCOLBLE_H

--- a/src/MessageProtocol/MessageProtocolMini.h
+++ b/src/MessageProtocol/MessageProtocolMini.h
@@ -46,12 +46,15 @@ public:
     int getLoginMaxLength() const override { return LOGIN_MAX_LENGTH; }
     int getPwdMaxLength() const override { return PWD_MAX_LENGTH; }
 
+    QByteArray getCpzValue(const QByteArray &cpzCtr) const override { return cpzCtr.mid(CPZ_START, CPZ_LENGTH); }
+
     virtual void fillCommandMapping() override;
 
 private:
     static constexpr uint CRED_PACKAGE_SIZE = 6;
     static constexpr int PWD_MAX_LENGTH = 32;
     static constexpr int LOGIN_MAX_LENGTH = 63;
+    static constexpr int CPZ_START = 0;
 };
 
 #endif // MESSAGEPROTOCOLMINI_H


### PR DESCRIPTION
### Changset:
**Extra user datas are added to export file:**
- HID_CMD_GET_CPZ_LUT_ENTRY
- user security settings
- user language
- bt keyboard layout
- usb keyboard layout

They are imported, when an initailized card inserted.
**Fix for the SimpleCrypt bug** is also implemented.