### PR TITLE
[BLE] Add new device settings on MC side

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -293,6 +293,15 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->comboBoxKnock->addItem(tr("Medium"), 2);
     ui->comboBoxKnock->addItem(tr("High"), 3);
 
+    ui->comboBoxInactivityTimer->addItem(tr("No Inactivity"), 0);
+    ui->comboBoxInactivityTimer->addItem(tr("20 minutes"), 1);
+    ui->comboBoxInactivityTimer->addItem(tr("40 minutes"), 2);
+    ui->comboBoxInactivityTimer->addItem(tr("1 hour"), 3);
+    ui->comboBoxInactivityTimer->addItem(tr("2 hours"), 6);
+    ui->comboBoxInactivityTimer->addItem(tr("3 hours"), 9);
+    ui->comboBoxInactivityTimer->addItem(tr("4 hours"), 12);
+    ui->comboBoxInactivityTimer->addItem(tr("5 hours"), 15);
+
     // Close behavior
 #ifdef Q_OS_MAC
     ui->closeBehaviorComboBox->addItem(

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1128,6 +1128,50 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QWidget" name="setting_ble_inactivity_lock" native="true">
+                 <layout class="QHBoxLayout" name="horizontalLayout_57">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="label_InactivityTimer">
+                    <property name="text">
+                     <string>Inactivity Timer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBoxInactivityTimer"/>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_53">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -1463,6 +1507,27 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                  </property>
                  <property name="text">
                   <string>Device Lock on USB Disconnection</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxSwitchOffUSBDisc">
+                 <property name="text">
+                  <string>Switch off device after USB Disconnection</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxDisableBleOnCardRemove">
+                 <property name="text">
+                  <string>Disable BLE on card removed</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxDisableBleOnLock">
+                 <property name="text">
+                  <string>Disable BLE on device lock</string>
                  </property>
                 </widget>
                </item>

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -39,6 +39,10 @@ void MPSettingsBLE::loadParameters()
                         set_pin_shown_on_back(m_lastDeviceSettings.at(DeviceSettingsBLE::PIN_SHOWN_ON_BACK_BYTE) != 0);
                         set_tutorial_enabled(m_lastDeviceSettings.at(DeviceSettingsBLE::DEVICE_TUTORIAL_BYTE) != 0);
                         set_pin_show_on_entry(m_lastDeviceSettings.at(DeviceSettingsBLE::PIN_SHOW_ON_ENTRY_BYTE) != 0);
+                        set_disable_ble_on_card_remove(m_lastDeviceSettings.at(DeviceSettingsBLE::DISABLE_BLE_ON_CARD_REMOVE) != 0);
+                        set_disable_ble_on_lock(m_lastDeviceSettings.at(DeviceSettingsBLE::DISABLE_BLE_ON_LOCK) != 0);
+                        set_nb_20mins_ticks_for_lock(m_lastDeviceSettings.at(DeviceSettingsBLE::NB_20MINS_TICKS_FOR_LOCK));
+                        set_switch_off_after_usb_disc(m_lastDeviceSettings.at(DeviceSettingsBLE::SWITCH_OFF_AFTER_USB_DISC) != 0);
                         return true;
                     }
     ));

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -225,6 +225,10 @@ public:
         DEVICE_LOCK_USB_DISC,
         PIN_SHOWN_ON_BACK,
         PIN_SHOW_ON_ENTRY,
+        DISABLE_BLE_ON_CARD_REMOVE,
+        DISABLE_BLE_ON_LOCK,
+        NB_20MINS_TICKS_FOR_LOCK,
+        SWITCH_OFF_AFTER_USB_DISC
     };
     Q_ENUM(Param)
 };

--- a/src/Settings/DeviceSettingsBLE.cpp
+++ b/src/Settings/DeviceSettingsBLE.cpp
@@ -32,5 +32,13 @@ void DeviceSettingsBLE::fillParameterMapping()
     m_paramMap.insert(MPParams::PIN_SHOW_ON_ENTRY, "pin_show_on_entry");
     m_bleByteMapping[MPParams::TUTORIAL_BOOL_PARAM] = DEVICE_TUTORIAL_BYTE;
     m_bleByteMapping[MPParams::PIN_SHOW_ON_ENTRY] = PIN_SHOW_ON_ENTRY_BYTE;
+    m_paramMap.insert(MPParams::DISABLE_BLE_ON_CARD_REMOVE, "disable_ble_on_card_remove");
+    m_bleByteMapping[MPParams::DISABLE_BLE_ON_CARD_REMOVE] = DISABLE_BLE_ON_CARD_REMOVE;
+    m_paramMap.insert(MPParams::DISABLE_BLE_ON_LOCK, "disable_ble_on_lock");
+    m_bleByteMapping[MPParams::DISABLE_BLE_ON_LOCK] = DISABLE_BLE_ON_LOCK;
+    m_paramMap.insert(MPParams::NB_20MINS_TICKS_FOR_LOCK, "nb_20mins_ticks_for_lock");
+    m_bleByteMapping[MPParams::NB_20MINS_TICKS_FOR_LOCK] = NB_20MINS_TICKS_FOR_LOCK;
+    m_paramMap.insert(MPParams::SWITCH_OFF_AFTER_USB_DISC, "switch_off_after_usb_disc");
+    m_bleByteMapping[MPParams::SWITCH_OFF_AFTER_USB_DISC] = SWITCH_OFF_AFTER_USB_DISC;
 }
 

