### PR TITLE
[BLE] Add TOTP Credential support

### DIFF
--- a/daemon.pro
+++ b/daemon.pro
@@ -11,7 +11,7 @@ CONFIG -= app_bundle
 
 CONFIG += c++11
 
-INCLUDEPATH += $$PWD/src $$PWD/src/MessageProtocol $$PWD/src/Mooltipass $$PWD/src/Settings
+INCLUDEPATH += $$PWD/src $$PWD/src/MessageProtocol $$PWD/src/Mooltipass $$PWD/src/Settings $$PWD/src/CyoEncode
 
 win32 {
     LIBS += -lsetupapi -luser32
@@ -56,6 +56,9 @@ mac {
 }
 
 SOURCES += src/main_daemon.cpp \
+    src/CyoEncode/Base32.cpp \
+    src/CyoEncode/CyoDecode.c \
+    src/CyoEncode/CyoEncode.c \
     src/MPDevice.cpp \
     src/MPDevice_localSocket.cpp \
     src/MPManager.cpp \
@@ -89,6 +92,11 @@ SOURCES += src/main_daemon.cpp \
 
 HEADERS  += \
     src/Common.h \
+    src/CyoEncode/Base32.h \
+    src/CyoEncode/CyoDecode.h \
+    src/CyoEncode/CyoDecode.hpp \
+    src/CyoEncode/CyoEncode.h \
+    src/CyoEncode/CyoEncode.hpp \
     src/MPDevice.h \
     src/MPDevice_localSocket.h \
     src/MPManager.h \

--- a/gui.pro
+++ b/gui.pro
@@ -26,6 +26,7 @@ SOURCES += src/main_gui.cpp \
     src/MainWindow.cpp \
     src/ParseDomain.cpp \
     src/Common.cpp \
+    src/TOTPCredential.cpp \
     src/WSClient.cpp \
     src/RotateSpinner.cpp \
     src/AppGui.cpp \
@@ -74,6 +75,7 @@ HEADERS  += src/MainWindow.h \
     src/ParseDomain.h \
     src/Common.h \
     src/QtHelper.h \
+    src/TOTPCredential.h \
     src/WSClient.h \
     src/RotateSpinner.h \
     src/version.h \
@@ -138,6 +140,7 @@ INCLUDEPATH += src\
     src/zxcvbn-c
 
 FORMS    += src/MainWindow.ui \
+    src/TOTPCredential.ui \
     src/WindowLog.ui \
     src/CredentialsManagement.ui \
     src/FilesManagement.ui \

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -298,6 +298,15 @@ void CredentialModel::updateCategories(const QString &cat1, const QString &cat2,
     m_categoryClean = true;
 }
 
+void CredentialModel::setTOTP(const QModelIndex &idx, QString secretKey, int timeStep, int codeSize)
+{
+    LoginItem *pLoginItem = getLoginItemByIndex(idx);
+    if (pLoginItem != nullptr)
+    {
+        pLoginItem->setTOTPCredential(secretKey, timeStep, codeSize);
+    }
+}
+
 void CredentialModel::updateLoginItem(const QModelIndex &idx, const QString &sPassword, const QString &sDescription, const QString &sName, int iCat, int iLoginKey, int iPwdKey)
 {
     // Retrieve item

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -224,6 +224,11 @@ void CredentialModel::load(const QJsonArray &json)
                 pLoginItem->setkeyAfterLogin(cnode["key_after_login"].toVariant().toInt());
                 pLoginItem->setkeyAfterPwd(cnode["key_after_pwd"].toVariant().toInt());
                 pLoginItem->setPwdBlankFlag(cnode["pwd_blank_flag"].toVariant().toInt());
+                if (cnode.contains("totp_time_step"))
+                {
+                    pLoginItem->setTotpTimeStep(cnode["totp_time_step"].toVariant().toInt());
+                    pLoginItem->setTotpCodeSize(cnode["totp_code_size"].toVariant().toInt());
+                }
             }
 
             QJsonArray a = cnode["address"].toArray();

--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -58,6 +58,7 @@ public:
     void updateCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
     bool isUserCategoryClean() const { return m_categoryClean; }
     void setUserCategoryClean(bool clean) { m_categoryClean = clean; }
+    void setTOTP(const QModelIndex &idx, QString secretKey, int timeStep, int codeSize);
 
 private:
     ServiceItem *addService(const QString &sServiceName);

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -482,6 +482,7 @@ void CredentialsManagement::saveSelectedTOTP()
         LoginItem *pLoginItem = m_pCredModel->getLoginItemByIndex(srcIndex);
         if (pLoginItem != nullptr) {
             m_pCredModel->setTOTP(srcIndex, m_pTOTPCred->getSecretKey(), m_pTOTPCred->getTimeStep(), m_pTOTPCred->getCodeSize());
+            credentialDataChanged();
         }
     }
 }
@@ -1236,16 +1237,7 @@ void CredentialsManagement::on_pushButtonTOTP_clicked()
 
     m_pTOTPCred = new TOTPCredential(this);
     m_pTOTPCred->show();
-    connect(m_pTOTPCred, &TOTPCredential::destroyed, [this]()
-    {
-        qCritical() << "TOTP Credential is destroyed";
-        m_pTOTPCred = nullptr;
-    });
 
-    connect(m_pTOTPCred, &TOTPCredential::accepted, [this]()
-    {
-        qCritical() << "Accepted";
-        qCritical() << m_pTOTPCred->getSecretKey();
-        saveSelectedTOTP();
-    });
+    connect(m_pTOTPCred, &TOTPCredential::accepted, this, &CredentialsManagement::saveSelectedTOTP);
+    connect(this, &CredentialsManagement::loginSelected, m_pTOTPCred, &TOTPCredential::clearFields);
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -113,6 +113,10 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     initKeyAfterInput(ui->credDisplayKeyAfterLoginInput);
     initKeyAfterInput(ui->credDisplayKeyAfterPwdInput);
 
+    m_pTOTPCred = new TOTPCredential(this);
+    connect(m_pTOTPCred, &TOTPCredential::accepted, this, &CredentialsManagement::saveSelectedTOTP);
+    connect(this, &CredentialsManagement::loginSelected, m_pTOTPCred, &TOTPCredential::clearFields);
+
     connect(m_pCredModel, &CredentialModel::modelReset, this, &CredentialsManagement::updateFavMenu);
     connect(m_pCredModel, &CredentialModel::dataChanged, this, &CredentialsManagement::updateFavMenu);
 
@@ -869,6 +873,16 @@ void CredentialsManagement::updateLoginDescription(LoginItem *pLoginItem)
                 ui->credDisplayKeyAfterLoginInput->setCurrentIndex(keyAfterLoginIdx);
                 auto keyAfterPwdIdx = ui->credDisplayKeyAfterPwdInput->findData(pLoginItem->keyAfterPwd());
                 ui->credDisplayKeyAfterPwdInput->setCurrentIndex(keyAfterPwdIdx);
+                if (pLoginItem->totpTimeStep() != 0)
+                {
+                    m_pTOTPCred->setTimeStep(pLoginItem->totpTimeStep());
+                    m_pTOTPCred->setCodeSize(pLoginItem->totpCodeSize());
+                    ui->pushButtonTOTP->setText(tr("View TOTP Credential"));
+                }
+                else
+                {
+                    ui->pushButtonTOTP->setText(tr("Setup TOTP Credential"));
+                }
             }
         }
     }
@@ -1234,10 +1248,4 @@ void CredentialsManagement::on_pushButtonTOTP_clicked()
         m_pTOTPCred->show();
         return;
     }
-
-    m_pTOTPCred = new TOTPCredential(this);
-    m_pTOTPCred->show();
-
-    connect(m_pTOTPCred, &TOTPCredential::accepted, this, &CredentialsManagement::saveSelectedTOTP);
-    connect(this, &CredentialsManagement::loginSelected, m_pTOTPCred, &TOTPCredential::clearFields);
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -51,6 +51,7 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->buttonSaveChanges->setStyleSheet(CSS_BLUE_BUTTON);
     ui->pushButtonEnterMMM->setIcon(AppGui::qtAwesome()->icon(fa::unlock, whiteButtons));
     ui->pushButtonConfirm->setStyleSheet(CSS_BLUE_BUTTON);
+    ui->pushButtonTOTP->setStyleSheet(CSS_BLUE_BUTTON);
 
     ui->buttonExit->setText(tr("Exit Credential Management"));
     ui->buttonExit->setStyleSheet(CSS_BLUE_BUTTON);
@@ -1122,6 +1123,7 @@ void CredentialsManagement::updateDeviceType(Common::MPHwVersion newDev)
         }
         ui->addCredPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
         ui->credDisplayPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
+        ui->pushButtonTOTP->show();
     }
     else
     {
@@ -1133,6 +1135,7 @@ void CredentialsManagement::updateDeviceType(Common::MPHwVersion newDev)
         ui->credDisplayKeyAfterPwdLabel->hide();
         ui->addCredPasswordInput->setMaxPasswordLength(MINI_PASSWORD_LENGTH);
         ui->credDisplayPasswordInput->setMaxPasswordLength(MINI_PASSWORD_LENGTH);
+        ui->pushButtonTOTP->hide();
     }
 }
 
@@ -1205,4 +1208,20 @@ void CredentialsManagement::handleAdvancedModeChange(bool isEnabled)
         ui->credDisplayKeyAfterPwdLabel->hide();
         ui->credDisplayKeyAfterPwdInput->hide();
     }
+}
+
+void CredentialsManagement::on_pushButtonTOTP_clicked()
+{
+    if (m_pTOTPCred)
+    {
+        m_pTOTPCred->show();
+        return;
+    }
+
+    m_pTOTPCred = new TOTPCredential(this);
+    m_pTOTPCred->show();
+    connect(m_pTOTPCred, &WindowLog::destroyed, [this]()
+    {
+        m_pTOTPCred = nullptr;
+    });
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -73,6 +73,12 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     ui->toolButtonEditService->setIcon(AppGui::qtAwesome()->icon(fa::edit));
     ui->toolButtonEditService->setToolTip(tr("Edit Service Name"));
 
+    ui->toolButtonTOTPService->setStyleSheet(CSS_BLUE_BUTTON);
+    ui->toolButtonTOTPService->setIcon(AppGui::qtAwesome()->icon(fa::clocko));
+    ui->toolButtonTOTPService->setToolTip(tr("There is a TOTP Credential for the service"));
+    ui->toolButtonTOTPService->setEnabled(false);
+    ui->toolButtonTOTPService->hide();
+
     ui->label_UserCategories->setText(tr("Set user categories"));
     ui->labelCategory1->setText(tr("Category 1:"));
     ui->labelCategory2->setText(tr("Category 2:"));
@@ -878,10 +884,12 @@ void CredentialsManagement::updateLoginDescription(LoginItem *pLoginItem)
                     m_pTOTPCred->setTimeStep(pLoginItem->totpTimeStep());
                     m_pTOTPCred->setCodeSize(pLoginItem->totpCodeSize());
                     ui->pushButtonTOTP->setText(tr("View TOTP Credential"));
+                    ui->toolButtonTOTPService->show();
                 }
                 else
                 {
                     ui->pushButtonTOTP->setText(tr("Setup TOTP Credential"));
+                    ui->toolButtonTOTPService->hide();
                 }
             }
         }

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -57,6 +57,7 @@ private slots:
     void onPasswordUnlocked(const QString &service, const QString &login, const QString &password, bool success);
     void onCredentialUpdated(const QString &service, const QString &login, const QString &description, bool success);
     void saveSelectedCredential();
+    void saveSelectedTOTP();
     void on_pushButtonEnterMMM_clicked();
     void on_buttonDiscard_pressed();
     void onButtonDiscard_confirmed();

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -24,6 +24,7 @@
 
 // Application
 #include "WSClient.h"
