### PR TITLE
#720 Exit MMM when user removes smart card

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3593,6 +3593,11 @@ void MPDevice::processStatusChange(const QByteArray &data)
             }
         }
 
+        if (Common::MMMMode == prevStatus && Common::NoCardInserted == s)
+        {
+            exitMemMgmtMode();
+        }
+
         if (s == Common::Unlocked)
         {
             /* If v1.2 firmware, query user change number */

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -462,10 +462,19 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if(rootobj["msg"] == "get_user_categories")
     {
         QJsonObject o = rootobj["data"].toObject();
-        emit displayUserCategories(o["category_1"].toString(),
-                                   o["category_2"].toString(),
-                                   o["category_3"].toString(),
-                                   o["category_4"].toString());
+        bool success = !o.contains("failed") || !o.value("failed").toBool();
+        if (success)
+        {
+            emit displayUserCategories(o["category_1"].toString(),
+                                       o["category_2"].toString(),
+                                       o["category_3"].toString(),
+                                       o["category_4"].toString());
+        }
+        else
+        {
+            qDebug() << "get_user_categories failed";
+        }
+
     }
     else if(rootobj["msg"] == "set_user_categories")
     {


### PR DESCRIPTION
Also fix handle when get_category fails.

_Note for #720 repro:_
> 4. the Credentials Management Mode is still there. If you move your mouse is dissapear and shows the no smartcard message

The few seconds delay is only there, because from the device the new status (with No Card Inserted status) only sent when "Card Removed" animation finished on the device.