### PR TITLE
[BLE] Fix Base32 decode result processing for TOTP

### DIFF
--- a/src/CyoEncode/Base32.cpp
+++ b/src/CyoEncode/Base32.cpp
@@ -44,16 +44,26 @@ QByteArray Base32::decode(QString str)
         return "";
     }
     QByteArray decodedArr;
-    if (decoded.front() != static_cast<char>(0x00))
+    const auto ZERO_CHAR = static_cast<char>(0x00);
+    for (auto& c : decoded)
     {
-        decodedArr.append((char*)&decoded.front());
+        decodedArr.append(static_cast<char>(c));
     }
-    else
+
+    if (decoded.front() != ZERO_CHAR)
     {
-        for (auto& c : decoded)
-        {
-            decodedArr.append(static_cast<char>(c));
-        }
+       // Truncate zero chars from the end
+       if (decodedArr.back() == ZERO_CHAR)
+       {
+           auto it = decodedArr.rbegin();
+           auto endZeroSize = 0;
+           while (*it == ZERO_CHAR)
+           {
+               ++endZeroSize;
+               ++it;
+           }
+           decodedArr.truncate(decodedArr.size() - endZeroSize);
+       }
     }
     return decodedArr;
 }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -642,6 +642,11 @@ void MPDeviceBleImpl::createTOTPCredMessage(const QString &service, const QStrin
     // 380->411 TOTP secret key
     QByteArray secKeyArr;
     secKeyArr.append(secretKey);
+    if (secKeyArr.length() > SECRET_KEY_LENGTH)
+    {
+        qCritical() << "Secretkey is longer than " << SECRET_KEY_LENGTH;
+        secKeyArr = secKeyArr.left(SECRET_KEY_LENGTH);
+    }
     Common::fill(secKeyArr, SECRET_KEY_LENGTH - secKeyArr.size(), ZERO_BYTE);
     data.append(secKeyArr);
     // 412 TOTP secret key length


### PR DESCRIPTION
With the original `decodedArr.append((char*)&decoded.front());` processing sometimes extra bytes were appended to the buffer.
Implemented processing the decoded vector and truncating the ending zero bytes.