### PR TITLE
Fix device disconnection/reconnection issues

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -603,6 +603,7 @@ void MPDeviceBleImpl::fetchCategories()
                              {
                                 QJsonObject ores;
                                 fillGetCategory(data, ores);
+                                emit userCategoriesFetched(ores);
                              }
                          });
     }

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -136,6 +136,7 @@ signals:
     void bleDeviceLanguage(const QJsonObject& langs);
     void bleKeyboardLayout(const QJsonObject& layouts);
     void batteryPercentChanged(int batteryPct);
+    void userCategoriesFetched(QJsonObject categories);
 
 private slots:
     void handleLongMessageTimeout();

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -531,12 +531,12 @@ void WSServerCon::resetDevice(MPDevice *dev)
         return;
     }
 
+    sendVersion();
     sendJsonMessage({{ "msg", "mp_connected" }});
 
     //Whenever mp status changes, send state update to client
     connect(mpdevice, &MPDevice::statusChanged, this, &WSServerCon::statusChanged);
 
-    sendVersion();
     mpdevice->settings()->connectSendParams(this);
 
     connect(mpdevice, SIGNAL(memMgmtModeChanged(bool)), this, SLOT(sendMemMgmtMode()));
@@ -556,6 +556,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
         connect(mpBle, &MPDeviceBleImpl::bleDeviceLanguage, this, &WSServerCon::sendDeviceLanguage);
         connect(mpBle, &MPDeviceBleImpl::bleKeyboardLayout, this, &WSServerCon::sendKeyboardLayout);
         connect(mpBle, &MPDeviceBleImpl::batteryPercentChanged, this, &WSServerCon::sendBatteryPercent);
+        connect(mpBle, &MPDeviceBleImpl::userCategoriesFetched, this, &WSServerCon::sendUserCategories);
     }
 }
 
@@ -762,6 +763,13 @@ void WSServerCon::sendUserSettings(QJsonObject settings)
 {
     QJsonObject oroot = { {"msg", "send_user_settings"} };
     oroot["data"] = settings;
+    sendJsonMessage(oroot);
+}
+
+void WSServerCon::sendUserCategories(QJsonObject categories)
+{
+    QJsonObject oroot = { {"msg", "get_user_categories"} };
+    oroot["data"] = categories;
     sendJsonMessage(oroot);
 }
 

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -66,6 +66,7 @@ private slots:
 
     void sendHibpNotification(QString credInfo, QString pwnedNum);
     void sendUserSettings(QJsonObject settings);
+    void sendUserCategories(QJsonObject categories);
 
     void sendBatteryPercent(int batteryPct);
 private:


### PR DESCRIPTION
1. Need to `sendVersion` before `mp_connected` message for GUI (otherwise in onDeviceConnected function the previous device is used)
2. After reconnection sometimes user categories were cleared, so sending it when it is empty on daemon side.