### PR TITLE
[BLE] #702 Keep looking for USB devices when connected through Bluetooth

### DIFF
--- a/src/MPDevice_mac.cpp
+++ b/src/MPDevice_mac.cpp
@@ -87,6 +87,17 @@ MPDevice_mac::MPDevice_mac(QObject *parent, const MPPlatformDef &platformDef):
 
 MPDevice_mac::~MPDevice_mac()
 {
+    IOHIDDeviceRegisterRemovalCallback(hidref, nullptr, this);
+    // Clear the registered callbacks.
+    IOHIDDeviceRegisterInputReportCallback(hidref,
+                                           (uint8_t *)readBuf.data(),
+                                           readBuf.size(),
+                                           nullptr,
+                                           this);
+
+    IOHIDDeviceRegisterRemovalCallback(hidref, nullptr, this);
+
+    IOHIDDeviceClose(hidref, kIOHIDOptionsTypeNone);
     CFRelease(hidref);
 }
 

--- a/src/MPManager.cpp
+++ b/src/MPManager.cpp
@@ -124,15 +124,7 @@ void MPManager::usbDeviceAdded(QString path)
 
         if (!devices.empty() && !isBluetooth)
         {
-            auto it = devices.begin();
-            auto devicePath = it.key();
-            if (it != devices.end())
-            {
-                qDebug() << "Disconnecting: " << devicePath;
-                emit mpDisconnected(it.value());
-                delete it.value();
-                devices.remove(devicePath);
-            }
+            disconnectDevice();
         }
 
         device = new MPDevice_win(this, MPDevice_win::getPlatDef(path, isBLE, isBluetooth));
@@ -153,12 +145,11 @@ void MPManager::usbDeviceAdded(QString path, bool isBLE, bool isBT)
 {
     disconnectLocalSocketDevice();
 
-    if (devices.empty())
+    if (devices.empty() || isBLEConnectedWithBT())
     {
-        if (isBLE && isBLEConnectedWithUsb())
+        if (!devices.empty() && !isBT)
         {
-            qDebug() << "BLE is already connected with usb";
-            return;
+            disconnectDevice();
         }
         MPDevice *device = nullptr;
         //Create our platform device object
@@ -355,6 +346,19 @@ void MPManager::disconnectLocalSocketDevice()
         qDebug() << "Device is connected, emulator disconnecting";
         emit sendNotification("show_emulator_disconnect");
         disconnectingDevices();
+    }
+}
+
+void MPManager::disconnectDevice()
+{
+    auto it = devices.begin();
+    auto devicePath = it.key();
+    if (it != devices.end())
+    {
+        qDebug() << "Disconnecting: " << devicePath;
+        emit mpDisconnected(it.value());
+        delete it.value();
+        devices.remove(devicePath);
     }
 }
 

--- a/src/MPManager.h
+++ b/src/MPManager.h
@@ -69,6 +69,7 @@ private:
     bool isLocalSocketDeviceConnected();
     void disconnectLocalSocketDevice();
     bool isBLEConnectedWithUsb();
+    bool isBLEConnectedWithBT();
     void disconnectingDevices();
 
     QHash<QString, MPDevice *> devices;

--- a/src/MPManager.h
+++ b/src/MPManager.h
@@ -68,6 +68,7 @@ private:
     void checkLocalSocketDevice();
     bool isLocalSocketDeviceConnected();
     void disconnectLocalSocketDevice();
+    void disconnectDevice();
     bool isBLEConnectedWithUsb();
     bool isBLEConnectedWithBT();
     void disconnectingDevices();

--- a/src/MPManager.h
+++ b/src/MPManager.h
@@ -51,7 +51,6 @@ signals:
     void mpConnected(MPDevice *device);
     void mpDisconnected(MPDevice *device);
     void sendNotification(QString message);
-    void removeDevice(QString device);
 
 private slots:
     void usbDeviceAdded();
