### PR TITLE
Fetch files before displaying save dialog for Files Management export

### DIFF
--- a/src/FilesManagement.ui
+++ b/src/FilesManagement.ui
@@ -219,6 +219,16 @@ border-right: none;
            <widget class="QListWidget" name="filesCacheListWidget"/>
           </item>
           <item>
+           <widget class="QLabel" name="labelConfirmRequest">
+            <property name="text">
+             <string>Confirm the request on your device.</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QProgressBar" name="progressBarQuick">
             <property name="value">
              <number>24</number>

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4297,6 +4297,8 @@ void MPDevice::getDataNode(QString service, const QString &fallback_service, con
     if (isBLE())
     {
         sdata.append((char)0);
+        QVariantMap m = {{ "service", service }};
+        jobs->user_data = m;
         jobs->append(new MPCommandJob(this, MPCmd::READ_DATA_FILE,
                                       sdata,
                   [this, jobs, cbProgress](const QByteArray &data, bool &)


### PR DESCRIPTION
When file is selected for export, first fetch the selected file:
![image](https://user-images.githubusercontent.com/11043249/98481684-37687580-21fc-11eb-8ebf-ea6cef31ea2d.png)
And only after that display the save dialog:
![image](https://user-images.githubusercontent.com/11043249/98481705-60890600-21fc-11eb-88c7-6ec22af9dc18.png)
