### PR TITLE
Add null check for settings in resetSettings

### DIFF
--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -152,6 +152,11 @@ bool SettingsGuiHelper::checkSettingsChanged()
 
 void SettingsGuiHelper::resetSettings()
 {
+    if (!m_settings)
+    {
+        qDebug() << "Cannot reset, settings is not inited yet";
+        return;
+    }
     auto* metaObj = m_settings->getMetaObject();
     while (nullptr != metaObj && QString{metaObj->className()} != "QObject")
     {


### PR DESCRIPTION
After #738 it was possible `resetSettings` called before `m_settings` is initialized, which was causing a GUI crash. (e.g.: without a device connected start daemon first, than gui and in some cases mp_disconnected sent too early)
Handled with adding a null check in `resetSettings`.