@@ -61,6 +60,7 @@ private slots:
     void usbDeviceAdded(QString path, bool isBLE, bool isBT);
 #endif
     void usbDeviceRemoved(QString path);
+    void disconnectAndCheckDevices();
 
 private:
     MPManager();

--- a/src/MPManager.h
+++ b/src/MPManager.h
@@ -51,6 +51,7 @@ signals:
     void mpConnected(MPDevice *device);
     void mpDisconnected(MPDevice *device);
     void sendNotification(QString message);
+    void removeDevice(QString device);
 
 private slots:
     void usbDeviceAdded();

--- a/src/UsbMonitor_mac.cpp
+++ b/src/UsbMonitor_mac.cpp
@@ -85,6 +85,7 @@ void _device_matching_callback(void *user_data,
         else if (UsbMonitor_mac::TRANSPORT_USB == transport)
         {
             qDebug() << "USB connection.";
+            def.isBluetooth = false;
         }
         else
         {
@@ -93,7 +94,7 @@ void _device_matching_callback(void *user_data,
         }
     }
 
-    if (def.isBLE)
+    if (def.isBLE && def.isBluetooth)
     {
         // Two hid interface is detected for bluetooth,
         // but we can only write the one with higher unique id
@@ -112,7 +113,7 @@ void _device_matching_callback(void *user_data,
             um->btMap.clear();
         }
     }
-    if (um->deviceHash.isEmpty())
+    if (um->deviceHash.isEmpty() || (def.isBLE && !def.isBluetooth))
     {
         um->deviceHash[def.id] = def;
         emit um->usbDeviceAdded(def.id);
@@ -232,5 +233,17 @@ void UsbMonitor_mac::handleBtTimeout()
         emit usbDeviceAdded(def.id);
         qDebug() << "Device added: " << def.id;
         btMap.clear();
+    }
+}
+
+void UsbMonitor_mac::removeDeviceHash(QString hash)
+{
+    if (deviceHash.contains(hash))
+    {
+        deviceHash.remove(hash);
+    }
+    else
+    {
+        qCritical() << "device hash does not contain: " << hash;
     }
 }

--- a/src/UsbMonitor_mac.cpp
+++ b/src/UsbMonitor_mac.cpp
@@ -237,14 +237,15 @@ void UsbMonitor_mac::handleBtTimeout()
     if (!btMap.empty())
     {
         auto& def = btMap.first();
-        deviceHash[def.id] = def;
         if (deviceHash.isEmpty())
         {
+            deviceHash[def.id] = def;
             emit usbDeviceAdded(def.id);
             qDebug() << "Device added: " << def.id;
         }
         else
         {
+            deviceHash[def.id] = def;
             qDebug() << "BT is detected: " << def.id
                      << ", but a device is already connected with USB";
         }

--- a/src/UsbMonitor_mac.h
+++ b/src/UsbMonitor_mac.h
@@ -41,10 +41,10 @@ public:
 signals:
     void usbDeviceAdded(QString path);
     void usbDeviceRemoved(QString path);
+    void disconnectCurrentDevice();
 
 private slots:
     void handleBtTimeout();
-    void removeDeviceHash(QString hash);
 
 private:
     UsbMonitor_mac();

--- a/src/UsbMonitor_mac.h
+++ b/src/UsbMonitor_mac.h
@@ -44,6 +44,7 @@ signals:
 
 private slots:
     void handleBtTimeout();
+    void removeDeviceHash(QString hash);
 
 private:
     UsbMonitor_mac();


### PR DESCRIPTION
Fixed #702 on Windows, Mac and Linux, but could not test on Linux, because was not able to connect BLE with BT.

On Mac when device is connected with BT, then plug in USB disconnecting BT device and connecting USB device caused crash, because the reported callback still received messages and crashed MC. For this I unregistered the Report Callback and closed the device in MPDevice_mac destructor.