### PR TITLE
#737 Disable Tabs when entering Credentials or Files management mode

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1413,7 +1413,10 @@ void MainWindow::updateTabButtons()
     };
 
     if (ui->stackedWidget->currentWidget() == ui->pageWaiting)
+    {
         setEnabledToAllTabButtons(false);
+        return;
+    }
 
     // Enable or Disable tabs according to the device status
     if (wsClient->get_status() == Common::UnknownSmartcard)


### PR DESCRIPTION
Fix for #737 

It was implemented in the code, but later in the function enabled all tab again.