### PR TITLE
#723 Reset device settings on device disconnection

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1742,6 +1742,7 @@ void MainWindow::onDeviceDisconnected()
     ui->groupBox_UserSettings->hide();
     wsClient->set_cardId("");
     ui->lineEdit_dbBackupFilePath->setText("");
+    on_pushButtonSettingsReset_clicked();
 }
 
 void MainWindow::on_checkBoxDebugHttp_stateChanged(int)


### PR DESCRIPTION
Fix for #723.
Device settings are fetched every time, but it is cached on Gui side, so need to reset it on device disconnections.