### PR TITLE
[BLE] #711 Inform device about computer is locked/unlocked

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7375,7 +7375,7 @@ void MPDevice::informLocked(const MessageHandlerCb &cb)
     auto *jobs = new AsyncJobs("Inform device about computer locked", this);
 
     const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
-    jobs->append(new MPCommandJob(this, MPCmd::LOCK_DEVICE, afterFn));
+    jobs->append(new MPCommandJob(this, MPCmd::INFORM_LOCKED, afterFn));
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
     {
@@ -7393,7 +7393,7 @@ void MPDevice::informUnlocked(const MessageHandlerCb &cb)
     auto *jobs = new AsyncJobs("Inform device about computer unlocked", this);
 
     const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
-    jobs->append(new MPCommandJob(this, MPCmd::INFORM_LOCKED, afterFn));
+    jobs->append(new MPCommandJob(this, MPCmd::INFORM_UNLOCKED, afterFn));
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
     {

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7370,6 +7370,42 @@ void MPDevice::lockDevice(const MessageHandlerCb &cb)
     runAndDequeueJobs();
 }
 
+void MPDevice::informLocked(const MessageHandlerCb &cb)
+{
+    auto *jobs = new AsyncJobs("Inform device about computer locked", this);
+
+    const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
+    jobs->append(new MPCommandJob(this, MPCmd::LOCK_DEVICE, afterFn));
+
+    connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
+    {
+        Q_UNUSED(failedJob);
+        qCritical() << "Failed to inform locked!";
+        cb(false, {});
+    });
+
+    jobsQueue.enqueue(jobs);
+    runAndDequeueJobs();
+}
+
+void MPDevice::informUnlocked(const MessageHandlerCb &cb)
+{
+    auto *jobs = new AsyncJobs("Inform device about computer unlocked", this);
+
+    const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
+    jobs->append(new MPCommandJob(this, MPCmd::INFORM_LOCKED, afterFn));
+
+    connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
+    {
+        Q_UNUSED(failedJob);
+        qCritical() << "Failed to inform unlocked!";
+        cb(false, {});
+    });
+
+    jobsQueue.enqueue(jobs);
+    runAndDequeueJobs();
+}
+
 void MPDevice::getAvailableUsers(const MessageHandlerCb &cb)
 {
     auto *jobs = new AsyncJobs("Get Available User", this);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -178,6 +178,9 @@ public:
     // Lock the devide.
     void lockDevice(const MessageHandlerCb &cb);
 
+    void informLocked(const MessageHandlerCb &cb);
+    void informUnlocked(const MessageHandlerCb &cb);
+
     void getAvailableUsers(const MessageHandlerCb &cb);
 
     // Returns bleImpl

--- a/src/MacSystemEvents.mm
+++ b/src/MacSystemEvents.mm
@@ -9,6 +9,7 @@
 @property(assign) void (*trigger)(const int, void *);
 
 - (void)screenLocked:(NSNotification *)notif;
+- (void)screenUnlocked:(NSNotification *)notif;
 - (void)loggingOff:(NSNotification *)notif;
 - (void)goingToSleep:(NSNotification *)notif;
 - (void)shuttingDown:(NSNotification *)notif;
@@ -27,6 +28,11 @@
         [center addObserver:newSelf
                    selector:@selector(screenLocked:)
                        name:@"com.apple.screenIsLocked"
+                     object:nil];
+
+        [center addObserver:newSelf
+                   selector:@selector(screenUnlocked:)
+                       name:@"com.apple.screenIsUnlocked"
                      object:nil];
 
         id notifCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
@@ -52,6 +58,12 @@
 {
     (void) notif;
     _trigger(SCREEN_LOCKED, _instance);
+}
+
+- (void)screenUnlocked:(NSNotification *)notif
+{
+    (void) notif;
+    _trigger(SCREEN_UNLOCKED, _instance);
 }
 
 - (void)loggingOff:(NSNotification *)notif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1712,6 +1712,14 @@ void MainWindow::onDeviceConnected()
     if (wsClient->isMPBLE())
     {
         wsClient->sendUserSettingsRequest();
+        if (m_computerUnlocked)
+        {
+            wsClient->sendInformUnlocked();
+        }
+        else
+        {
+            wsClient->sendInformLocked();
+        }
     }
     updateDeviceDependentUI();
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -499,6 +499,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(&eventHandler, &SystemEventHandler::loggingOff, this, &MainWindow::onSystemEvents);
     connect(&eventHandler, &SystemEventHandler::goingToSleep, this, &MainWindow::onSystemEvents);
     connect(&eventHandler, &SystemEventHandler::shuttingDown, this, &MainWindow::onSystemEvents);
+    connect(&eventHandler, &SystemEventHandler::screenUnlocked, this, &MainWindow::onSystemUnlock);
 
     checkAutoStart();
     checkSubdomainSelection();
@@ -1630,6 +1631,8 @@ void MainWindow::onSystemEvents()
         qDebug() << "System event. Locking device!";
         wsClient->sendLockDevice();
     }
