### PR TITLE
[BLE] Reset communication, when device opened after retry to avoid communication freeze

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -561,6 +561,13 @@ void MPDevice::removeFileFromCache(QString fileName)
     emit filesCacheChanged();
 }
 
+void MPDevice::resetCommunication()
+{
+    jobsQueue.clear();
+    currentJobs = nullptr;
+    commandQueue.clear();
+}
+
 void MPDevice::memMgmtModeReadFlash(AsyncJobs *jobs, bool fullScan,
                                     const MPDeviceProgressCb &cbProgress,bool getCreds,
                                     bool getData, bool getDataChilds)

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -237,6 +237,8 @@ protected:
         EXPORT_USB_LAYOUT_INDEX = 21
     };
 
+    void resetCommunication();
+
 signals:
     /* Signal emited by platform code when new data comes from MP */
     /* A signal is used for platform code that uses a dedicated thread */

--- a/src/MPDevice_win.cpp
+++ b/src/MPDevice_win.cpp
@@ -422,7 +422,14 @@ void MPDevice_win::openPathRetry()
 {
     if (openPath())
     {
+        qDebug() << "Device opening retry was successful";
         platformRead();
+        resetCommunication();
+        m_writeQueue.clear();
+        while (!m_writeBufferQueue.isEmpty())
+        {
+            delete[] m_writeBufferQueue.dequeue();
+        }
         sendInitMessages();
     }
     else


### PR DESCRIPTION
**Issue:**
When device is not opened on the first try MC tries to open it 50 msec later. In the meantime it is possible a command is getting in the queue which will get before reset flipbit command and causing communication freeze.

**Fix:**
After open device retry we clear the command queue to ensure reset flipbit is the first message to write.