+#include "TOTPCredential.h"
 
 namespace Ui {
 class CredentialsManagement;
@@ -90,6 +91,8 @@ private slots:
     void onCategoryEdited(const QString& edited);
     void handleAdvancedModeChange(bool isEnabled);
 
+    void on_pushButtonTOTP_clicked();
+
 private:
     void updateLoginDescription(const QModelIndex &srcIndex);
     void updateLoginDescription(LoginItem *pLoginItem);
@@ -117,6 +120,7 @@ private:
     WSClient *wsClient = nullptr;
     QTimer m_tSelectLoginTimer;
     LoginItem *m_pAddedLoginItem;
+    TOTPCredential *m_pTOTPCred = nullptr;
 
     QMenu m_favMenu;
     QJsonArray m_loadedModelSerialiation;

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -438,6 +438,22 @@ border-right: none;
                  </widget>
                 </item>
                 <item>
+                 <widget class="QToolButton" name="toolButtonTOTPService">
+                  <property name="minimumSize">
+                   <size>
+                    <width>18</width>
+                    <height>18</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="autoRaise">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QPushButton" name="pushButtonDelete">
                   <property name="minimumSize">
                    <size>
@@ -699,7 +715,7 @@ border-right: none;
                  <widget class="QPushButton" name="pushButtonTOTP">
                   <property name="maximumSize">
                    <size>
-                    <width>120</width>
+                    <width>150</width>
                     <height>16777215</height>
                    </size>
                   </property>

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -696,6 +696,19 @@ border-right: none;
                  <number>18</number>
                 </property>
                 <item>
+                 <widget class="QPushButton" name="pushButtonTOTP">
+                  <property name="maximumSize">
+                   <size>
+                    <width>120</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>TOTP Credential</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="AnimatedColorButton" name="pushButtonCancel" native="true">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -698,72 +698,80 @@ border-right: none;
                </layout>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_5">
-                <property name="spacing">
-                 <number>18</number>
-                </property>
-                <property name="leftMargin">
-                 <number>18</number>
-                </property>
-                <property name="topMargin">
-                 <number>10</number>
-                </property>
-                <property name="rightMargin">
-                 <number>18</number>
-                </property>
+               <layout class="QVBoxLayout" name="verticalLayout_5">
                 <item>
-                 <widget class="QPushButton" name="pushButtonTOTP">
-                  <property name="maximumSize">
-                   <size>
-                    <width>150</width>
-                    <height>16777215</height>
-                   </size>
+                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <property name="spacing">
+                   <number>18</number>
                   </property>
-                  <property name="text">
-                   <string>TOTP Credential</string>
+                  <property name="leftMargin">
+                   <number>18</number>
                   </property>
-                 </widget>
+                  <property name="topMargin">
+                   <number>10</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>18</number>
+                  </property>
+                  <item>
+                   <widget class="AnimatedColorButton" name="pushButtonCancel" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>50</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pushButtonConfirm">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Confirm changes</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                 <item>
-                 <widget class="AnimatedColorButton" name="pushButtonCancel" native="true">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>50</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="pushButtonConfirm">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Confirm changes</string>
-                  </property>
-                 </widget>
+                 <layout class="QHBoxLayout" name="horizontalLayout_8">
+                  <item>
+                   <widget class="QPushButton" name="pushButtonTOTP">
+                    <property name="maximumSize">
+                     <size>
+                      <width>180</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>TOTP Credential</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                </layout>
               </item>

--- a/src/CyoEncode/Base32.cpp
+++ b/src/CyoEncode/Base32.cpp
@@ -1,0 +1,41 @@
+#include "Base32.h"
+#include "CyoEncode.hpp"
+#include "CyoDecode.hpp"
+
+#include <vector>
+#include <QDebug>
+
+Base32::Base32()
+{
+
+}
+
+QString Base32::encode(QString str)
+{
+    auto test = str.toStdString().c_str();
+    std::vector<char> encoded;
+    size_t required = CyoEncode::Base32::GetLength(strlen(test));
+    encoded.resize(required);
+    if (0 == CyoEncode::Base32::Encode(&encoded.front(), (const CyoEncode::byte_t*)test, strlen(test)))
+    {
+        qCritical() << "Base32 encoding failed";
+        return "";
+    }
+    auto encodedStr = std::string(&encoded.front());
+    return QString::fromUtf8(encodedStr.c_str());
+}
+
+QString Base32::decode(QString str)
+{
+    auto decTest = str.toStdString();
+    std::vector<CyoEncode::byte_t> decoded;
+    size_t required = CyoDecode::Base32::GetLength(decTest.size());
+    decoded.resize(required);
+    if (0 == CyoDecode::Base32::Decode((CyoEncode::byte_t*)&decoded.front(), decTest.c_str(), decTest.size()))
+    {
+        qCritical() << "Base32 decoding failed";
+        return "";
+    }
+    std::string decodedStr((char*)&decoded.front());
+    return QString::fromUtf8(decodedStr.c_str());
+}

--- a/src/CyoEncode/Base32.cpp
+++ b/src/CyoEncode/Base32.cpp
@@ -12,11 +12,11 @@ Base32::Base32()
 
 QString Base32::encode(QString str)
 {
-    auto test = str.toStdString().c_str();
+    auto decodedStr = str.toStdString().c_str();
     std::vector<char> encoded;
-    size_t required = CyoEncode::Base32::GetLength(strlen(test));
+    size_t required = CyoEncode::Base32::GetLength(strlen(decodedStr));
     encoded.resize(required);
-    if (0 == CyoEncode::Base32::Encode(&encoded.front(), (const CyoEncode::byte_t*)test, strlen(test)))
+    if (0 == CyoEncode::Base32::Encode(&encoded.front(), (const CyoEncode::byte_t*)decodedStr, strlen(decodedStr)))
     {
         qCritical() << "Base32 encoding failed";
         return "";
@@ -27,11 +27,18 @@ QString Base32::encode(QString str)
 
 QString Base32::decode(QString str)
 {
-    auto decTest = str.toStdString();
+    // Fill = padding if necessary
+    if (str.size() % BASE32_BYTE != 0)
+    {
+        QString padding = "";
+        padding.fill('=', BASE32_BYTE - str.size() % BASE32_BYTE);
+        str += padding;
+    }
+    auto encodedStr = str.toStdString();
     std::vector<CyoEncode::byte_t> decoded;
-    size_t required = CyoDecode::Base32::GetLength(decTest.size());
+    size_t required = CyoDecode::Base32::GetLength(encodedStr.size());
     decoded.resize(required);
-    if (0 == CyoDecode::Base32::Decode((CyoEncode::byte_t*)&decoded.front(), decTest.c_str(), decTest.size()))
+    if (0 == CyoDecode::Base32::Decode((CyoEncode::byte_t*)&decoded.front(), encodedStr.c_str(), encodedStr.size()))
     {
         qCritical() << "Base32 decoding failed";
         return "";

--- a/src/CyoEncode/Base32.h
+++ b/src/CyoEncode/Base32.h
@@ -9,6 +9,8 @@ public:
     Base32();
     static QString encode(QString str);
     static QString decode(QString str);
+
+    static constexpr int BASE32_BYTE = 8;
 };
 
 #endif // BASE32_H

--- a/src/CyoEncode/Base32.h
+++ b/src/CyoEncode/Base32.h
@@ -1,0 +1,14 @@
+#ifndef BASE32_H
+#define BASE32_H
+
+#include <QString>
+
+class Base32
+{
+public:
+    Base32();
+    static QString encode(QString str);
+    static QString decode(QString str);
+};
+
+#endif // BASE32_H

--- a/src/CyoEncode/CyoDecode.c
+++ b/src/CyoEncode/CyoDecode.c
@@ -1,0 +1,1286 @@
+/*
+ * CyoDecode.c - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CyoDecode.h"
+
+#include <assert.h>
+
+/********************************** Shared ***********************************/
+
+static int cyoBaseXXValidateA(const char* src, size_t srcChars, size_t inputBytes,
+    size_t maxPadding, unsigned char maxValue, const unsigned char table[])
+{
+    /*
+     * returns 0 if the source is a valid baseXX encoding
+     */
+
+    if (!src)
+        return -1; /*ERROR - NULL pointer*/
+
+    if (srcChars % inputBytes != 0)
+        return -1; /*ERROR - extra characters*/
+
+    /* check the bytes */
+    for (; srcChars >= 1; --srcChars, ++src)
+    {
+        unsigned char ch = *src;
+        if ((ch >= 0x80) || (table[ch] > maxValue))
+            break;
+    }
+
+    /* check any padding */
+    for (; 1 <= srcChars && srcChars <= maxPadding; --srcChars, ++src)
+    {
+        unsigned char ch = *src;
+        if ((ch >= 0x80) || (table[ch] != maxValue + 1))
+            break;
+    }
+
+    /* if srcChars isn't zero then the encoded string isn't valid */
+    if (srcChars != 0)
+        return -2; /*ERROR - invalid baseXX character*/
+
+    /* OK */
+    return 0;
+}
+
+static int cyoBaseXXValidateW(const wchar_t* src, size_t srcChars, size_t inputBytes,
+    size_t maxPadding, unsigned char maxValue, const unsigned char table[])
+{
+    /*
+    * returns 0 if the source is a valid baseXX encoding
+    */
+
+    if (!src)
+        return -1; /*ERROR - NULL pointer*/
+
+    if (srcChars % inputBytes != 0)
+        return -1; /*ERROR - extra characters*/
+
+    /* check the bytes */
+    for (; srcChars >= 1; --srcChars, ++src)
+    {
+        wchar_t ch = *src;
+        if ((ch >= 0x80) || (table[ch] > maxValue))
+            break;
+    }
+
+    /* check any padding */
+    for (; 1 <= srcChars && srcChars <= maxPadding; --srcChars, ++src)
+    {
+        wchar_t ch = *src;
+        if ((ch >= 0x80) || (table[ch] != maxValue + 1))
+            break;
+    }
+
+    /* if srcChars isn't zero then the encoded string isn't valid */
+    if (srcChars != 0)
+        return -2; /*ERROR - invalid baseXX character*/
+
+    /* OK */
+    return 0;
+}
+
+static size_t cyoBaseXXDecodeGetLength(size_t srcChars, size_t inputBytes,
+    size_t outputBytes)
+{
+    if (srcChars % inputBytes != 0)
+        return 0; /*ERROR - extra characters*/
+
+    /* OK */
+    return (((srcChars + inputBytes - 1) / inputBytes) * outputBytes);
+}
+
+/****************************** Base16 Decoding ******************************/
+
+/*
+ * output 1 byte for every 2 input:
+ *
+ *               outputs: 1
+ * inputs: 1 = ----1111 = 1111----
+ *         2 = ----2222 = ----2222
+ */
+
+static const size_t BASE16_INPUT = 2;
+static const size_t BASE16_OUTPUT = 1;
+static const size_t BASE16_MAX_PADDING = 0;
+static const unsigned char BASE16_MAX_VALUE = 15;
+static const unsigned char BASE16_TABLE[ 0x80 ] = {
+    /*00-07*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*08-0f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*10-17*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*18-1f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*20-27*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*28-2f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*30-37*/ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /*8 = '0'-'7'*/
+    /*38-3f*/ 0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /*2 = '8'-'9'*/
+    /*40-47*/ 0xFF, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xFF, /*6 = 'A'-'F'*/
+    /*48-4f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*50-57*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*58-5f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*60-67*/ 0xFF, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xFF, /*6 = 'a'-'f' (same as 'A'-'F')*/
+    /*68-6f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*70-77*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*78-7f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
+int cyoBase16ValidateA(const char* src, size_t srcChars)
+{
+    return cyoBaseXXValidateA(src, srcChars, BASE16_INPUT,
+        BASE16_MAX_PADDING, BASE16_MAX_VALUE, BASE16_TABLE);
+}
+
+int cyoBase16ValidateW(const wchar_t* src, size_t srcChars)
+{
+    return cyoBaseXXValidateW(src, srcChars, BASE16_INPUT,
+        BASE16_MAX_PADDING, BASE16_MAX_VALUE, BASE16_TABLE);
+}
+
+size_t cyoBase16DecodeGetLength(size_t srcChars)
+{
+    return cyoBaseXXDecodeGetLength(srcChars, BASE16_INPUT, BASE16_OUTPUT);
+}
+
+size_t cyoBase16DecodeA(void* dest, const char* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE16_INPUT == 0))
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        unsigned char in1, in2;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 2 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            dwSrcSize -= BASE16_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80)
+                return 0; /*ERROR - invalid base16 character*/
+
+            /* Convert ASCII to base16 */
+            in1 = BASE16_TABLE[in1];
+            in2 = BASE16_TABLE[in2];
+
+            /* Validate base16 */
+            if (in1 > BASE16_MAX_VALUE || in2 > BASE16_MAX_VALUE)
+                return 0; /*ERROR - invalid base16 character*/
+
+            /* 1 output */
+            *pDest++ = ((in1 << 4) | in2);
+            dwDestSize += BASE16_OUTPUT;
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 2*/
+}
+
+size_t cyoBase16DecodeW(void* dest, const wchar_t* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE16_INPUT == 0))
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        wchar_t in1, in2;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 2 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            dwSrcSize -= BASE16_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80)
+                return 0; /*ERROR - invalid base16 character*/
+
+            /* Convert ASCII to base16 */
+            in1 = BASE16_TABLE[in1];
+            in2 = BASE16_TABLE[in2];
+
+            /* Validate base16 */
+            if (in1 > BASE16_MAX_VALUE || in2 > BASE16_MAX_VALUE)
+                return 0; /*ERROR - invalid base16 character*/
+
+            /* 1 output */
+            *pDest++ = (unsigned char)((in1 << 4) | in2);
+            dwDestSize += BASE16_OUTPUT;
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 2*/
+}
+
+size_t cyoBase16DecodeBlockA(void* dest, const char* src)
+{
+    if (dest && src)
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        unsigned char in1, in2;
+
+        /* 2 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80)
+            return 0; /*ERROR - invalid base16 character*/
+
+        /* Convert ASCII to base16 */
+        in1 = BASE16_TABLE[in1];
+        in2 = BASE16_TABLE[in2];
+
+        /* Validate base16 */
+        if (in1 > BASE16_MAX_VALUE || in2 > BASE16_MAX_VALUE)
+            return 0; /*ERROR - invalid base16 character*/
+
+        /* 1 output */
+        *pDest++ = ((in1 << 4) | in2);
+
+        return BASE16_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase16DecodeBlockW(void* dest, const wchar_t* src)
+{
+    if (dest && src)
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        wchar_t in1, in2;
+
+        /* 2 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80)
+            return 0; /*ERROR - invalid base16 character*/
+
+        /* Convert ASCII to base16 */
+        in1 = BASE16_TABLE[in1];
+        in2 = BASE16_TABLE[in2];
+
+        /* Validate base16 */
+        if (in1 > BASE16_MAX_VALUE || in2 > BASE16_MAX_VALUE)
+            return 0; /*ERROR - invalid base16 character*/
+
+        /* 1 output */
+        *pDest++ = (unsigned char)((in1 << 4) | in2);
+
+        return BASE16_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base32 Decoding ******************************/
+
+/*
+ * output 5 bytes for every 8 input:
+ *
+ *               outputs: 1        2        3        4        5
+ * inputs: 1 = ---11111 = 11111---
+ *         2 = ---222XX = -----222 XX------
+ *         3 = ---33333 =          --33333-
+ *         4 = ---4XXXX =          -------4 XXXX----
+ *         5 = ---5555X =                   ----5555 X-------
+ *         6 = ---66666 =                            -66666--
+ *         7 = ---77XXX =                            ------77 XXX-----
+ *         8 = ---88888 =                                     ---88888
+ */
+
+static const size_t BASE32_INPUT = 8;
+static const size_t BASE32_OUTPUT = 5;
+static const size_t BASE32_MAX_PADDING = 6;
+static const unsigned char BASE32_MAX_VALUE = 31;
+static const unsigned char BASE32_TABLE[ 0x80 ] = {
+    /*00-07*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*08-0f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*10-17*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*18-1f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*20-27*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*28-2f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*30-37*/ 0xFF, 0xFF, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, /*6 = '2'-'7'*/
+    /*38-3f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x20, 0xFF, 0xFF, /*1 = '='*/
+    /*40-47*/ 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, /*7 = 'A'-'G'*/
+    /*48-4f*/ 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, /*8 = 'H'-'O'*/
+    /*50-57*/ 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, /*8 = 'P'-'W'*/
+    /*58-5f*/ 0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /*3 = 'X'-'Z'*/
+    /*60-67*/ 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, /*7 = 'a'-'g' (same as 'A'-'G')*/
+    /*68-6f*/ 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, /*8 = 'h'-'o' (same as 'H'-'O')*/
+    /*70-77*/ 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, /*8 = 'p'-'w' (same as 'P'-'W')*/
+    /*78-7f*/ 0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF  /*3 = 'x'-'z' (same as 'X'-'Z')*/
+};
+
+int cyoBase32ValidateA(const char* src, size_t srcChars)
+{
+    return cyoBaseXXValidateA(src, srcChars, BASE32_INPUT,
+        BASE32_MAX_PADDING, BASE32_MAX_VALUE, BASE32_TABLE);
+}
+
+int cyoBase32ValidateW(const wchar_t* src, size_t srcChars)
+{
+    return cyoBaseXXValidateW(src, srcChars, BASE32_INPUT,
+        BASE32_MAX_PADDING, BASE32_MAX_VALUE, BASE32_TABLE);
+}
+
+size_t cyoBase32DecodeGetLength(size_t srcChars)
+{
+    return cyoBaseXXDecodeGetLength(srcChars, BASE32_INPUT, BASE32_OUTPUT);
+}
+
+size_t cyoBase32DecodeA(void* dest, const char* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE32_INPUT == 0))
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        unsigned char in1, in2, in3, in4, in5, in6, in7, in8;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 8 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            in3 = *pSrc++;
+            in4 = *pSrc++;
+            in5 = *pSrc++;
+            in6 = *pSrc++;
+            in7 = *pSrc++;
+            in8 = *pSrc++;
+            dwSrcSize -= BASE32_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80
+                || in5 >= 0x80 || in6 >= 0x80 || in7 >= 0x80 || in8 >= 0x80)
+                return 0; /*ERROR - invalid base32 character*/
+            if (in1 == '=' || in2 == '=')
+                return 0; /*ERROR - invalid padding*/
+            if (dwSrcSize == 0)
+            {
+                if (in3 == '=' && in4 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in4 == '=' && in5 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in5 == '=' && in6 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in6 == '=' && in7 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in7 == '=' && in8 != '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+            else
+            {
+                if (in3 == '=' || in4 == '=' || in5 == '=' || in6 == '=' || in7 == '=' || in8 == '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+
+            /* Convert ASCII to base32 */
+            in1 = BASE32_TABLE[in1];
+            in2 = BASE32_TABLE[in2];
+            in3 = BASE32_TABLE[in3];
+            in4 = BASE32_TABLE[in4];
+            in5 = BASE32_TABLE[in5];
+            in6 = BASE32_TABLE[in6];
+            in7 = BASE32_TABLE[in7];
+            in8 = BASE32_TABLE[in8];
+
+            /* Validate base32 */
+            if (in1 > BASE32_MAX_VALUE || in2 > BASE32_MAX_VALUE)
+                return 0; /*ERROR - invalid base32 character*/
+            /*the following can be padding*/
+            if (in3 > BASE32_MAX_VALUE + 1 || in4 > BASE32_MAX_VALUE + 1
+                || in5 > BASE32_MAX_VALUE + 1 || in6 > BASE32_MAX_VALUE + 1
+                || in7 > BASE32_MAX_VALUE + 1 || in8 > BASE32_MAX_VALUE + 1)
+                return 0; /*ERROR - invalid base32 character*/
+
+            /* 5 outputs */
+            *pDest++ = ((in1 & 0x1f) << 3) | ((in2 & 0x1c) >> 2);
+            *pDest++ = ((in2 & 0x03) << 6) | ((in3 & 0x1f) << 1) | ((in4 & 0x10) >> 4);
+            *pDest++ = ((in4 & 0x0f) << 4) | ((in5 & 0x1e) >> 1);
+            *pDest++ = ((in5 & 0x01) << 7) | ((in6 & 0x1f) << 2) | ((in7 & 0x18) >> 3);
+            *pDest++ = ((in7 & 0x07) << 5) | (in8 & 0x1f);
+            dwDestSize += BASE32_OUTPUT;
+
+            /* Padding */
+            if (in8 == BASE32_MAX_VALUE + 1)
+            {
+                --dwDestSize;
+                assert((in7 == BASE32_MAX_VALUE + 1 && in6 == BASE32_MAX_VALUE + 1)
+                    || (in7 != BASE32_MAX_VALUE + 1));
+                if (in6 == BASE32_MAX_VALUE + 1)
+                {
+                    --dwDestSize;
+                    if (in5 == BASE32_MAX_VALUE + 1)
+                    {
+                        --dwDestSize;
+                        assert((in4 == BASE32_MAX_VALUE + 1 && in3 == BASE32_MAX_VALUE + 1)
+                            || (in4 != BASE32_MAX_VALUE + 1));
+                        if (in3 == BASE32_MAX_VALUE + 1)
+                        {
+                            --dwDestSize;
+                        }
+                    }
+                }
+            }
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 8*/
+}
+
+size_t cyoBase32DecodeW(void* dest, const wchar_t* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE32_INPUT == 0))
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        wchar_t in1, in2, in3, in4, in5, in6, in7, in8;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 8 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            in3 = *pSrc++;
+            in4 = *pSrc++;
+            in5 = *pSrc++;
+            in6 = *pSrc++;
+            in7 = *pSrc++;
+            in8 = *pSrc++;
+            dwSrcSize -= BASE32_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80
+                || in5 >= 0x80 || in6 >= 0x80 || in7 >= 0x80 || in8 >= 0x80)
+                return 0; /*ERROR - invalid base32 character*/
+            if (in1 == '=' || in2 == '=')
+                return 0; /*ERROR - invalid padding*/
+            if (dwSrcSize == 0)
+            {
+                if (in3 == '=' && in4 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in4 == '=' && in5 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in5 == '=' && in6 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in6 == '=' && in7 != '=')
+                    return 0; /*ERROR - invalid padding*/
+                if (in7 == '=' && in8 != '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+            else
+            {
+                if (in3 == '=' || in4 == '=' || in5 == '=' || in6 == '=' || in7 == '=' || in8 == '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+
+            /* Convert ASCII to base32 */
+            in1 = BASE32_TABLE[in1];
+            in2 = BASE32_TABLE[in2];
+            in3 = BASE32_TABLE[in3];
+            in4 = BASE32_TABLE[in4];
+            in5 = BASE32_TABLE[in5];
+            in6 = BASE32_TABLE[in6];
+            in7 = BASE32_TABLE[in7];
+            in8 = BASE32_TABLE[in8];
+
+            /* Validate base32 */
+            if (in1 > BASE32_MAX_VALUE || in2 > BASE32_MAX_VALUE)
+                return 0; /*ERROR - invalid base32 character*/
+            /*the following can be padding*/
+            if (in3 > BASE32_MAX_VALUE + 1 || in4 > BASE32_MAX_VALUE + 1
+                || in5 > BASE32_MAX_VALUE + 1 || in6 > BASE32_MAX_VALUE + 1
+                || in7 > BASE32_MAX_VALUE + 1 || in8 > BASE32_MAX_VALUE + 1)
+                return 0; /*ERROR - invalid base32 character*/
+
+            /* 5 outputs */
+            *pDest++ = ((in1 & 0x1f) << 3) | ((in2 & 0x1c) >> 2);
+            *pDest++ = ((in2 & 0x03) << 6) | ((in3 & 0x1f) << 1) | ((in4 & 0x10) >> 4);
+            *pDest++ = ((in4 & 0x0f) << 4) | ((in5 & 0x1e) >> 1);
+            *pDest++ = ((in5 & 0x01) << 7) | ((in6 & 0x1f) << 2) | ((in7 & 0x18) >> 3);
+            *pDest++ = ((in7 & 0x07) << 5) | (in8 & 0x1f);
+            dwDestSize += BASE32_OUTPUT;
+
+            /* Padding */
+            if (in8 == BASE32_MAX_VALUE + 1)
+            {
+                --dwDestSize;
+                assert((in7 == BASE32_MAX_VALUE + 1 && in6 == BASE32_MAX_VALUE + 1)
+                    || (in7 != BASE32_MAX_VALUE + 1));
+                if (in6 == BASE32_MAX_VALUE + 1)
+                {
+                    --dwDestSize;
+                    if (in5 == BASE32_MAX_VALUE + 1)
+                    {
+                        --dwDestSize;
+                        assert((in4 == BASE32_MAX_VALUE + 1 && in3 == BASE32_MAX_VALUE + 1)
+                            || (in4 != BASE32_MAX_VALUE + 1));
+                        if (in3 == BASE32_MAX_VALUE + 1)
+                        {
+                            --dwDestSize;
+                        }
+                    }
+                }
+            }
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 8*/
+}
+
+size_t cyoBase32DecodeBlockA(void* dest, const char* src)
+{
+    if (dest && src)
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        unsigned char in1, in2, in3, in4, in5, in6, in7, in8;
+
+        /* 8 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+        in3 = *pSrc++;
+        in4 = *pSrc++;
+        in5 = *pSrc++;
+        in6 = *pSrc++;
+        in7 = *pSrc++;
+        in8 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80
+            || in5 >= 0x80 || in6 >= 0x80 || in7 >= 0x80 || in8 >= 0x80)
+            return 0; /*ERROR - invalid base32 character*/
+
+        /* Convert ASCII to base32 */
+        in1 = BASE32_TABLE[in1];
+        in2 = BASE32_TABLE[in2];
+        in3 = BASE32_TABLE[in3];
+        in4 = BASE32_TABLE[in4];
+        in5 = BASE32_TABLE[in5];
+        in6 = BASE32_TABLE[in6];
+        in7 = BASE32_TABLE[in7];
+        in8 = BASE32_TABLE[in8];
+
+        /* Validate base32 */
+        if (in1 > BASE32_MAX_VALUE || in2 > BASE32_MAX_VALUE)
+            return 0; /*ERROR - invalid base32 character*/
+        /*the following can be padding*/
+        if (in3 > BASE32_MAX_VALUE + 1 || in4 > BASE32_MAX_VALUE + 1
+            || in5 > BASE32_MAX_VALUE + 1 || in6 > BASE32_MAX_VALUE + 1
+            || in7 > BASE32_MAX_VALUE + 1 || in8 > BASE32_MAX_VALUE + 1)
+            return 0; /*ERROR - invalid base32 character*/
+
+        /* 5 outputs */
+        *pDest++ = ((in1 & 0x1f) << 3) | ((in2 & 0x1c) >> 2);
+        *pDest++ = ((in2 & 0x03) << 6) | ((in3 & 0x1f) << 1) | ((in4 & 0x10) >> 4);
+        *pDest++ = ((in4 & 0x0f) << 4) | ((in5 & 0x1e) >> 1);
+        *pDest++ = ((in5 & 0x01) << 7) | ((in6 & 0x1f) << 2) | ((in7 & 0x18) >> 3);
+        *pDest++ = ((in7 & 0x07) << 5) | (in8 & 0x1f);
+
+        return BASE32_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase32DecodeBlockW(void* dest, const wchar_t* src)
+{
+    if (dest && src)
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        wchar_t in1, in2, in3, in4, in5, in6, in7, in8;
+
+        /* 8 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+        in3 = *pSrc++;
+        in4 = *pSrc++;
+        in5 = *pSrc++;
+        in6 = *pSrc++;
+        in7 = *pSrc++;
+        in8 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80
+            || in5 >= 0x80 || in6 >= 0x80 || in7 >= 0x80 || in8 >= 0x80)
+            return 0; /*ERROR - invalid base32 character*/
+
+        /* Convert ASCII to base32 */
+        in1 = BASE32_TABLE[in1];
+        in2 = BASE32_TABLE[in2];
+        in3 = BASE32_TABLE[in3];
+        in4 = BASE32_TABLE[in4];
+        in5 = BASE32_TABLE[in5];
+        in6 = BASE32_TABLE[in6];
+        in7 = BASE32_TABLE[in7];
+        in8 = BASE32_TABLE[in8];
+
+        /* Validate base32 */
+        if (in1 > BASE32_MAX_VALUE || in2 > BASE32_MAX_VALUE)
+            return 0; /*ERROR - invalid base32 character*/
+        /*the following can be padding*/
+        if (in3 > BASE32_MAX_VALUE + 1 || in4 > BASE32_MAX_VALUE + 1
+            || in5 > BASE32_MAX_VALUE + 1 || in6 > BASE32_MAX_VALUE + 1
+            || in7 > BASE32_MAX_VALUE + 1 || in8 > BASE32_MAX_VALUE + 1)
+            return 0; /*ERROR - invalid base32 character*/
+
+        /* 5 outputs */
+        *pDest++ = ((in1 & 0x1f) << 3) | ((in2 & 0x1c) >> 2);
+        *pDest++ = ((in2 & 0x03) << 6) | ((in3 & 0x1f) << 1) | ((in4 & 0x10) >> 4);
+        *pDest++ = ((in4 & 0x0f) << 4) | ((in5 & 0x1e) >> 1);
+        *pDest++ = ((in5 & 0x01) << 7) | ((in6 & 0x1f) << 2) | ((in7 & 0x18) >> 3);
+        *pDest++ = ((in7 & 0x07) << 5) | (in8 & 0x1f);
+
+        return BASE32_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base64 Decoding ******************************/
+
+/*
+ * output 3 bytes for every 4 input:
+ *
+ *               outputs: 1        2        3
+ * inputs: 1 = --111111 = 111111--
+ *         2 = --22XXXX = ------22 XXXX----
+ *         3 = --3333XX =          ----3333 XX------
+ *         4 = --444444 =                   --444444
+ */
+
+static const size_t BASE64_INPUT = 4;
+static const size_t BASE64_OUTPUT = 3;
+static const size_t BASE64_MAX_PADDING = 2;
+static const unsigned char BASE64_MAX_VALUE = 63;
+static const unsigned char BASE64_TABLE[ 0x80 ] = {
+    /*00-07*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*08-0f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*10-17*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*18-1f*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*20-27*/ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    /*28-2f*/ 0xFF, 0xFF, 0xFF, 0x3e, 0xFF, 0xFF, 0xFF, 0x3f, /*2 = '+' and '/'*/
+    /*30-37*/ 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, /*8 = '0'-'7'*/
+    /*38-3f*/ 0x3c, 0x3d, 0xFF, 0xFF, 0xFF, 0x40, 0xFF, 0xFF, /*2 = '8'-'9' and '='*/
+    /*40-47*/ 0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, /*7 = 'A'-'G'*/
+    /*48-4f*/ 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, /*8 = 'H'-'O'*/
+    /*50-57*/ 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, /*8 = 'P'-'W'*/
+    /*58-5f*/ 0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, /*3 = 'X'-'Z'*/
+    /*60-67*/ 0xFF, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, /*7 = 'a'-'g'*/
+    /*68-6f*/ 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, /*8 = 'h'-'o'*/
+    /*70-77*/ 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, /*8 = 'p'-'w'*/
+    /*78-7f*/ 0x31, 0x32, 0x33, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF  /*3 = 'x'-'z'*/
+};
+
+int cyoBase64ValidateA(const char* src, size_t srcChars)
+{
+    return cyoBaseXXValidateA(src, srcChars, BASE64_INPUT,
+        BASE64_MAX_PADDING, BASE64_MAX_VALUE, BASE64_TABLE);
+}
+
+int cyoBase64ValidateW(const wchar_t* src, size_t srcChars)
+{
+    return cyoBaseXXValidateW(src, srcChars, BASE64_INPUT,
+        BASE64_MAX_PADDING, BASE64_MAX_VALUE, BASE64_TABLE);
+}
+
+size_t cyoBase64DecodeGetLength(size_t srcChars)
+{
+    return cyoBaseXXDecodeGetLength(srcChars, BASE64_INPUT, BASE64_OUTPUT);
+}
+
+size_t cyoBase64DecodeA(void* dest, const char* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE64_INPUT == 0))
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        unsigned char in1, in2, in3, in4;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 4 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            in3 = *pSrc++;
+            in4 = *pSrc++;
+            dwSrcSize -= BASE64_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80)
+                return 0; /*ERROR - invalid base64 character*/
+            if (in1 == '=' || in2 == '=')
+                return 0; /*ERROR - invalid padding*/
+            if (dwSrcSize == 0)
+            {
+                if (in3 == '=' && in4 != '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+            else
+            {
+                if (in3 == '=' || in4 == '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+
+            /* Convert ASCII to base64 */
+            in1 = BASE64_TABLE[in1];
+            in2 = BASE64_TABLE[in2];
+            in3 = BASE64_TABLE[in3];
+            in4 = BASE64_TABLE[in4];
+
+            /* Validate base64 */
+            if (in1 > BASE64_MAX_VALUE || in2 > BASE64_MAX_VALUE)
+                return 0; /*ERROR - invalid base64 character*/
+            /*the following can be padding*/
+            if (in3 > BASE64_MAX_VALUE + 1 || in4 > BASE64_MAX_VALUE + 1)
+                return 0; /*ERROR - invalid base64 character*/
+
+            /* 3 outputs */
+            *pDest++ = ((in1 & 0x3f) << 2) | ((in2 & 0x30) >> 4);
+            *pDest++ = ((in2 & 0x0f) << 4) | ((in3 & 0x3c) >> 2);
+            *pDest++ = ((in3 & 0x03) << 6) | (in4 & 0x3f);
+            dwDestSize += BASE64_OUTPUT;
+
+            /* Padding */
+            if (in4 == BASE64_MAX_VALUE + 1)
+            {
+                --dwDestSize;
+                if (in3 == BASE64_MAX_VALUE + 1)
+                {
+                    --dwDestSize;
+                }
+            }
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 4*/
+}
+
+size_t cyoBase64DecodeW(void* dest, const wchar_t* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE64_INPUT == 0))
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        wchar_t in1, in2, in3, in4;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 4 inputs */
+            in1 = *pSrc++;
+            in2 = *pSrc++;
+            in3 = *pSrc++;
+            in4 = *pSrc++;
+            dwSrcSize -= BASE64_INPUT;
+
+            /* Validate ASCII */
+            if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80)
+                return 0; /*ERROR - invalid base64 character*/
+            if (in1 == '=' || in2 == '=')
+                return 0; /*ERROR - invalid padding*/
+            if (dwSrcSize == 0)
+            {
+                if (in3 == '=' && in4 != '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+            else
+            {
+                if (in3 == '=' || in4 == '=')
+                    return 0; /*ERROR - invalid padding*/
+            }
+
+            /* Convert ASCII to base64 */
+            in1 = BASE64_TABLE[in1];
+            in2 = BASE64_TABLE[in2];
+            in3 = BASE64_TABLE[in3];
+            in4 = BASE64_TABLE[in4];
+
+            /* Validate base64 */
+            if (in1 > BASE64_MAX_VALUE || in2 > BASE64_MAX_VALUE)
+                return 0; /*ERROR - invalid base64 character*/
+            /*the following can be padding*/
+            if (in3 > BASE64_MAX_VALUE + 1 || in4 > BASE64_MAX_VALUE + 1)
+                return 0; /*ERROR - invalid base64 character*/
+
+            /* 3 outputs */
+            *pDest++ = ((in1 & 0x3f) << 2) | ((in2 & 0x30) >> 4);
+            *pDest++ = ((in2 & 0x0f) << 4) | ((in3 & 0x3c) >> 2);
+            *pDest++ = ((in3 & 0x03) << 6) | (in4 & 0x3f);
+            dwDestSize += BASE64_OUTPUT;
+
+            /* Padding */
+            if (in4 == BASE64_MAX_VALUE + 1)
+            {
+                --dwDestSize;
+                if (in3 == BASE64_MAX_VALUE + 1)
+                {
+                    --dwDestSize;
+                }
+            }
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 4*/
+}
+
+size_t cyoBase64DecodeBlockA(void* dest, const char* src)
+{
+    if (dest && src)
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        unsigned char in1, in2, in3, in4;
+
+        /* 4 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+        in3 = *pSrc++;
+        in4 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80)
+            return 0; /*ERROR - invalid base64 character*/
+
+        /* Convert ASCII to base64 */
+        in1 = BASE64_TABLE[in1];
+        in2 = BASE64_TABLE[in2];
+        in3 = BASE64_TABLE[in3];
+        in4 = BASE64_TABLE[in4];
+
+        /* Validate base64 */
+        if (in1 > BASE64_MAX_VALUE || in2 > BASE64_MAX_VALUE)
+            return 0; /*ERROR - invalid base64 character*/
+        /*the following can be padding*/
+        if (in3 > BASE64_MAX_VALUE + 1 || in4 > BASE64_MAX_VALUE + 1)
+            return 0; /*ERROR - invalid base64 character*/
+
+        /* 3 outputs */
+        *pDest++ = ((in1 & 0x3f) << 2) | ((in2 & 0x30) >> 4);
+        *pDest++ = ((in2 & 0x0f) << 4) | ((in3 & 0x3c) >> 2);
+        *pDest++ = ((in3 & 0x03) << 6) | (in4 & 0x3f);
+
+        return BASE64_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase64DecodeBlockW(void* dest, const wchar_t* src)
+{
+    if (dest && src)
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        wchar_t in1, in2, in3, in4;
+
+        /* 4 inputs */
+        in1 = *pSrc++;
+        in2 = *pSrc++;
+        in3 = *pSrc++;
+        in4 = *pSrc++;
+
+        /* Validate ASCII */
+        if (in1 >= 0x80 || in2 >= 0x80 || in3 >= 0x80 || in4 >= 0x80)
+            return 0; /*ERROR - invalid base64 character*/
+
+        /* Convert ASCII to base64 */
+        in1 = BASE64_TABLE[in1];
+        in2 = BASE64_TABLE[in2];
+        in3 = BASE64_TABLE[in3];
+        in4 = BASE64_TABLE[in4];
+
+        /* Validate base64 */
+        if (in1 > BASE64_MAX_VALUE || in2 > BASE64_MAX_VALUE)
+            return 0; /*ERROR - invalid base64 character*/
+        /*the following can be padding*/
+        if (in3 > BASE64_MAX_VALUE + 1 || in4 > BASE64_MAX_VALUE + 1)
+            return 0; /*ERROR - invalid base64 character*/
+
+        /* 3 outputs */
+        *pDest++ = ((in1 & 0x3f) << 2) | ((in2 & 0x30) >> 4);
+        *pDest++ = ((in2 & 0x0f) << 4) | ((in3 & 0x3c) >> 2);
+        *pDest++ = ((in3 & 0x03) << 6) | (in4 & 0x3f);
+
+        return BASE64_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base85 Decoding ******************************/
+
+/*
+ * output 4 bytes for every 5 input
+ */
+
+static const size_t BASE85_INPUT = 5;
+static const size_t BASE85_OUTPUT = 4;
+
+#define FOLD_ZERO 1 /*output 'z' instead of '!!!!!'*/
+//#define FOLD_SPACES 1 /*output 'y' instead of 4 spaces*/
+
+int cyoBase85ValidateA(const char* src, size_t srcChars)
+{
+    const char* pSrc = src;
+    size_t dwSrcSize = srcChars;
+    unsigned char in1, in2, in3, in4, in5;
+
+    while (dwSrcSize >= 1)
+    {
+#if FOLD_ZERO
+        if (*pSrc == 'z')
+        {
+            --dwSrcSize;
+            continue;
+        }
+#endif
+
+        /* 5 inputs */
+        assert(dwSrcSize >= 1);
+        in1 = (*pSrc++ - 33);
+        --dwSrcSize;
+        in2 = in3 = in4 = in5 = 0;
+        if (dwSrcSize >= 1)
+        {
+            in2 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in3 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in4 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in5 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+
+        /* Validate */
+        if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+            return -2; /*ERROR - invalid base85 character*/
+    }
+
+    /* OK */
+    return 0;
+}
+
+int cyoBase85ValidateW(const wchar_t* src, size_t srcChars)
+{
+    const wchar_t* pSrc = src;
+    size_t dwSrcSize = srcChars;
+    wchar_t in1, in2, in3, in4, in5;
+
+    while (dwSrcSize >= 1)
+    {
+#if FOLD_ZERO
+        if (*pSrc == L'z')
+        {
+            --dwSrcSize;
+            continue;
+        }
+#endif
+
+        /* 5 inputs */
+        assert(dwSrcSize >= 1);
+        in1 = (*pSrc++ - 33);
+        --dwSrcSize;
+        in2 = in3 = in4 = in5 = 0;
+        if (dwSrcSize >= 1)
+        {
+            in2 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in3 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in4 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+        if (dwSrcSize >= 1)
+        {
+            in5 = (*pSrc++ - 33);
+            --dwSrcSize;
+        }
+
+        /* Validate */
+        if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+            return -2; /*ERROR - invalid base85 character*/
+    }
+
+    /* OK */
+    return 0;
+}
+
+size_t cyoBase85DecodeGetLength(size_t srcChars)
+{
+    return cyoBaseXXDecodeGetLength(srcChars, BASE85_INPUT, BASE85_OUTPUT);
+}
+
+size_t cyoBase85DecodeA(void* dest, const char* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE85_INPUT == 0))
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        unsigned char in1, in2, in3, in4, in5;
+        unsigned int out;
+
+        while (dwSrcSize >= 1)
+        {
+#if FOLD_ZERO
+            if (*pSrc == 'z')
+            {
+                ++pSrc;
+                *pDest++ = 0;
+                dwDestSize += BASE85_OUTPUT;
+                continue;
+            }
+#endif
+
+            /* 5 inputs */
+            in1 = (*pSrc++ - 33);
+            in2 = (*pSrc++ - 33);
+            in3 = (*pSrc++ - 33);
+            in4 = (*pSrc++ - 33);
+            in5 = (*pSrc++ - 33);
+            dwSrcSize -= BASE85_INPUT;
+
+            /* Validate */
+            if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+                return 0; /*ERROR - invalid base85 character*/
+
+            /* Output */
+            out = in1;
+            out *= 85;
+            out |= in2;
+            out *= 85;
+            out |= in3;
+            out *= 85;
+            out |= in4;
+            out *= 85;
+            out |= in5;
+            *(unsigned int*)pDest = out;
+            pDest += BASE85_OUTPUT;
+            dwDestSize += BASE85_OUTPUT;
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 5*/
+}
+
+size_t cyoBase85DecodeW(void* dest, const wchar_t* src, size_t srcChars)
+{
+    if (dest && src && (srcChars % BASE85_INPUT == 0))
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        size_t dwSrcSize = srcChars;
+        size_t dwDestSize = 0;
+        wchar_t in1, in2, in3, in4, in5;
+        unsigned int out;
+
+        while (dwSrcSize >= 1)
+        {
+#if FOLD_ZERO
+            if (*pSrc == L'z')
+            {
+                ++pSrc;
+                *pDest++ = 0;
+                dwDestSize += BASE85_OUTPUT;
+                continue;
+            }
+#endif
+
+            /* 5 inputs */
+            in1 = (*pSrc++ - 33);
+            in2 = (*pSrc++ - 33);
+            in3 = (*pSrc++ - 33);
+            in4 = (*pSrc++ - 33);
+            in5 = (*pSrc++ - 33);
+            dwSrcSize -= BASE85_INPUT;
+
+            /* Validate */
+            if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+                return 0; /*ERROR - invalid base85 character*/
+
+            /* Output */
+            out = in1;
+            out *= 85;
+            out |= in2;
+            out *= 85;
+            out |= in3;
+            out *= 85;
+            out |= in4;
+            out *= 85;
+            out |= in5;
+            *(unsigned int*)pDest = out;
+            pDest += BASE85_OUTPUT;
+            dwDestSize += BASE85_OUTPUT;
+        }
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer, or srcChars isn't a multiple of 5*/
+}
+
+size_t cyoBase85DecodeBlockA(void* dest, const char* src)
+{
+    if (dest && src)
+    {
+        const char* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        unsigned char in1, in2, in3, in4, in5;
+        unsigned int out;
+
+#if FOLD_ZERO
+        if (*pSrc == 'z')
+        {
+            *pDest = 0;
+            return BASE85_OUTPUT;
+        }
+#endif
+
+        /* 5 inputs */
+        in1 = (*pSrc++ - 33);
+        in2 = (*pSrc++ - 33);
+        in3 = (*pSrc++ - 33);
+        in4 = (*pSrc++ - 33);
+        in5 = (*pSrc++ - 33);
+
+        /* Validate */
+        if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+            return 0; /*ERROR - invalid base85 character*/
+
+        /* Output */
+        out = in1;
+        out *= 85;
+        out |= in2;
+        out *= 85;
+        out |= in3;
+        out *= 85;
+        out |= in4;
+        out *= 85;
+        out |= in5;
+        *(unsigned int*)pDest = out;
+        return BASE85_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase85DecodeBlockW(void* dest, const wchar_t* src)
+{
+    if (dest && src)
+    {
+        const wchar_t* pSrc = src;
+        unsigned char* pDest = (unsigned char*)dest;
+        wchar_t in1, in2, in3, in4, in5;
+        unsigned int out;
+
+#if FOLD_ZERO
+        if (*pSrc == L'z')
+        {
+            *pDest = 0;
+            return BASE85_OUTPUT;
+        }
+#endif
+
+        /* 5 inputs */
+        in1 = (*pSrc++ - 33);
+        in2 = (*pSrc++ - 33);
+        in3 = (*pSrc++ - 33);
+        in4 = (*pSrc++ - 33);
+        in5 = (*pSrc++ - 33);
+
+        /* Validate */
+        if (in1 >= 85 || in2 >= 85 || in3 >= 85 || in4 >= 85 || in5 >= 85)
+            return 0; /*ERROR - invalid base85 character*/
+
+        /* Output */
+        out = in1;
+        out *= 85;
+        out |= in2;
+        out *= 85;
+        out |= in3;
+        out *= 85;
+        out |= in4;
+        out *= 85;
+        out |= in5;
+        *(unsigned int*)pDest = out;
+        return BASE85_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}

--- a/src/CyoEncode/CyoDecode.h
+++ b/src/CyoEncode/CyoDecode.h
@@ -1,0 +1,98 @@
+/*
+ * CyoDecode.h - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CYODECODE_H
+#define __CYODECODE_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Base16 Decoding
+ */
+int cyoBase16ValidateA(const char* src, size_t srcChars);
+int cyoBase16ValidateW(const wchar_t* src, size_t srcChars);
+size_t cyoBase16DecodeGetLength(size_t srcChars);
+size_t cyoBase16DecodeA(void* dest, const char* src, size_t srcChars);
+size_t cyoBase16DecodeW(void* dest, const wchar_t* src, size_t srcChars);
+size_t cyoBase16DecodeBlockA(void* dest, const char* src); /*decodes 2 input chars, outputs 1 byte*/
+size_t cyoBase16DecodeBlockW(void* dest, const wchar_t* src); /*decodes 2 input chars, outputs 1 byte*/
+#define cyoBase16Validate cyoBase16ValidateA
+#define cyoBase16Decode cyoBase16DecodeA
+#define cyoBase16DecodeBlock cyoBase16DecodeBlockA
+
+/*
+ * Base32 Decoding
+ */
+int cyoBase32ValidateA(const char* src, size_t srcChars);
+int cyoBase32ValidateW(const wchar_t* src, size_t srcChars);
+size_t cyoBase32DecodeGetLength(size_t srcChars);
+size_t cyoBase32DecodeA(void* dest, const char* src, size_t srcChars);
+size_t cyoBase32DecodeW(void* dest, const wchar_t* src, size_t srcChars);
+size_t cyoBase32DecodeBlockA(void* dest, const char* src); /*decodes 8 input chars, outputs 5 bytes*/
+size_t cyoBase32DecodeBlockW(void* dest, const wchar_t* src); /*decodes 8 input chars, outputs 5 bytes*/
+#define cyoBase32Validate cyoBase32ValidateA
+#define cyoBase32Decode cyoBase32DecodeA
+#define cyoBase32DecodeBlock cyoBase32DecodeBlockA
+
+/*
+ * Base64 Decoding
+ */
+int cyoBase64ValidateA(const char* src, size_t srcChars);
+int cyoBase64ValidateW(const wchar_t* src, size_t srcChars);
+size_t cyoBase64DecodeGetLength(size_t srcChars);
+size_t cyoBase64DecodeA(void* dest, const char* src, size_t srcChars);
+size_t cyoBase64DecodeW(void* dest, const wchar_t* src, size_t srcChars);
+size_t cyoBase64DecodeBlockA(void* dest, const char* src); /*decodes 4 input chars, outputs 3 bytes*/
+size_t cyoBase64DecodeBlockW(void* dest, const wchar_t* src); /*decodes 4 input chars, outputs 3 bytes*/
+#define cyoBase64Validate cyoBase64ValidateA
+#define cyoBase64Decode cyoBase64DecodeA
+#define cyoBase64DecodeBlock cyoBase64DecodeBlockA
+
+/*
+ * Base85 Decoding
+ */
+int cyoBase85ValidateA(const char* src, size_t srcChars);
+int cyoBase85ValidateW(const wchar_t* src, size_t srcChars);
+size_t cyoBase85DecodeGetLength(size_t srcChars);
+size_t cyoBase85DecodeA(void* dest, const char* src, size_t srcChars);
+size_t cyoBase85DecodeW(void* dest, const wchar_t* src, size_t srcChars);
+size_t cyoBase85DecodeBlockA(void* dest, const char* src); /*decodes 5 input chars, outputs 4 bytes*/
+size_t cyoBase85DecodeBlockW(void* dest, const wchar_t* src); /*decodes 5 input chars, outputs 4 bytes*/
+#define cyoBase85Validate cyoBase85ValidateA
+#define cyoBase85Decode cyoBase85DecodeA
+#define cyoBase85DecodeBlock cyoBase85DecodeBlockA
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__CYODECODE_H*/

--- a/src/CyoEncode/CyoDecode.hpp
+++ b/src/CyoEncode/CyoDecode.hpp
@@ -1,0 +1,143 @@
+/*
+ * CyoDecode.hpp - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CYODECODE_HPP
+#define __CYODECODE_HPP
+
+#include "CyoDecode.h"
+
+namespace CyoDecode
+{
+    typedef unsigned char byte_t;
+
+    class Base16
+    {
+    public:
+        static int Validate(const char* src, size_t srcChars) {
+            return cyoBase16ValidateA(src, srcChars);
+        }
+        static int Validate(const wchar_t* src, size_t srcChars) {
+            return cyoBase16ValidateW(src, srcChars);
+        }
+        static size_t GetLength(size_t srcChars) {
+            return cyoBase16DecodeGetLength(srcChars);
+        }
+        static size_t Decode(byte_t* dest, const char* src, size_t srcChars) {
+            return cyoBase16DecodeA(dest, src, srcChars);
+        }
+        static size_t Decode(byte_t* dest, const wchar_t* src, size_t srcChars) {
+            return cyoBase16DecodeW(dest, src, srcChars);
+        }
+        static size_t DecodeBlock(byte_t& dest, const char src[2]) {
+            return cyoBase16DecodeBlockA(&dest, src);
+        }
+        static size_t DecodeBlock(byte_t& dest, const wchar_t src[2]) {
+            return cyoBase16DecodeBlockW(&dest, src);
+        }
+    };
+
+    class Base32
+    {
+    public:
+        static int Validate(const char* src, size_t srcChars) {
+            return cyoBase32ValidateA(src, srcChars);
+        }
+        static int Validate(const wchar_t* src, size_t srcChars) {
+            return cyoBase32ValidateW(src, srcChars);
+        }
+        static size_t GetLength(size_t srcChars) {
+            return cyoBase32DecodeGetLength(srcChars);
+        }
+        static size_t Decode(byte_t* dest, const char* src, size_t srcChars) {
+            return cyoBase32DecodeA(dest, src, srcChars);
+        }
+        static size_t Decode(byte_t* dest, const wchar_t* src, size_t srcChars) {
+            return cyoBase32DecodeW(dest, src, srcChars);
+        }
+        static size_t DecodeBlock(byte_t dest[5], const char src[8]) {
+            return cyoBase32DecodeBlockA(dest, src);
+        }
+        static size_t DecodeBlock(byte_t dest[5], const wchar_t src[8]) {
+            return cyoBase32DecodeBlockW(dest, src);
+        }
+    };
+
+    class Base64
+    {
+    public:
+        static int Validate(const char* src, size_t srcChars) {
+            return cyoBase64ValidateA(src, srcChars);
+        }
+        static int Validate(const wchar_t* src, size_t srcChars) {
+            return cyoBase64ValidateW(src, srcChars);
+        }
+        static size_t GetLength(size_t srcChars) {
+            return cyoBase64DecodeGetLength(srcChars);
+        }
+        static size_t Decode(byte_t* dest, const char* src, size_t srcChars) {
+            return cyoBase64DecodeA(dest, src, srcChars);
+        }
+        static size_t Decode(byte_t* dest, const wchar_t* src, size_t srcChars) {
+            return cyoBase64DecodeW(dest, src, srcChars);
+        }
+        static size_t DecodeBlock(byte_t dest[3], const char src[4]) {
+            return cyoBase64DecodeBlockA(dest, src);
+        }
+        static size_t DecodeBlock(byte_t dest[3], const wchar_t src[4]) {
+            return cyoBase64DecodeBlockW(dest, src);
+        }
+    };
+
+    class Base85
+    {
+    public:
+        static int Validate(const char* src, size_t srcChars) {
+            return cyoBase85ValidateA(src, srcChars);
+        }
+        static int Validate(const wchar_t* src, size_t srcChars) {
+            return cyoBase85ValidateW(src, srcChars);
+        }
+        static size_t GetLength(size_t srcChars) {
+            return cyoBase85DecodeGetLength(srcChars);
+        }
+        static size_t Decode(byte_t* dest, const char* src, size_t srcChars) {
+            return cyoBase85DecodeA(dest, src, srcChars);
+        }
+        static size_t Decode(byte_t* dest, const wchar_t* src, size_t srcChars) {
+            return cyoBase85DecodeW(dest, src, srcChars);
+        }
+        static size_t DecodeBlock(byte_t dest[3], const char src[4]) {
+            return cyoBase85DecodeBlockA(dest, src);
+        }
+        static size_t DecodeBlock(byte_t dest[3], const wchar_t src[4]) {
+            return cyoBase85DecodeBlockW(dest, src);
+        }
+    };
+}
+
+#endif //__CYODECODE_HPP

--- a/src/CyoEncode/CyoEncode.c
+++ b/src/CyoEncode/CyoEncode.c
@@ -1,0 +1,978 @@
+/*
+ * CyoEncode.c - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CyoEncode.h"
+
+#include <assert.h>
+
+/********************************** Shared ***********************************/
+
+static size_t cyoBaseXXEncodeGetLength(size_t srcBytes, size_t inputBytes, size_t outputBytes)
+{
+    return (((srcBytes + inputBytes - 1) / inputBytes) * outputBytes) + 1; /*plus terminator*/
+}
+
+/****************************** Base16 Encoding ******************************/
+
+/*
+ * output 2 bytes for every 1 input:
+ *
+ *                 inputs: 1
+ * outputs: 1 = ----1111 = 1111----
+ *          2 = ----2222 = ----2222
+ */
+
+static const size_t BASE16_INPUT = 1;
+static const size_t BASE16_OUTPUT = 2;
+static const char* const BASE16_TABLE = "0123456789ABCDEF";
+
+size_t cyoBase16EncodeGetLength(size_t srcBytes)
+{
+    return cyoBaseXXEncodeGetLength(srcBytes, BASE16_INPUT, BASE16_OUTPUT);
+}
+
+size_t cyoBase16EncodeA(char* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        unsigned char ch;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 1 input */
+            ch = *pSrc++;
+            dwSrcSize -= BASE16_INPUT;
+
+            /* 2 outputs */
+            *pDest++ = BASE16_TABLE[(ch & 0xf0) >> 4];
+            *pDest++ = BASE16_TABLE[ch & 0x0f];
+            dwDestSize += BASE16_OUTPUT;
+        }
+        *pDest++ = '\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase16EncodeW(wchar_t* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        unsigned char ch;
+
+        while (dwSrcSize >= 1)
+        {
+            /* 1 input */
+            ch = *pSrc++;
+            dwSrcSize -= BASE16_INPUT;
+
+            /* 2 outputs */
+            *pDest++ = BASE16_TABLE[(ch & 0xf0) >> 4];
+            *pDest++ = BASE16_TABLE[ch & 0x0f];
+            dwDestSize += BASE16_OUTPUT;
+        }
+        *pDest++ = L'\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase16EncodeBlockA(char* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        unsigned char ch;
+
+        /* 1 input */
+        ch = pSrc[0];
+
+        /* 2 outputs */
+        *pDest++ = BASE16_TABLE[(ch & 0xf0) >> 4];
+        *pDest++ = BASE16_TABLE[ch & 0x0f];
+
+        return BASE16_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase16EncodeBlockW(wchar_t* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        unsigned char ch;
+
+        /* 1 input */
+        ch = pSrc[0];
+
+        /* 2 outputs */
+        *pDest++ = BASE16_TABLE[(ch & 0xf0) >> 4];
+        *pDest++ = BASE16_TABLE[ch & 0x0f];
+
+        return BASE16_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base32 Encoding ******************************/
+
+/*
+ * output 8 bytes for every 5 input:
+ *
+ *                 inputs: 1        2        3        4        5
+ * outputs: 1 = ---11111 = 11111---
+ *          2 = ---222XX = -----222 XX------
+ *          3 = ---33333 =          --33333-
+ *          4 = ---4XXXX =          -------4 XXXX----
+ *          5 = ---5555X =                   ----5555 X-------
+ *          6 = ---66666 =                            -66666--
+ *          7 = ---77XXX =                            ------77 XXX-----
+ *          8 = ---88888 =                                     ---88888
+ */
+
+static const size_t BASE32_INPUT = 5;
+static const size_t BASE32_OUTPUT = 8;
+static const char* const BASE32_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=";
+
+size_t cyoBase32EncodeGetLength(size_t srcBytes)
+{
+    return cyoBaseXXEncodeGetLength(srcBytes, BASE32_INPUT, BASE32_OUTPUT);
+}
+
+size_t cyoBase32EncodeA(char* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        size_t dwBlockSize;
+        unsigned char n1, n2, n3, n4, n5, n6, n7, n8;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            dwBlockSize = (dwSrcSize < BASE32_INPUT ? dwSrcSize : BASE32_INPUT);
+            n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = 0;
+            switch (dwBlockSize)
+            {
+            case 5:
+                n8 = (pSrc[4] & 0x1f);
+                n7 = ((pSrc[4] & 0xe0) >> 5);
+            case 4:
+                n7 |= ((pSrc[3] & 0x03) << 3);
+                n6 = ((pSrc[3] & 0x7c) >> 2);
+                n5 = ((pSrc[3] & 0x80) >> 7);
+            case 3:
+                n5 |= ((pSrc[2] & 0x0f) << 1);
+                n4 = ((pSrc[2] & 0xf0) >> 4);
+            case 2:
+                n4 |= ((pSrc[1] & 0x01) << 4);
+                n3 = ((pSrc[1] & 0x3e) >> 1);
+                n2 = ((pSrc[1] & 0xc0) >> 6);
+            case 1:
+                n2 |= ((pSrc[0] & 0x07) << 2);
+                n1 = ((pSrc[0] & 0xf8) >> 3);
+                break;
+
+            default:
+                assert(0);
+            }
+            pSrc += dwBlockSize;
+            dwSrcSize -= dwBlockSize;
+
+            /* Validate */
+            assert(n1 <= 31);
+            assert(n2 <= 31);
+            assert(n3 <= 31);
+            assert(n4 <= 31);
+            assert(n5 <= 31);
+            assert(n6 <= 31);
+            assert(n7 <= 31);
+            assert(n8 <= 31);
+
+            /* Padding */
+            switch (dwBlockSize)
+            {
+            case 1: n3 = n4 = 32;
+            case 2: n5 = 32;
+            case 3: n6 = n7 = 32;
+            case 4: n8 = 32;
+            case 5:
+                break;
+
+            default:
+                assert(0);
+            }
+
+            /* 8 outputs */
+            *pDest++ = BASE32_TABLE[n1];
+            *pDest++ = BASE32_TABLE[n2];
+            *pDest++ = BASE32_TABLE[n3];
+            *pDest++ = BASE32_TABLE[n4];
+            *pDest++ = BASE32_TABLE[n5];
+            *pDest++ = BASE32_TABLE[n6];
+            *pDest++ = BASE32_TABLE[n7];
+            *pDest++ = BASE32_TABLE[n8];
+            dwDestSize += BASE32_OUTPUT;
+        }
+        *pDest++ = '\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase32EncodeW(wchar_t* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        size_t dwBlockSize;
+        unsigned char n1, n2, n3, n4, n5, n6, n7, n8;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            dwBlockSize = (dwSrcSize < BASE32_INPUT ? dwSrcSize : BASE32_INPUT);
+            n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = 0;
+            switch (dwBlockSize)
+            {
+            case 5:
+                n8 = (pSrc[4] & 0x1f);
+                n7 = ((pSrc[4] & 0xe0) >> 5);
+            case 4:
+                n7 |= ((pSrc[3] & 0x03) << 3);
+                n6 = ((pSrc[3] & 0x7c) >> 2);
+                n5 = ((pSrc[3] & 0x80) >> 7);
+            case 3:
+                n5 |= ((pSrc[2] & 0x0f) << 1);
+                n4 = ((pSrc[2] & 0xf0) >> 4);
+            case 2:
+                n4 |= ((pSrc[1] & 0x01) << 4);
+                n3 = ((pSrc[1] & 0x3e) >> 1);
+                n2 = ((pSrc[1] & 0xc0) >> 6);
+            case 1:
+                n2 |= ((pSrc[0] & 0x07) << 2);
+                n1 = ((pSrc[0] & 0xf8) >> 3);
+                break;
+
+            default:
+                assert(0);
+            }
+            pSrc += dwBlockSize;
+            dwSrcSize -= dwBlockSize;
+
+            /* Validate */
+            assert(n1 <= 31);
+            assert(n2 <= 31);
+            assert(n3 <= 31);
+            assert(n4 <= 31);
+            assert(n5 <= 31);
+            assert(n6 <= 31);
+            assert(n7 <= 31);
+            assert(n8 <= 31);
+
+            /* Padding */
+            switch (dwBlockSize)
+            {
+            case 1: n3 = n4 = 32;
+            case 2: n5 = 32;
+            case 3: n6 = n7 = 32;
+            case 4: n8 = 32;
+            case 5:
+                break;
+
+            default:
+                assert(0);
+            }
+
+            /* 8 outputs */
+            *pDest++ = BASE32_TABLE[n1];
+            *pDest++ = BASE32_TABLE[n2];
+            *pDest++ = BASE32_TABLE[n3];
+            *pDest++ = BASE32_TABLE[n4];
+            *pDest++ = BASE32_TABLE[n5];
+            *pDest++ = BASE32_TABLE[n6];
+            *pDest++ = BASE32_TABLE[n7];
+            *pDest++ = BASE32_TABLE[n8];
+            dwDestSize += BASE32_OUTPUT;
+        }
+        *pDest++ = L'\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase32EncodeBlockA(char* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        unsigned char n1, n2, n3, n4, n5, n6, n7, n8;
+
+        /* Encode inputs */
+        n8 = (pSrc[4] & 0x1f);
+        n7 = ((pSrc[4] & 0xe0) >> 5);
+        n7 |= ((pSrc[3] & 0x03) << 3);
+        n6 = ((pSrc[3] & 0x7c) >> 2);
+        n5 = ((pSrc[3] & 0x80) >> 7);
+        n5 |= ((pSrc[2] & 0x0f) << 1);
+        n4 = ((pSrc[2] & 0xf0) >> 4);
+        n4 |= ((pSrc[1] & 0x01) << 4);
+        n3 = ((pSrc[1] & 0x3e) >> 1);
+        n2 = ((pSrc[1] & 0xc0) >> 6);
+        n2 |= ((pSrc[0] & 0x07) << 2);
+        n1 = ((pSrc[0] & 0xf8) >> 3);
+
+        /* Validate */
+        assert(n1 <= 31);
+        assert(n2 <= 31);
+        assert(n3 <= 31);
+        assert(n4 <= 31);
+        assert(n5 <= 31);
+        assert(n6 <= 31);
+        assert(n7 <= 31);
+        assert(n8 <= 31);
+
+        /* 8 outputs */
+        *pDest++ = BASE32_TABLE[n1];
+        *pDest++ = BASE32_TABLE[n2];
+        *pDest++ = BASE32_TABLE[n3];
+        *pDest++ = BASE32_TABLE[n4];
+        *pDest++ = BASE32_TABLE[n5];
+        *pDest++ = BASE32_TABLE[n6];
+        *pDest++ = BASE32_TABLE[n7];
+        *pDest++ = BASE32_TABLE[n8];
+
+        return BASE32_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase32EncodeBlockW(wchar_t* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        unsigned char n1, n2, n3, n4, n5, n6, n7, n8;
+
+        /* Encode inputs */
+        n8 = (pSrc[4] & 0x1f);
+        n7 = ((pSrc[4] & 0xe0) >> 5);
+        n7 |= ((pSrc[3] & 0x03) << 3);
+        n6 = ((pSrc[3] & 0x7c) >> 2);
+        n5 = ((pSrc[3] & 0x80) >> 7);
+        n5 |= ((pSrc[2] & 0x0f) << 1);
+        n4 = ((pSrc[2] & 0xf0) >> 4);
+        n4 |= ((pSrc[1] & 0x01) << 4);
+        n3 = ((pSrc[1] & 0x3e) >> 1);
+        n2 = ((pSrc[1] & 0xc0) >> 6);
+        n2 |= ((pSrc[0] & 0x07) << 2);
+        n1 = ((pSrc[0] & 0xf8) >> 3);
+
+        /* Validate */
+        assert(n1 <= 31);
+        assert(n2 <= 31);
+        assert(n3 <= 31);
+        assert(n4 <= 31);
+        assert(n5 <= 31);
+        assert(n6 <= 31);
+        assert(n7 <= 31);
+        assert(n8 <= 31);
+
+        /* 8 outputs */
+        *pDest++ = BASE32_TABLE[n1];
+        *pDest++ = BASE32_TABLE[n2];
+        *pDest++ = BASE32_TABLE[n3];
+        *pDest++ = BASE32_TABLE[n4];
+        *pDest++ = BASE32_TABLE[n5];
+        *pDest++ = BASE32_TABLE[n6];
+        *pDest++ = BASE32_TABLE[n7];
+        *pDest++ = BASE32_TABLE[n8];
+
+        return BASE32_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base64 Encoding ******************************/
+
+/*
+ * output 4 bytes for every 3 input:
+ *
+ *                 inputs: 1        2        3
+ * outputs: 1 = --111111 = 111111--
+ *          2 = --22XXXX = ------22 XXXX----
+ *          3 = --3333XX =          ----3333 XX------
+ *          4 = --444444 =                   --444444
+ */
+
+static const size_t BASE64_INPUT = 3;
+static const size_t BASE64_OUTPUT = 4;
+static const char* const BASE64_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+size_t cyoBase64EncodeGetLength(size_t srcBytes)
+{
+    return cyoBaseXXEncodeGetLength(srcBytes, BASE64_INPUT, BASE64_OUTPUT);
+}
+
+size_t cyoBase64EncodeA(char* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        size_t dwBlockSize = 0;
+        unsigned char n1, n2, n3, n4;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            dwBlockSize = (dwSrcSize < BASE64_INPUT ? dwSrcSize : BASE64_INPUT);
+            n1 = n2 = n3 = n4 = 0;
+            switch (dwBlockSize)
+            {
+            case 3:
+                n4 = (pSrc[2] & 0x3f);
+                n3 = ((pSrc[2] & 0xc0) >> 6);
+            case 2:
+                n3 |= ((pSrc[1] & 0x0f) << 2);
+                n2 = ((pSrc[1] & 0xf0) >> 4);
+            case 1:
+                n2 |= ((pSrc[0] & 0x03) << 4);
+                n1 = ((pSrc[0] & 0xfc) >> 2);
+                break;
+
+            default:
+                assert(0);
+            }
+            pSrc += dwBlockSize;
+            dwSrcSize -= dwBlockSize;
+
+            /* Validate */
+            assert(n1 <= 63);
+            assert(n2 <= 63);
+            assert(n3 <= 63);
+            assert(n4 <= 63);
+
+            /* Padding */
+            switch (dwBlockSize)
+            {
+            case 1: n3 = 64;
+            case 2: n4 = 64;
+            case 3:
+                break;
+
+            default:
+                assert(0);
+            }
+
+            /* 4 outputs */
+            *pDest++ = BASE64_TABLE[n1];
+            *pDest++ = BASE64_TABLE[n2];
+            *pDest++ = BASE64_TABLE[n3];
+            *pDest++ = BASE64_TABLE[n4];
+            dwDestSize += BASE64_OUTPUT;
+        }
+        *pDest++ = '\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase64EncodeW(wchar_t* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        size_t dwBlockSize = 0;
+        unsigned char n1, n2, n3, n4;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            dwBlockSize = (dwSrcSize < BASE64_INPUT ? dwSrcSize : BASE64_INPUT);
+            n1 = n2 = n3 = n4 = 0;
+            switch (dwBlockSize)
+            {
+            case 3:
+                n4 = (pSrc[2] & 0x3f);
+                n3 = ((pSrc[2] & 0xc0) >> 6);
+            case 2:
+                n3 |= ((pSrc[1] & 0x0f) << 2);
+                n2 = ((pSrc[1] & 0xf0) >> 4);
+            case 1:
+                n2 |= ((pSrc[0] & 0x03) << 4);
+                n1 = ((pSrc[0] & 0xfc) >> 2);
+                break;
+
+            default:
+                assert(0);
+            }
+            pSrc += dwBlockSize;
+            dwSrcSize -= dwBlockSize;
+
+            /* Validate */
+            assert(n1 <= 63);
+            assert(n2 <= 63);
+            assert(n3 <= 63);
+            assert(n4 <= 63);
+
+            /* Padding */
+            switch (dwBlockSize)
+            {
+            case 1: n3 = 64;
+            case 2: n4 = 64;
+            case 3:
+                break;
+
+            default:
+                assert(0);
+            }
+
+            /* 4 outputs */
+            *pDest++ = BASE64_TABLE[n1];
+            *pDest++ = BASE64_TABLE[n2];
+            *pDest++ = BASE64_TABLE[n3];
+            *pDest++ = BASE64_TABLE[n4];
+            dwDestSize += BASE64_OUTPUT;
+        }
+        *pDest++ = L'\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase64EncodeBlockA(char* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        unsigned char n1, n2, n3, n4;
+
+        /* Encode inputs */
+        n4 = (pSrc[2] & 0x3f);
+        n3 = ((pSrc[2] & 0xc0) >> 6);
+        n3 |= ((pSrc[1] & 0x0f) << 2);
+        n2 = ((pSrc[1] & 0xf0) >> 4);
+        n2 |= ((pSrc[0] & 0x03) << 4);
+        n1 = ((pSrc[0] & 0xfc) >> 2);
+
+        /* Validate */
+        assert(n1 <= 63);
+        assert(n2 <= 63);
+        assert(n3 <= 63);
+        assert(n4 <= 63);
+
+        /* 4 outputs */
+        *pDest++ = BASE64_TABLE[n1];
+        *pDest++ = BASE64_TABLE[n2];
+        *pDest++ = BASE64_TABLE[n3];
+        *pDest++ = BASE64_TABLE[n4];
+
+        return BASE64_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase64EncodeBlockW(wchar_t* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        unsigned char n1, n2, n3, n4;
+
+        /* Encode inputs */
+        n4 = (pSrc[2] & 0x3f);
+        n3 = ((pSrc[2] & 0xc0) >> 6);
+        n3 |= ((pSrc[1] & 0x0f) << 2);
+        n2 = ((pSrc[1] & 0xf0) >> 4);
+        n2 |= ((pSrc[0] & 0x03) << 4);
+        n1 = ((pSrc[0] & 0xfc) >> 2);
+
+        /* Validate */
+        assert(n1 <= 63);
+        assert(n2 <= 63);
+        assert(n3 <= 63);
+        assert(n4 <= 63);
+
+        /* 4 outputs */
+        *pDest++ = BASE64_TABLE[n1];
+        *pDest++ = BASE64_TABLE[n2];
+        *pDest++ = BASE64_TABLE[n3];
+        *pDest++ = BASE64_TABLE[n4];
+
+        return BASE64_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+/****************************** Base85 Encoding ******************************/
+
+/*
+ * output 5 bytes for every 4 input
+ */
+
+static const size_t BASE85_INPUT = 4;
+static const size_t BASE85_OUTPUT = 5;
+
+#define FOLD_ZERO 1 /*output 'z' instead of '!!!!!'*/
+//#define FOLD_SPACES 1 /*output 'y' instead of 4 spaces*/
+
+size_t cyoBase85EncodeGetLength(size_t srcBytes)
+{
+    return cyoBaseXXEncodeGetLength(srcBytes, BASE85_INPUT, BASE85_OUTPUT);
+}
+
+size_t cyoBase85EncodeA(char* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        unsigned int n;
+        unsigned char n1, n2, n3, n4, n5;
+        size_t i;
+        int padding;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            n = 0;
+            padding = 0;
+            for (i = 0; i < BASE85_INPUT; ++i)
+            {
+                n <<= 8;
+                if (dwSrcSize >= 1)
+                {
+                    n |= *pSrc++;
+                    --dwSrcSize;
+                }
+                else
+                    ++padding;
+            }
+#if FOLD_ZERO
+            if (n == 0)
+            {
+                *pDest++ = 'z';
+                dwDestSize += 1;
+                continue;
+            }
+#endif
+
+            n5 = (unsigned char)(n % 85);
+            n = (n - n5) / 85;
+            n4 = (unsigned char)(n % 85);
+            n = (n - n4) / 85;
+            n3 = (unsigned char)(n % 85);
+            n = (n - n3) / 85;
+            n2 = (unsigned char)(n % 85);
+            n = (n - n2) / 85;
+            n1 = (unsigned char)n;
+
+            /* Validate */
+            assert(n1 < 85);
+            assert(n2 < 85);
+            assert(n3 < 85);
+            assert(n4 < 85);
+            assert(n5 < 85);
+
+            /* Outputs */
+            if (padding == 0)
+            {
+                /* 5 outputs */
+                *pDest++ = (n1 + 33);
+                *pDest++ = (n2 + 33);
+                *pDest++ = (n3 + 33);
+                *pDest++ = (n4 + 33);
+                *pDest++ = (n5 + 33);
+                dwDestSize += BASE85_OUTPUT;
+            }
+            else
+            {
+                /* 1-4 outputs */
+                assert(1 <= padding && padding <= 4);
+                *pDest++ = (n1 + 33);
+                if (padding < 4)
+                    *pDest++ = (n2 + 33);
+                if (padding < 3)
+                    *pDest++ = (n3 + 33);
+                if (padding < 2)
+                    *pDest++ = (n4 + 33);
+                if (padding < 1)
+                    *pDest++ = (n5 + 33);
+                dwDestSize += (BASE85_OUTPUT - padding);
+            }
+        }
+        *pDest++ = '\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase85EncodeW(wchar_t* dest, const void* src, size_t srcBytes)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        size_t dwSrcSize = srcBytes;
+        size_t dwDestSize = 0;
+        unsigned int n;
+        unsigned char n1, n2, n3, n4, n5;
+        size_t i;
+        int padding;
+
+        while (dwSrcSize >= 1)
+        {
+            /* Encode inputs */
+            n = 0;
+            padding = 0;
+            for (i = 0; i < BASE85_INPUT; ++i)
+            {
+                n <<= 8;
+                if (dwSrcSize >= 1)
+                {
+                    n |= *pSrc++;
+                    --dwSrcSize;
+                }
+                else
+                    ++padding;
+            }
+#if FOLD_ZERO
+            if (n == 0)
+            {
+                *pDest++ = 'z';
+                dwDestSize += 1;
+                continue;
+            }
+#endif
+
+            n5 = (unsigned char)(n % 85);
+            n = (n - n5) / 85;
+            n4 = (unsigned char)(n % 85);
+            n = (n - n4) / 85;
+            n3 = (unsigned char)(n % 85);
+            n = (n - n3) / 85;
+            n2 = (unsigned char)(n % 85);
+            n = (n - n2) / 85;
+            n1 = (unsigned char)n;
+
+            /* Validate */
+            assert(n1 < 85);
+            assert(n2 < 85);
+            assert(n3 < 85);
+            assert(n4 < 85);
+            assert(n5 < 85);
+
+            /* Outputs */
+            if (padding == 0)
+            {
+                /* 5 outputs */
+                *pDest++ = (n1 + 33);
+                *pDest++ = (n2 + 33);
+                *pDest++ = (n3 + 33);
+                *pDest++ = (n4 + 33);
+                *pDest++ = (n5 + 33);
+                dwDestSize += BASE85_OUTPUT;
+            }
+            else
+            {
+                /* 1-4 outputs */
+                assert(1 <= padding && padding <= 4);
+                *pDest++ = (n1 + 33);
+                if (padding < 4)
+                    *pDest++ = (n2 + 33);
+                if (padding < 3)
+                    *pDest++ = (n3 + 33);
+                if (padding < 2)
+                    *pDest++ = (n4 + 33);
+                if (padding < 1)
+                    *pDest++ = (n5 + 33);
+                dwDestSize += (BASE85_OUTPUT - padding);
+            }
+        }
+        *pDest++ = L'\x0'; /*append terminator*/
+
+        return dwDestSize;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase85EncodeBlockA(char* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        char* pDest = dest;
+        unsigned int n = 0;
+        unsigned char n1, n2, n3, n4, n5;
+        size_t i;
+
+        /* Encode inputs */
+        for (i = 0; i < BASE85_INPUT; ++i)
+        {
+            n <<= 8;
+            n |= *pSrc++;
+        }
+#if FOLD_ZERO
+        if (n == 0)
+        {
+            *pDest++ = 'z';
+            return 1;
+        }
+#endif
+        n5 = (unsigned char)(n % 85);
+        n = (n - n5) / 85;
+        n4 = (unsigned char)(n % 85);
+        n = (n - n4) / 85;
+        n3 = (unsigned char)(n % 85);
+        n = (n - n3) / 85;
+        n2 = (unsigned char)(n % 85);
+        n = (n - n2) / 85;
+        n1 = (unsigned char)n;
+
+        /* Validate */
+        assert(n1 < 85);
+        assert(n2 < 85);
+        assert(n3 < 85);
+        assert(n4 < 85);
+        assert(n5 < 85);
+
+        /* Outputs */
+        *pDest++ = (n1 + 33);
+        *pDest++ = (n2 + 33);
+        *pDest++ = (n3 + 33);
+        *pDest++ = (n4 + 33);
+        *pDest++ = (n5 + 33);
+
+        return BASE85_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}
+
+size_t cyoBase85EncodeBlockW(wchar_t* dest, const void* src)
+{
+    if (dest && src)
+    {
+        unsigned char* pSrc = (unsigned char*)src;
+        wchar_t* pDest = dest;
+        unsigned int n = 0;
+        unsigned char n1, n2, n3, n4, n5;
+        size_t i;
+
+        /* Encode inputs */
+        for (i = 0; i < BASE85_INPUT; ++i)
+        {
+            n <<= 8;
+            n |= *pSrc++;
+        }
+#if FOLD_ZERO
+        if (n == 0)
+        {
+            *pDest++ = 'z';
+            return 1;
+        }
+#endif
+        n5 = (unsigned char)(n % 85);
+        n = (n - n5) / 85;
+        n4 = (unsigned char)(n % 85);
+        n = (n - n4) / 85;
+        n3 = (unsigned char)(n % 85);
+        n = (n - n3) / 85;
+        n2 = (unsigned char)(n % 85);
+        n = (n - n2) / 85;
+        n1 = (unsigned char)n;
+
+        /* Validate */
+        assert(n1 < 85);
+        assert(n2 < 85);
+        assert(n3 < 85);
+        assert(n4 < 85);
+        assert(n5 < 85);
+
+        /* Outputs */
+        *pDest++ = (n1 + 33);
+        *pDest++ = (n2 + 33);
+        *pDest++ = (n3 + 33);
+        *pDest++ = (n4 + 33);
+        *pDest++ = (n5 + 33);
+
+        return BASE85_OUTPUT;
+    }
+    else
+        return 0; /*ERROR - null pointer*/
+}

--- a/src/CyoEncode/CyoEncode.h
+++ b/src/CyoEncode/CyoEncode.h
@@ -1,0 +1,86 @@
+/*
+ * CyoEncode.h - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CYOENCODE_H
+#define __CYOENCODE_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Base16 Encoding
+ */
+size_t cyoBase16EncodeGetLength(size_t srcBytes);
+size_t cyoBase16EncodeA(char* dest, const void* src, size_t srcBytes);
+size_t cyoBase16EncodeW(wchar_t* dest, const void* src, size_t srcBytes);
+size_t cyoBase16EncodeBlockA(char* dest, const void* src); /*encodes 1 input bytes, outputs 2 chars*/
+size_t cyoBase16EncodeBlockW(wchar_t* dest, const void* src); /*encodes 1 input bytes, outputs 2 chars*/
+#define cyoBase16Encode cyoBase16EncodeA
+#define cyoBase16EncodeBlock cyoBase16EncodeBlockA
+
+/*
+ * Base32 Encoding
+ */
+size_t cyoBase32EncodeGetLength(size_t srcBytes);
+size_t cyoBase32EncodeA(char* dest, const void* src, size_t srcBytes);
+size_t cyoBase32EncodeW(wchar_t* dest, const void* src, size_t srcBytes);
+size_t cyoBase32EncodeBlockA(char* dest, const void* src); /*encodes 5 input bytes, outputs 8 chars*/
+size_t cyoBase32EncodeBlockW(wchar_t* dest, const void* src); /*encodes 5 input bytes, outputs 8 chars*/
+#define cyoBase32Encode cyoBase32EncodeA
+#define cyoBase32EncodeBlock cyoBase32EncodeBlockA
+
+/*
+ * Base64 Encoding
+ */
+size_t cyoBase64EncodeGetLength(size_t srcBytes);
+size_t cyoBase64EncodeA(char* dest, const void* src, size_t srcBytes);
+size_t cyoBase64EncodeW(wchar_t* dest, const void* src, size_t srcBytes);
+size_t cyoBase64EncodeBlockA(char* dest, const void* src); /*encodes 3 input bytes, outputs 4 chars*/
+size_t cyoBase64EncodeBlockW(wchar_t* dest, const void* src); /*encodes 3 input bytes, outputs 4 chars*/
+#define cyoBase64Encode cyoBase64EncodeA
+#define cyoBase64EncodeBlock cyoBase64EncodeBlockA
+
+/*
+ * Base85 Encoding
+ */
+size_t cyoBase85EncodeGetLength(size_t srcBytes);
+size_t cyoBase85EncodeA(char* dest, const void* src, size_t srcBytes);
+size_t cyoBase85EncodeW(wchar_t* dest, const void* src, size_t srcBytes);
+size_t cyoBase85EncodeBlockA(char* dest, const void* src); /*encodes 4 input bytes, outputs 5 chars*/
+size_t cyoBase85EncodeBlockW(wchar_t* dest, const void* src); /*encodes 4 input bytes, outputs 5 chars*/
+#define cyoBase85Encode cyoBase85EncodeA
+#define cyoBase85EncodeBlock cyoBase85EncodeBlockA
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__CYOENCODE_H*/

--- a/src/CyoEncode/CyoEncode.hpp
+++ b/src/CyoEncode/CyoEncode.hpp
@@ -1,0 +1,119 @@
+/*
+ * CyoEncode.hpp - part of the CyoEncode library
+ *
+ * Copyright (c) 2009-2017, Graham Bull.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CYOENCODE_HPP
+#define __CYOENCODE_HPP
+
+#include "CyoEncode.h"
+
+namespace CyoEncode
+{
+    typedef unsigned char byte_t;
+
+    class Base16
+    {
+    public:
+        static size_t GetLength(size_t srcBytes) {
+            return cyoBase16EncodeGetLength(srcBytes);
+        }
+        static size_t Encode(char* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase16EncodeA(dest, src, srcBytes);
+        }
+        static size_t Encode(wchar_t* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase16EncodeW(dest, src, srcBytes);
+        }
+        static size_t EncodeBlock(char dest[2], const byte_t src) {
+            return cyoBase16EncodeBlockA(dest, &src);
+        }
+        static size_t EncodeBlock(wchar_t dest[2], const byte_t src) {
+            return cyoBase16EncodeBlockW(dest, &src);
+        }
+    };
+
+    class Base32
+    {
+    public:
+        static size_t GetLength(size_t srcBytes) {
+            return cyoBase32EncodeGetLength(srcBytes);
+        }
+        static size_t Encode(char* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase32EncodeA(dest, src, srcBytes);
+        }
+        static size_t Encode(wchar_t* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase32EncodeW(dest, src, srcBytes);
+        }
+        static size_t EncodeBlock(char dest[8], const byte_t src[5]) {
+            return cyoBase32EncodeBlockA(dest, src);
+        }
+        static size_t EncodeBlock(wchar_t dest[8], const byte_t src[5]) {
+            return cyoBase32EncodeBlockW(dest, src);
+        }
+    };
+
+    class Base64
+    {
+    public:
+        static size_t GetLength(size_t srcBytes) {
+            return cyoBase64EncodeGetLength(srcBytes);
+        }
+        static size_t Encode(char* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase64EncodeA(dest, src, srcBytes);
+        }
+        static size_t Encode(wchar_t* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase64EncodeW(dest, src, srcBytes);
+        }
+        static size_t EncodeBlock(char dest[4], const byte_t src[3]) {
+            return cyoBase64EncodeBlockA(dest, src);
+        }
+        static size_t EncodeBlock(wchar_t dest[4], const byte_t src[3]) {
+            return cyoBase64EncodeBlockW(dest, src);
+        }
+    };
+
+    class Base85
+    {
+    public:
+        static size_t GetLength(size_t srcBytes) {
+            return cyoBase85EncodeGetLength(srcBytes);
+        }
+        static size_t Encode(char* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase85EncodeA(dest, src, srcBytes);
+        }
+        static size_t Encode(wchar_t* dest, const byte_t* src, size_t srcBytes) {
+            return cyoBase85EncodeW(dest, src, srcBytes);
+        }
+        static size_t EncodeBlock(char dest[4], const byte_t src[3]) {
+            return cyoBase85EncodeBlockA(dest, src);
+        }
+        static size_t EncodeBlock(wchar_t dest[4], const byte_t src[3]) {
+            return cyoBase85EncodeBlockW(dest, src);
+        }
+    };
+}
+
+#endif //__CYOENCODE_HPP

--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -83,6 +83,12 @@ QJsonObject LoginItem::toJson() const
         ret.insert("category", m_iCategory);
         ret.insert("key_after_login", m_iKeyAfterLogin);
         ret.insert("key_after_pwd", m_iKeyAfterPwd);
+        if (m_totpCred.valid)
+        {
+            ret.insert("totp_secret_key", m_totpCred.secretKey);
+            ret.insert("totp_time_step", m_totpCred.timeStep);
+            ret.insert("totp_code_size", m_totpCred.codeSize);
+        }
     }
     return ret;
 }
@@ -105,4 +111,9 @@ bool LoginItem::hasBlankPwdChanged() const
 TreeItem::TreeType LoginItem::treeType() const
 {
     return Login;
+}
+
+void LoginItem::setTOTPCredential(QString secretKey, int timeStep, int codeSize)
+{
+    m_totpCred = TOTPCredential{secretKey, timeStep, codeSize};
 }

--- a/src/LoginItem.cpp
+++ b/src/LoginItem.cpp
@@ -85,9 +85,11 @@ QJsonObject LoginItem::toJson() const
         ret.insert("key_after_pwd", m_iKeyAfterPwd);
         if (m_totpCred.valid)
         {
-            ret.insert("totp_secret_key", m_totpCred.secretKey);
-            ret.insert("totp_time_step", m_totpCred.timeStep);
-            ret.insert("totp_code_size", m_totpCred.codeSize);
+            QJsonObject totp;
+            totp["totp_secret_key"] = m_totpCred.secretKey;
+            totp["totp_time_step"] = m_totpCred.timeStep;
+            totp["totp_code_size"] = m_totpCred.codeSize;
+            ret.insert("totp", totp);
         }
     }
     return ret;

--- a/src/LoginItem.h
+++ b/src/LoginItem.h
@@ -26,12 +26,33 @@ public:
     bool passwordLocked() const;
     bool hasBlankPwdChanged() const;
     virtual TreeType treeType()  const Q_DECL_OVERRIDE;
+    void setTOTPCredential(QString secretKey, int timeStep, int codeSize);
 private:    
     QByteArray m_bAddress;
     qint8 m_iFavorite;
     QString m_sPassword;
     QString m_sPasswordOrig;
     bool m_bPasswordLocked;
+
+    struct TOTPCredential
+    {
+        QString secretKey;
+        int timeStep;
+        int codeSize;
+        bool valid = false;
+
+        TOTPCredential(QString secretKey, int timeStep, int codeSize):
+            secretKey{secretKey},
+            timeStep{timeStep},
+            codeSize{codeSize},
+            valid{true}
+        {}
+
+        TOTPCredential() = default;
+
+    };
+
+    TOTPCredential m_totpCred;
 };
 
 #endif // LOGINITEM_H

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -620,6 +620,68 @@ QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categorie
     return data;
 }
 
+void MPDeviceBleImpl::createTOTPCredMessage(const QString &service, const QString &login, const QJsonObject &totp)
+{
+    QByteArray data;
+    QString secretKey = totp["totp_secret_key"].toString();
+    int timeStep = totp["totp_time_step"].toInt();
+    int codeSize = totp["totp_code_size"].toInt();
+
+    // 0->251 Service name
+    QByteArray serviceArr = bleProt->toByteArray(service);
+    Common::fill(serviceArr, MPNodeBLE::SERVICE_LENGTH - serviceArr.size(), ZERO_BYTE);
+    data.append(serviceArr);
+    // 252->379 Login name
+    QByteArray loginArr = bleProt->toByteArray(login);
+    Common::fill(loginArr, MPNodeBLE::LOGIN_LENGTH - loginArr.size(), ZERO_BYTE);
+    data.append(loginArr);
+    // 380->411 TOTP secret key
+    QByteArray secKeyArr;
+    secKeyArr.append(secretKey);
+    Common::fill(secKeyArr, SECRET_KEY_LENGTH - secKeyArr.size(), ZERO_BYTE);
+    data.append(secKeyArr);
+    // 412 TOTP secret key length
+    data.append(secretKey.size());
+    // 413 TOTP number of digits
+    data.append(codeSize);
+    // 414 TOTP time step
+    data.append(timeStep);
+    // 415 TOTP SHA version
+    data.append(ZERO_BYTE);
+
+    mmmTOTPStoreArray.append(data);
+}
+
+bool MPDeviceBleImpl::storeTOTPCreds()
+{
+    if (mmmTOTPStoreArray.isEmpty())
+    {
+        return false;
+    }
+    AsyncJobs *totpStoreJob = new AsyncJobs("Storing TOTP Credentials...", this);
+    for (QByteArray& totpMsg : mmmTOTPStoreArray)
+    {
+        totpStoreJob->append(new MPCommandJob(mpDev, MPCmd::STORE_TOTP_CRED,
+                                      totpMsg,
+                                      [this](const QByteArray &data, bool &) -> bool
+        {
+            if (bleProt->getFirstPayloadByte(data) == MSG_FAILED)
+            {
+                mpDev->currentJobs->setCurrentJobError("store_totp_cred failed on device");
+                qWarning() << "Failed to set TOTP Credential";
+                return false;
+            }
+            else
+            {
+                qDebug() << "Stored TOTP Credential succesfully";
+                return true;
+            }
+        }));
+    }
+    mpDev->jobsQueue.enqueue(totpStoreJob);
+    return true;
+}
+
 void MPDeviceBleImpl::readUserSettings(const QByteArray& settings)
 {
     quint8 d = settings[0];

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -4,6 +4,7 @@
 #include "MPNodeBLE.h"
 #include "AppDaemon.h"
 #include "DeviceSettingsBLE.h"
+#include "Base32.h"
 
 int MPDeviceBleImpl::s_LangNum = 0;
 int MPDeviceBleImpl::s_LayoutNum = 0;
@@ -623,7 +624,7 @@ QByteArray MPDeviceBleImpl::createUserCategoriesMsg(const QJsonObject &categorie
 void MPDeviceBleImpl::createTOTPCredMessage(const QString &service, const QString &login, const QJsonObject &totp)
 {
     QByteArray data;
-    QString secretKey = totp["totp_secret_key"].toString();
+    QString secretKey = Base32::decode(totp["totp_secret_key"].toString());
     int timeStep = totp["totp_time_step"].toInt();
     int codeSize = totp["totp_code_size"].toInt();
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -88,6 +88,9 @@ public:
     void setUserCategories(const QJsonObject &categories, const MessageHandlerCbData &cb);
     void fillGetCategory(const QByteArray& data, QJsonObject &categories);
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
+    void createTOTPCredMessage(const QString& service, const QString& login, const QJsonObject& totp);
+    bool storeTOTPCreds();
+    void clearTOTPCredArray() { mmmTOTPStoreArray.clear(); }
 
     void readUserSettings(const QByteArray& settings);
     void sendUserSettings();
@@ -173,6 +176,7 @@ private:
     QJsonObject m_deviceLanguages;
     QJsonObject m_keyboardLayouts;
     MPMiniToBleNodeConverter m_bleNodeConverter;
+    QList<QByteArray> mmmTOTPStoreArray;
 
     static constexpr int INVALID_BATTERY = -1;
     int m_battery = INVALID_BATTERY;
@@ -199,6 +203,7 @@ private:
     const static int FIRST_DATA_STARTING_ADDR = 10;
     const static int STATUS_MSG_SIZE_WITH_BATTERY = 5;
     const static int BATTERY_BYTE = 1;
+    const static int SECRET_KEY_LENGTH = 32;
 };
 
 #endif // MPDEVICEBLEIMPL_H

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -306,6 +306,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::ADD_DATA_SERVICE      , 0x0021},
         {MPCmd::WRITE_DATA_FILE       , 0x0022},
         {MPCmd::READ_DATA_FILE        , 0x0023},
+        {MPCmd::STORE_TOTP_CRED       , 0x0027},
         {MPCmd::GET_CUR_CARD_CPZ      , 0x000B},
         {MPCmd::CANCEL_USER_REQUEST   , 0x0005},
         {MPCmd::PLEASE_RETRY          , 0x0002},

--- a/src/MessageProtocol/MessageProtocolBLE.h
+++ b/src/MessageProtocol/MessageProtocolBLE.h
@@ -56,6 +56,8 @@ public:
 
     QByteArray getCpzValue(const QByteArray &cpzCtr) const override { return cpzCtr.mid(CPZ_START, CPZ_LENGTH); }
 
+    static constexpr uint TOTP_PACKAGE_SIZE = 10;
+
 private:
     virtual void fillCommandMapping() override;
     int getStartingPayloadPosition(const QByteArray &data) const;

--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -447,6 +447,8 @@ QJsonObject MPNode::toJson() const
             obj["key_after_login"] = QString::number(bleNode->getKeyAfterLogin());
             obj["key_after_pwd"] = QString::number(bleNode->getKeyAfterPwd());
             obj["pwd_blank_flag"] = QString::number(bleNode->getPwdBlankFlag());
+            obj["totp_time_step"] = QString::number(bleNode->getTOTPTimeStep());
+            obj["totp_code_size"] = QString::number(bleNode->getTOTPCodeSize());
         }
     }
     else if (getType() == NodeChildData)

--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -447,8 +447,12 @@ QJsonObject MPNode::toJson() const
             obj["key_after_login"] = QString::number(bleNode->getKeyAfterLogin());
             obj["key_after_pwd"] = QString::number(bleNode->getKeyAfterPwd());
             obj["pwd_blank_flag"] = QString::number(bleNode->getPwdBlankFlag());
-            obj["totp_time_step"] = QString::number(bleNode->getTOTPTimeStep());
-            obj["totp_code_size"] = QString::number(bleNode->getTOTPCodeSize());
+            int totpTimeStep = bleNode->getTOTPTimeStep();
+            if (0 != totpTimeStep)
+            {
+                obj["totp_time_step"] = QString::number(totpTimeStep);
+                obj["totp_code_size"] = QString::number(bleNode->getTOTPCodeSize());
+            }
         }
     }
     else if (getType() == NodeChildData)

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -212,3 +212,15 @@ void MPNodeBLE::setPwdBlankFlag()
         data[PWD_BLANK_FLAG] = static_cast<char>(BLANK_CHAR);
     }
 }
+
+int MPNodeBLE::getTOTPTimeStep() const
+{
+    if (!isValid()) return 0;
+    return data[TOTP_TIME_STEP];
+}
+
+int MPNodeBLE::getTOTPCodeSize() const
+{
+    if (!isValid()) return 0;
+    return data[TOTP_CODE_SIZE];
+}

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -40,15 +40,15 @@ public:
 
     static constexpr int PARENT_NODE_LENGTH = 264;
     static constexpr int CHILD_NODE_LENGTH = 528;
+    static constexpr int SERVICE_LENGTH = 252;
+    static constexpr int LOGIN_LENGTH = 128;
 
 protected:
-    static constexpr int SERVICE_LENGTH = 252;
     static constexpr int CTR_DATA_ADDR_START = 261;
     static constexpr int CTR_ADDR_START = 395;
     static constexpr int DESC_ADDR_START = 140;
     static constexpr int DESC_LENGTH = 48;
     static constexpr int LOGIN_ADDR_START = 12;
-    static constexpr int LOGIN_LENGTH = 128;
     static constexpr int PWD_ENC_ADDR_START = 266;
     static constexpr int PWD_ENC_LENGTH = 128;
     static constexpr int DATE_CREATED_ADDR_START = 8;

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -38,6 +38,9 @@ public:
     int getPwdBlankFlag() const;
     void setPwdBlankFlag();
 
+    int getTOTPTimeStep() const;
+    int getTOTPCodeSize() const;
+
     static constexpr int PARENT_NODE_LENGTH = 264;
     static constexpr int CHILD_NODE_LENGTH = 528;
     static constexpr int SERVICE_LENGTH = 252;
@@ -56,6 +59,8 @@ protected:
     static constexpr int KEY_AFTER_LOGIN_ADDR_START = 260;
     static constexpr int KEY_AFTER_PWD_ADDR_START = 262;
     static constexpr int PWD_BLANK_FLAG = 266;
+    static constexpr int TOTP_TIME_STEP = 453;
+    static constexpr int TOTP_CODE_SIZE = 455;
     static constexpr int KEY_AFTER_LENGTH = 2;
     static constexpr char BLANK_CHAR = 0x01;
 };

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -59,8 +59,8 @@ protected:
     static constexpr int KEY_AFTER_LOGIN_ADDR_START = 260;
     static constexpr int KEY_AFTER_PWD_ADDR_START = 262;
     static constexpr int PWD_BLANK_FLAG = 266;
-    static constexpr int TOTP_TIME_STEP = 453;
-    static constexpr int TOTP_CODE_SIZE = 455;
+    static constexpr int TOTP_TIME_STEP = 434;
+    static constexpr int TOTP_CODE_SIZE = 436;
     static constexpr int KEY_AFTER_LENGTH = 2;
     static constexpr char BLANK_CHAR = 0x01;
 };

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -151,6 +151,7 @@ public:
             INFORM_LOCKED       ,
             INFORM_UNLOCKED     ,
             SET_NODE_PASSWORD   ,
+            STORE_TOTP_CRED     ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -1,12 +1,18 @@
 #include "TOTPCredential.h"
 #include "ui_TOTPCredential.h"
 
+#include <QPushButton>
+
+const QString TOTPCredential::BASE32_REGEXP = "[^A-Z2-7=*]";
+
 TOTPCredential::TOTPCredential(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::TOTPCredential)
 {
     ui->setupUi(this);
     setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+    ui->labelError->setStyleSheet("QLabel { color : red; }");
+    ui->labelError->hide();
 }
 
 TOTPCredential::~TOTPCredential()
@@ -34,4 +40,18 @@ void TOTPCredential::clearFields()
     ui->lineEditSecretKey->clear();
     ui->spinBoxTimeStep->setValue(DEFAULT_TIME_STEP);
     ui->spinBoxCodeSize->setValue(DEFAULT_CODE_SIZE);
+}
+
+void TOTPCredential::on_lineEditSecretKey_textChanged(const QString &arg1)
+{
+    if (arg1.contains(QRegExp(BASE32_REGEXP)))
+    {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        ui->labelError->show();
+    }
+    else
+    {
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+        ui->labelError->hide();
+    }
 }

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -13,3 +13,18 @@ TOTPCredential::~TOTPCredential()
 {
     delete ui;
 }
+
+QString TOTPCredential::getSecretKey() const
+{
+    return ui->lineEditSecretKey->text();
+}
+
+int TOTPCredential::getTimeStep() const
+{
+    return ui->spinBoxTimeStep->value();
+}
+
+int TOTPCredential::getCodeSize() const
+{
+    return ui->spinBoxCodeSize->value();
+}

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -1,0 +1,15 @@
+#include "TOTPCredential.h"
+#include "ui_TOTPCredential.h"
+
+TOTPCredential::TOTPCredential(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::TOTPCredential)
+{
+    ui->setupUi(this);
+    setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+}
+
+TOTPCredential::~TOTPCredential()
+{
+    delete ui;
+}

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -30,9 +30,19 @@ int TOTPCredential::getTimeStep() const
     return ui->spinBoxTimeStep->value();
 }
 
+void TOTPCredential::setTimeStep(int timeStep)
+{
+    ui->spinBoxTimeStep->setValue(timeStep);
+}
+
 int TOTPCredential::getCodeSize() const
 {
     return ui->spinBoxCodeSize->value();
+}
+
+void TOTPCredential::setCodeSize(int codeSize)
+{
+    ui->spinBoxCodeSize->setValue(codeSize);
 }
 
 void TOTPCredential::clearFields()

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -28,3 +28,10 @@ int TOTPCredential::getCodeSize() const
 {
     return ui->spinBoxCodeSize->value();
 }
+
+void TOTPCredential::clearFields()
+{
+    ui->lineEditSecretKey->clear();
+    ui->spinBoxTimeStep->setValue(DEFAULT_TIME_STEP);
+    ui->spinBoxCodeSize->setValue(DEFAULT_CODE_SIZE);
+}

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -1,0 +1,22 @@
+#ifndef TOTPCREDENTIAL_H
+#define TOTPCREDENTIAL_H
+
+#include <QDialog>
+
+namespace Ui {
+class TOTPCredential;
+}
+
+class TOTPCredential : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TOTPCredential(QWidget *parent = nullptr);
+    ~TOTPCredential();
+
+private:
+    Ui::TOTPCredential *ui;
+};
+
+#endif // TOTPCREDENTIAL_H

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -14,6 +14,9 @@ class TOTPCredential : public QDialog
 public:
     explicit TOTPCredential(QWidget *parent = nullptr);
     ~TOTPCredential();
+    QString getSecretKey() const;
+    int getTimeStep() const;
+    int getCodeSize() const;
 
 private:
     Ui::TOTPCredential *ui;

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -21,11 +21,15 @@ public:
 public slots:
     void clearFields();
 
+private slots:
+    void on_lineEditSecretKey_textChanged(const QString &arg1);
+
 private:
     Ui::TOTPCredential *ui;
 
     static constexpr int DEFAULT_TIME_STEP = 30;
     static constexpr int DEFAULT_CODE_SIZE = 6;
+    static const QString BASE32_REGEXP;
 };
 
 #endif // TOTPCREDENTIAL_H

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -16,7 +16,9 @@ public:
     ~TOTPCredential();
     QString getSecretKey() const;
     int getTimeStep() const;
+    void setTimeStep(int timeStep);
     int getCodeSize() const;
+    void setCodeSize(int codeSize);
 
 public slots:
     void clearFields();

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -18,8 +18,14 @@ public:
     int getTimeStep() const;
     int getCodeSize() const;
 
+public slots:
+    void clearFields();
+
 private:
     Ui::TOTPCredential *ui;
+
+    static constexpr int DEFAULT_TIME_STEP = 30;
+    static constexpr int DEFAULT_CODE_SIZE = 6;
 };
 
 #endif // TOTPCREDENTIAL_H

--- a/src/TOTPCredential.ui
+++ b/src/TOTPCredential.ui
@@ -48,6 +48,9 @@
            <height>25</height>
           </size>
          </property>
+         <property name="maxLength">
+          <number>48</number>
+         </property>
         </widget>
        </item>
       </layout>
@@ -124,7 +127,7 @@
            <number>6</number>
           </property>
           <property name="maximum">
-           <number>9</number>
+           <number>8</number>
           </property>
          </widget>
         </item>

--- a/src/TOTPCredential.ui
+++ b/src/TOTPCredential.ui
@@ -104,7 +104,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QSpinBox" name="spinBox_2">
+         <widget class="QSpinBox" name="spinBoxCodeSize">
           <property name="minimumSize">
            <size>
             <width>0</width>

--- a/src/TOTPCredential.ui
+++ b/src/TOTPCredential.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TOTPCredential</class>
+ <widget class="QDialog" name="TOTPCredential">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>267</width>
+    <height>285</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>TOTP Credential</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="topMargin">
+        <number>10</number>
+       </property>
+       <property name="bottomMargin">
+        <number>20</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="labelSecretKey">
+         <property name="text">
+          <string>Secret Key:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEditSecretKey">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>25</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBoxSettings">
+       <property name="title">
+        <string>Settings</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="topMargin">
+         <number>20</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelTimeStep">
+          <property name="text">
+           <string>Time step:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="spinBoxTimeStep">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="suffix">
+           <string> sec</string>
+          </property>
+          <property name="minimum">
+           <number>30</number>
+          </property>
+          <property name="maximum">
+           <number>90</number>
+          </property>
+          <property name="singleStep">
+           <number>30</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelCodeSize">
+          <property name="text">
+           <string>Code size:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="spinBox_2">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="suffix">
+           <string> digits</string>
+          </property>
+          <property name="minimum">
+           <number>6</number>
+          </property>
+          <property name="maximum">
+           <number>9</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TOTPCredential</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TOTPCredential</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/TOTPCredential.ui
+++ b/src/TOTPCredential.ui
@@ -26,6 +26,19 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
+      <widget class="QLabel" name="labelError">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>15</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>You have entered an invalid Base32 character.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="topMargin">
         <number>10</number>

--- a/src/TreeItem.cpp
+++ b/src/TreeItem.cpp
@@ -145,6 +145,26 @@ void TreeItem::setPwdBlankFlag(int flag)
     m_iPwdBlankFlag = flag;
 }
 
+int TreeItem::totpTimeStep() const
+{
+    return m_iTOTPTimeStep;
+}
+
+void TreeItem::setTotpTimeStep(int timeStep)
+{
+    m_iTOTPTimeStep = timeStep;
+}
+
+int TreeItem::totpCodeSize() const
+{
+    return m_iTOTPCodeSize;
+}
+
+void TreeItem::setTotpCodeSize(int codeSize)
+{
+    m_iTOTPCodeSize = codeSize;
+}
+
 const QVector<TreeItem *> &TreeItem::childs() const
 {
     return m_vChilds;

--- a/src/TreeItem.h
+++ b/src/TreeItem.h
@@ -35,6 +35,10 @@ public:
     void setkeyAfterPwd(int key);
     int pwdBlankFlag() const;
     void setPwdBlankFlag(int flag);
+    int totpTimeStep() const;
+    void setTotpTimeStep(int timeStep);
+    int totpCodeSize() const;
+    void setTotpCodeSize(int codeSize);
     TreeItem *child(int iIndex);
     const QVector<TreeItem *> &childs() const;
     int childCount() const;
@@ -65,6 +69,8 @@ protected:
     int m_iKeyAfterLogin = 0xFFFF;
     int m_iKeyAfterPwd = 0xFFFF;
     int m_iPwdBlankFlag = 0;
+    int m_iTOTPTimeStep = 0;
+    int m_iTOTPCodeSize = 0;
 };
 
 #endif // TREEITEM_H


### PR DESCRIPTION
- Added TOTP Credential dialog in MMM

![kép](https://user-images.githubusercontent.com/11043249/97118752-30296e00-170c-11eb-845d-f1f24c910b45.png)

- Added CyoEncode lib for Base32 encode/decode

**Credential with TOTP:**
![kép](https://user-images.githubusercontent.com/11043249/97118789-6e269200-170c-11eb-9080-818b08ebb9ab.png)
View TOTP Credential button and a clock icon next to edit icon are displayed

**Credential without TOTP:**
![kép](https://user-images.githubusercontent.com/11043249/97118820-8e565100-170c-11eb-8756-bf491dd7d995.png)