+    wsClient->sendInformLocked();
+    m_computerUnlocked = false;
 
     // In certain cases it is necessary to tell the system that it can proceed closing the
     // application down. It doesn't have any effect if the application wasn't about to be closed
@@ -1637,6 +1640,13 @@ void MainWindow::onSystemEvents()
 #ifdef Q_OS_MAC
     QTimer::singleShot(2 * 1000, &eventHandler, &SystemEventHandler::readyToTerminate);
 #endif
+}
+
+void MainWindow::onSystemUnlock()
+{
+    qDebug() << "System is unlocked, informing device.";
+    wsClient->sendInformUnlocked();
+    m_computerUnlocked = true;
 }
 
 void MainWindow::on_comboBoxSystrayIcon_currentIndexChanged(int index)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1631,7 +1631,10 @@ void MainWindow::onSystemEvents()
         qDebug() << "System event. Locking device!";
         wsClient->sendLockDevice();
     }
-    wsClient->sendInformLocked();
+    if (wsClient->isMPBLE())
+    {
+        wsClient->sendInformLocked();
+    }
     m_computerUnlocked = false;
 
     // In certain cases it is necessary to tell the system that it can proceed closing the
@@ -1644,8 +1647,11 @@ void MainWindow::onSystemEvents()
 
 void MainWindow::onSystemUnlock()
 {
-    qDebug() << "System is unlocked, informing device.";
-    wsClient->sendInformUnlocked();
+    if (wsClient->isMPBLE())
+    {
+        qDebug() << "System is unlocked, informing device.";
+        wsClient->sendInformUnlocked();
+    }
     m_computerUnlocked = true;
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -145,6 +145,7 @@ private slots:
 
     void onLockDeviceSystemEventsChanged(bool checked);
     void onSystemEvents();
+    void onSystemUnlock();
 
     void on_comboBoxSystrayIcon_currentIndexChanged(int index);
 
@@ -221,6 +222,8 @@ private:
 
     QJsonObject m_keyboardLayoutCache;
     QJsonObject m_languagesCache;
+
+    bool m_computerUnlocked = true;
 
     const QString HIBP_URL = "https://haveibeenpwned.com/Passwords";
 #ifdef Q_OS_MAC

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -330,6 +330,8 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_USER_CHANGE_NB    , 0x000A},
         {MPCmd::SET_DESCRIPTION       , 0xD8},
         {MPCmd::LOCK_DEVICE           , 0x0010},
+        {MPCmd::INFORM_LOCKED         , 0x0024},
+        {MPCmd::INFORM_UNLOCKED       , 0x0025},
         {MPCmd::GET_SERIAL            , 0xDA},
         {MPCmd::CMD_DBG_MESSAGE       , 0x8000},
         {MPCmd::GET_PLAT_INFO         , 0x0003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -148,6 +148,8 @@ public:
             SET_KEYB_LAYOUT_ID  ,
             SET_USER_LANG       ,
             SET_DEVICE_LANG     ,
+            INFORM_LOCKED       ,
+            INFORM_UNLOCKED     ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/SystemEvent.h
+++ b/src/SystemEvent.h
@@ -6,7 +6,8 @@ enum SystemEvent
     SCREEN_LOCKED,
     LOGGING_OFF,
     GOING_TO_SLEEP,
-    SHUTTING_DOWN
+    SHUTTING_DOWN,
+    SCREEN_UNLOCKED
 };
 
 #endif // SRC_SYSTEMEVENT_H

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -168,6 +168,10 @@ bool SystemEventHandler::nativeEventFilter(const QByteArray &eventType, void *me
         {
             emit screenLocked();
         }
+        else if (msg->message == WM_WTSSESSION_CHANGE && msg->wParam == WTS_SESSION_UNLOCK)
+        {
+            emit screenUnlocked();
+        }
     }
 #else
     Q_UNUSED(eventType);

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -212,6 +212,10 @@ void SystemEventHandler::screenSaverActiveChanged(bool on)
     {
         emit screenLocked();
     }
