### PR TITLE
[BLE] #690 Fix category change of favorite credentials in MMM

### DIFF
--- a/src/CredentialModel.h
+++ b/src/CredentialModel.h
@@ -59,9 +59,11 @@ public:
     bool isUserCategoryClean() const { return m_categoryClean; }
     void setUserCategoryClean(bool clean) { m_categoryClean = clean; }
     void setTOTP(const QModelIndex &idx, QString secretKey, int timeStep, int codeSize);
+    QSet<qint8> getTakenFavorites() const;
 
 private:
     ServiceItem *addService(const QString &sServiceName);
+    qint8 getAvailableFavorite(qint8 newFav);
 
 private:
     RootItem *m_pRootItem;


### PR DESCRIPTION
Fix for #690 
Previously when the user changed a credential's category which was set as favorite then favorite was reset.
Currently the following logic is implemented during category change:
- If favorite is available for the new category, then using it
- If the same favorite is taken in the new category then search for an available slot
- If no available favorite slot for the new category then reset favorite for the credential