### PR TITLE
[BLE] Fix clearing TOTP Credential during MMM exit & validate secretkey string

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -482,6 +482,10 @@ void CredentialsManagement::saveSelectedCredential()
 
 void CredentialsManagement::saveSelectedTOTP()
 {
+    if (!m_pTOTPCred->validateInput())
+    {
+        return;
+    }
     const QItemSelectionModel *pSelectionModel = ui->credentialTreeView->selectionModel();
     const QModelIndex currentSelectionIndex = pSelectionModel->currentIndex();
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7224,10 +7224,6 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 mmmPasswordChangeArray.clear();
                 mmmPasswordChangeNewAddrArray.clear();
                 mmmPasswordChangeExistingAddrArray.clear();
-                if (isBLE())
-                {
-                    bleImpl->clearTOTPCredArray();
-                }
             });
 
             connect(pwdChangeJobs, &AsyncJobs::failed, [this, cb](AsyncJob *failedJob)
@@ -7236,10 +7232,6 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 mmmPasswordChangeArray.clear();
                 mmmPasswordChangeNewAddrArray.clear();
                 mmmPasswordChangeExistingAddrArray.clear();
-                if (isBLE())
-                {
-                    bleImpl->clearTOTPCredArray();
-                }
                 qCritical() << "Couldn't change passwords";
                 cb(false, "Please Approve Password Changes On The Device");
             });

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -680,6 +680,20 @@ bool MPDeviceBleImpl::storeTOTPCreds()
             }
         }));
     }
+
+    connect(totpStoreJob, &AsyncJobs::finished, [this](const QByteArray &)
+    {
+        qInfo() << "TOTP Credentials added!";
+        mmmTOTPStoreArray.clear();
+    });
+
+    connect(totpStoreJob, &AsyncJobs::failed, [this](AsyncJob *failedJob)
+    {
+        Q_UNUSED(failedJob)
+        mmmTOTPStoreArray.clear();
+        qCritical() << "Couldn't change setup/update TOTP Credential";
+    });
+
     mpDev->jobsQueue.enqueue(totpStoreJob);
     return true;
 }

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -90,7 +90,6 @@ public:
     QByteArray createUserCategoriesMsg(const QJsonObject &categories);
     void createTOTPCredMessage(const QString& service, const QString& login, const QJsonObject& totp);
     bool storeTOTPCreds();
-    void clearTOTPCredArray() { mmmTOTPStoreArray.clear(); }
 
     void readUserSettings(const QByteArray& settings);
     void sendUserSettings();

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -52,7 +52,7 @@ bool TOTPCredential::validateInput()
     if (!getSecretKey().contains(QRegExp(BASE32_REGEXP)))
     {
         QMessageBox::warning(this, tr("Invalid Secret Key"), tr("The entered Secret Key is not a valid Base32 string"));
-        clearFields();
+        ui->lineEditSecretKey->clear();
         return false;
     }
     return true;

--- a/src/TOTPCredential.cpp
+++ b/src/TOTPCredential.cpp
@@ -2,8 +2,10 @@
 #include "ui_TOTPCredential.h"
 
 #include <QPushButton>
+#include <QMessageBox>
 
-const QString TOTPCredential::BASE32_REGEXP = "[^A-Z2-7=*]";
+const QString TOTPCredential::BASE32_REGEXP = "^(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}={0,6}|[A-Z2-7]{4}={0,4}|[A-Z2-7]{5}={0,3}|[A-Z2-7]{7}={0,1})?$";
+const QString TOTPCredential::BASE32_CHAR_REGEXP = "[^A-Z2-7=*]";
 
 TOTPCredential::TOTPCredential(QWidget *parent) :
     QDialog(parent),
@@ -45,6 +47,17 @@ void TOTPCredential::setCodeSize(int codeSize)
     ui->spinBoxCodeSize->setValue(codeSize);
 }
 
+bool TOTPCredential::validateInput()
+{
+    if (!getSecretKey().contains(QRegExp(BASE32_REGEXP)))
+    {
+        QMessageBox::warning(this, tr("Invalid Secret Key"), tr("The entered Secret Key is not a valid Base32 string"));
+        clearFields();
+        return false;
+    }
+    return true;
+}
+
 void TOTPCredential::clearFields()
 {
     ui->lineEditSecretKey->clear();
@@ -54,7 +67,7 @@ void TOTPCredential::clearFields()
 
 void TOTPCredential::on_lineEditSecretKey_textChanged(const QString &arg1)
 {
-    if (arg1.contains(QRegExp(BASE32_REGEXP)))
+    if (arg1.contains(QRegExp(BASE32_CHAR_REGEXP)))
     {
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
         ui->labelError->show();

--- a/src/TOTPCredential.h
+++ b/src/TOTPCredential.h
@@ -20,6 +20,8 @@ public:
     int getCodeSize() const;
     void setCodeSize(int codeSize);
 
+    bool validateInput();
+
 public slots:
     void clearFields();
 
@@ -32,6 +34,7 @@ private:
     static constexpr int DEFAULT_TIME_STEP = 30;
     static constexpr int DEFAULT_CODE_SIZE = 6;
     static const QString BASE32_REGEXP;
+    static const QString BASE32_CHAR_REGEXP;
 };
 
 #endif // TOTPCREDENTIAL_H


### PR DESCRIPTION
**Base32 validation**
Only the valid character check was implemented for Base32 string, but it was still possible to enter an invalid one, now created an extra check for that and if the user enters an invalid one, displaying the following dialog:
![image](https://user-images.githubusercontent.com/11043249/97746858-59227800-1aeb-11eb-858d-30a5fd654828.png)
Base32 regular expression:
`"^(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}={0,6}|[A-Z2-7]{4}={0,4}|[A-Z2-7]{5}={0,3}|[A-Z2-7]{7}={0,1})?$"`

**Clearing TOTP Credential during MMM exit**
The previous implementation of clear was not called if there were no other credential related modification, so TOTP credentials were  saved again during the next MMM enter/exits.