### PR TITLE
[BLE] Check number of languages/layouts on connection and fetch if different as the last

### DIFF
--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -110,7 +110,7 @@ public:
 
     QByteArray getStartAddressToSet(const QVector<QByteArray>& startNodeArray, Common::AddressType addrType) const;
 
-    void readLanguages();
+    void readLanguages(bool onlyCheck);
 
     void loadWebAuthnNodes(AsyncJobs * jobs, const MPDeviceProgressCb &cbProgress);
     void appendLoginNode(MPNode* loginNode, MPNode* loginNodeClone, Common::AddressType addrType);
@@ -167,6 +167,9 @@ private:
     QJsonObject m_deviceLanguages;
     QJsonObject m_keyboardLayouts;
     MPMiniToBleNodeConverter m_bleNodeConverter;
+
+    static int s_LangNum;
+    static int s_LayoutNum;
 
     static constexpr quint8 MESSAGE_FLIP_BIT = 0x80;
     static constexpr quint8 MESSAGE_ACK_AND_PAYLOAD_LENGTH = 0x7F;

--- a/src/Settings/DeviceSettings.h
+++ b/src/Settings/DeviceSettings.h
@@ -41,7 +41,7 @@ public:
     virtual void loadParameters() = 0;
     virtual void updateParam(MPParams::Param param, int val) = 0;
     void updateParam(MPParams::Param param, bool en);
-    virtual void setupKeyboardLayout() {}
+    virtual void setupKeyboardLayout(bool) {}
 
     const QMetaObject* getMetaObject() const {return metaObject();}
 

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -64,7 +64,7 @@ void SettingsGuiBLE::updateUI()
     ui->settings_advanced_lockunlock->show();
 }
 
-void SettingsGuiBLE::setupKeyboardLayout()
+void SettingsGuiBLE::setupKeyboardLayout(bool onlyCheck)
 {
-    m_mw->wsClient->requestBleKeyboardLayout();
+    m_mw->wsClient->requestBleKeyboardLayout(onlyCheck);
 }

--- a/src/Settings/SettingsGuiBLE.h
+++ b/src/Settings/SettingsGuiBLE.h
@@ -15,7 +15,7 @@ public:
     void loadParameters() override;
     void updateParam(MPParams::Param param, int val) override;
     void updateUI() override;
-    void setupKeyboardLayout() override;
+    void setupKeyboardLayout(bool onlyCheck) override;
 
     static const int NONE_INDEX = 0;
     static const int TAB_INDEX = 9;

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -81,6 +81,11 @@ void SettingsGuiHelper::createSettingUIMapping()
     else if (m_settings)
     {
         // If type is not different do not recreate m_settings
+        if (Common::MP_BLE == type)
+        {
+            // For BLE check if it is the same number of lang/layout
+            m_settings->setupKeyboardLayout(true);
+        }
         return;
     }
     m_deviceType = type;
@@ -97,7 +102,7 @@ void SettingsGuiHelper::createSettingUIMapping()
         return;
     }
 
-    m_settings->setupKeyboardLayout();
+    m_settings->setupKeyboardLayout(false);
     m_settings->connectSendParams(this);
     dynamic_cast<ISettingsGui*>(m_settings)->updateUI();
     initKnockSetting();

--- a/src/Settings/SettingsGuiMini.cpp
+++ b/src/Settings/SettingsGuiMini.cpp
@@ -61,7 +61,7 @@ void SettingsGuiMini::updateUI()
     ui->settings_advanced_lockunlock->show();
 }
 
-void SettingsGuiMini::setupKeyboardLayout()
+void SettingsGuiMini::setupKeyboardLayout(bool)
 {
     auto* langCb = ui->comboBoxLang;
     if (langCb->count() > 0)

--- a/src/Settings/SettingsGuiMini.h
+++ b/src/Settings/SettingsGuiMini.h
@@ -16,7 +16,7 @@ public:
     void loadParameters() override;
     void updateParam(MPParams::Param param, int val) override;
     void updateUI() override;
-    void setupKeyboardLayout() override;
+    void setupKeyboardLayout(bool onlyCheck) override;
 
 
     static const int TAB_INDEX = 43;

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -717,9 +717,11 @@ void WSClient::sendLoadParams()
     sendJsonData({{ "msg", "load_params" }});
 }
 
-void WSClient::requestBleKeyboardLayout()
+void WSClient::requestBleKeyboardLayout(bool onlyCheck)
 {
-    sendJsonData({{ "msg", "request_keyboard_layout" }});
+    QJsonObject o;
+    o["only_check"] = onlyCheck;
+    sendJsonData({{ "msg", "request_keyboard_layout" }, {"data", o}});
 }
 
 void WSClient::sendLockDevice()

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -109,7 +109,7 @@ public:
     inline bool isFw12() const { return isFwVersion(12); }
     inline bool isFw13() const { return isFwVersion(13); }
 
-    void requestBleKeyboardLayout();
+    void requestBleKeyboardLayout(bool onlyCheck);
 
     void sendLockDevice();
     SettingsGuiHelper* settingsHelper();

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1165,7 +1165,8 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     }
     else if (root["msg"] == "request_keyboard_layout")
     {
-        bleImpl->readLanguages();
+        QJsonObject o = root["data"].toObject();
+        bleImpl->readLanguages(o["only_check"].toBool());
     }
     else
     {


### PR DESCRIPTION
Previously languages and layouts was only fetched when a different device was connected (e.g.: BLE after a Mini). 
Fixed it and now also fetched when the number of languages or layouts is different as before.
`onlyCheck` is needed to force fetching when different devices connected.