+    else
+    {
+        emit screenUnlocked();
+    }
 }
 
 void SystemEventHandler::kdeAboutToSuspend()

--- a/src/SystemEventHandler.cpp
+++ b/src/SystemEventHandler.cpp
@@ -114,6 +114,10 @@ void SystemEventHandler::emitEvent(const SystemEvent event)
             emit screenLocked();
             break;
 
+        case SCREEN_UNLOCKED:
+            emit screenUnlocked();
+            break;
+
         case LOGGING_OFF:
             emit loggingOff();
             break;

--- a/src/SystemEventHandler.h
+++ b/src/SystemEventHandler.h
@@ -26,6 +26,7 @@ signals:
     void loggingOff();
     void goingToSleep();
     void shuttingDown();
+    void screenUnlocked();
 
 public slots:
 #ifdef Q_OS_MAC

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -729,6 +729,16 @@ void WSClient::sendLockDevice()
     sendJsonData({{ "msg", "lock_device" }});
 }
 
+void WSClient::sendInformLocked()
+{
+    sendJsonData({{ "msg", "inform_locked" }});
+}
+
+void WSClient::sendInformUnlocked()
+{
+    sendJsonData({{ "msg", "inform_unlocked" }});
+}
+
 SettingsGuiHelper* WSClient::settingsHelper()
 {
     return m_settingsHelper;

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -112,6 +112,8 @@ public:
     void requestBleKeyboardLayout(bool onlyCheck);
 
     void sendLockDevice();
+    void sendInformLocked();
+    void sendInformUnlocked();
     SettingsGuiHelper* settingsHelper();
 
 signals:

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1168,6 +1168,40 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
         QJsonObject o = root["data"].toObject();
         bleImpl->readLanguages(o["only_check"].toBool());
     }
+    else if (root["msg"] == "inform_locked")
+    {
+        mpdevice->lockDevice([this, root](bool success, QString errstr)
+        {
+            if (!success)
+            {
+                sendFailedJson(root, errstr);
+                return;
+            }
+
+            QJsonObject ores;
+            QJsonObject oroot = root;
+            ores["success"] = "true";
+            oroot["data"] = ores;
+            sendJsonMessage(oroot);
+        });
+    }
+    else if (root["msg"] == "inform_unlocked")
+    {
+        mpdevice->lockDevice([this, root](bool success, QString errstr)
+        {
+            if (!success)
+            {
+                sendFailedJson(root, errstr);
+                return;
+            }
+
+            QJsonObject ores;
+            QJsonObject oroot = root;
+            ores["success"] = "true";
+            oroot["data"] = ores;
+            sendJsonMessage(oroot);
+        });
+    }
     else
     {
         qDebug() << root["msg"] << " message have not implemented yet for BLE";

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1170,7 +1170,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     }
     else if (root["msg"] == "inform_locked")
     {
-        mpdevice->lockDevice([this, root](bool success, QString errstr)
+        mpdevice->informLocked([this, root](bool success, QString errstr)
         {
             if (!success)
             {
@@ -1187,7 +1187,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     }
     else if (root["msg"] == "inform_unlocked")
     {
-        mpdevice->lockDevice([this, root](bool success, QString errstr)
+        mpdevice->informUnlocked([this, root](bool success, QString errstr)
         {
             if (!success)
             {


### PR DESCRIPTION
Implement sending locked/unlocked messages when computer is locked/unlocked. #711
Also send current computer status when device is connected.
Storing computer state in MC (MainWindow) and handling lock/unlock on every OS.