### PR TITLE
Prevent ble backup file import into the standard mini

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5134,6 +5134,13 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
         return false;
     }
 
+    if (isBleExport && !isBLE())
+    {
+        qWarning() << "Cannot use BLE export file for mini";
+        errorString = "Selected File Is A BLE Backup";
+        return false;
+    }
+
     /* Know which bundle we're dealing with */
     if (deviceVersion == "mooltipass")
     {


### PR DESCRIPTION
When user is trying to import a ble backup file to the mini:
![kép](https://user-images.githubusercontent.com/11043249/79322913-c4b94500-7f0d-11ea-8b70-37fc1dd44d56.png)