--- a/src/Settings/DeviceSettingsBLE.h
+++ b/src/Settings/DeviceSettingsBLE.h
@@ -18,6 +18,11 @@ class DeviceSettingsBLE : public DeviceSettings
     QT_SETTINGS_PROPERTY(bool, device_lock_usb_disc, false, MPParams::DEVICE_LOCK_USB_DISC)
     QT_SETTINGS_PROPERTY(bool, pin_shown_on_back, false, MPParams::PIN_SHOWN_ON_BACK)
     QT_SETTINGS_PROPERTY(bool, pin_show_on_entry, false, MPParams::PIN_SHOW_ON_ENTRY)
+    QT_SETTINGS_PROPERTY(bool, disable_ble_on_card_remove, false, MPParams::DISABLE_BLE_ON_CARD_REMOVE)
+    QT_SETTINGS_PROPERTY(bool, disable_ble_on_lock, false, MPParams::DISABLE_BLE_ON_LOCK)
+    QT_SETTINGS_PROPERTY(int, nb_20mins_ticks_for_lock, 0, MPParams::NB_20MINS_TICKS_FOR_LOCK)
+    QT_SETTINGS_PROPERTY(bool, switch_off_after_usb_disc, false, MPParams::SWITCH_OFF_AFTER_USB_DISC)
+
 
 public:
     DeviceSettingsBLE(QObject *parent);
@@ -40,6 +45,10 @@ public:
         UNLOCK_FEATURE_BYTE = 15,
         DEVICE_TUTORIAL_BYTE = 16,
         PIN_SHOW_ON_ENTRY_BYTE = 17,
+        DISABLE_BLE_ON_CARD_REMOVE = 18,
+        DISABLE_BLE_ON_LOCK = 19,
+        NB_20MINS_TICKS_FOR_LOCK = 20,
+        SWITCH_OFF_AFTER_USB_DISC = 21
     };
 
     static constexpr char USB_LAYOUT_ID = 0x01;

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -56,6 +56,9 @@ void SettingsGuiBLE::updateUI()
     ui->checkBoxPinOnBack->show();
     ui->checkBoxPinOnEntry->show();
     ui->checkBoxNoPasswordPrompt->show();
+    ui->checkBoxSwitchOffUSBDisc->show();
+    ui->checkBoxDisableBleOnCardRemove->show();
+    ui->checkBoxDisableBleOnLock->show();
 
     ui->groupBox_BLESettings->show();
     ui->checkBoxBLEReserved->hide();
@@ -65,6 +68,7 @@ void SettingsGuiBLE::updateUI()
     ui->checkBoxScreensaver->hide();
     ui->hashDisplayFeatureCheckBox->hide();
     ui->settings_advanced_lockunlock->show();
+    ui->setting_ble_inactivity_lock->show();
 }
 
 void SettingsGuiBLE::setupKeyboardLayout(bool onlyCheck)

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -52,7 +52,11 @@ void SettingsGuiHelper::setMainWindow(MainWindow *mw)
         {MPParams::BOOT_ANIMATION_PARAM, ui->checkBoxBootAnim},
         {MPParams::DEVICE_LOCK_USB_DISC, ui->checkBoxDeviceLockUSBDisc},
         {MPParams::PIN_SHOWN_ON_BACK, ui->checkBoxPinOnBack},
-        {MPParams::PIN_SHOW_ON_ENTRY, ui->checkBoxPinOnEntry}
+        {MPParams::PIN_SHOW_ON_ENTRY, ui->checkBoxPinOnEntry},
+        {MPParams::DISABLE_BLE_ON_CARD_REMOVE, ui->checkBoxDisableBleOnCardRemove},
+        {MPParams::DISABLE_BLE_ON_LOCK, ui->checkBoxDisableBleOnLock},
+        {MPParams::SWITCH_OFF_AFTER_USB_DISC, ui->checkBoxSwitchOffUSBDisc},
+        {MPParams::NB_20MINS_TICKS_FOR_LOCK, ui->comboBoxInactivityTimer}
     };
     //When something changed in GUI, show save/reset buttons
     for (const auto& widget : m_widgetMapping)

--- a/src/Settings/SettingsGuiMini.cpp
+++ b/src/Settings/SettingsGuiMini.cpp
@@ -54,6 +54,10 @@ void SettingsGuiMini::updateUI()
     ui->checkBoxPinOnEntry->hide();
     ui->checkBoxNoPasswordPrompt->hide();
 
+    ui->checkBoxSwitchOffUSBDisc->hide();
+    ui->checkBoxDisableBleOnCardRemove->hide();
+    ui->checkBoxDisableBleOnLock->hide();
+
     ui->groupBox_BLESettings->hide();
 
     // Inactivity groupbox
@@ -61,6 +65,7 @@ void SettingsGuiMini::updateUI()
     ui->checkBoxScreensaver->show();
     ui->hashDisplayFeatureCheckBox->show();
     ui->settings_advanced_lockunlock->show();
+    ui->setting_ble_inactivity_lock->hide();
 }
 
 void SettingsGuiMini::setupKeyboardLayout(bool)


### PR DESCRIPTION
New Settings:
- SETTINGS_DISABLE_BLE_ON_CARD_REMOVE
- SETTINGS_DISABLE_BLE_ON_LOCK
- SETTINGS_NB_20MINS_TICKS_FOR_LOCK
- SETTINGS_SWITCH_OFF_AFTER_USB_DISC

![kép](https://user-images.githubusercontent.com/11043249/95505322-73ff4200-09ae-11eb-8e9e-f56657aa7dbd.png)
New settings from image: 
- Inactivity Timer
- Switch off device after USB Disconnection
- Disable BLE on card removed
- Disable BLE on device lock