### PR TITLE
[BLE] Migrating upload technique to the new messages

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -56,6 +56,8 @@ void BleDev::setWsClient(WSClient *c)
 void BleDev::clearWidgets()
 {
     ui->lineEditBundlePassword->clear();
+    ui->progressBarUpload->hide();
+    ui->label_UploadProgress->hide();
 }
 
 void BleDev::initUITexts()
@@ -169,7 +171,6 @@ void BleDev::displayUploadBundleResultReceived(bool success)
     if (success)
     {
         // Update platform after successful upload
-        wsClient->sendFlashMCU();
         QMessageBox::information(this, title,
                                  tr("Upload bundle finished successfully."));
     }

--- a/src/BleDev.ui
+++ b/src/BleDev.ui
@@ -149,6 +149,12 @@
         </item>
         <item>
          <widget class="QLineEdit" name="lineEditBundlePassword">
+          <property name="minimumSize">
+           <size>
+            <width>280</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="font">
            <font>
             <weight>50</weight>

--- a/src/CyoEncode/Base32.cpp
+++ b/src/CyoEncode/Base32.cpp
@@ -53,7 +53,7 @@ QByteArray Base32::decode(QString str)
     if (decoded.front() != ZERO_CHAR)
     {
        // Truncate zero chars from the end
-       if (decodedArr.back() == ZERO_CHAR)
+       if (decodedArr.at(decodedArr.size() - 1) == ZERO_CHAR)
        {
            auto it = decodedArr.rbegin();
            auto endZeroSize = 0;

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1334,7 +1334,7 @@ void MPDeviceBleImpl::sendBundleToDevice(QString filePath, AsyncJobs *jobs, cons
         ++byteCounter;
         if ((BUNBLE_DATA_WRITE_SIZE + BUNBLE_DATA_ADDRESS_SIZE) == byteCounter)
         {
-            jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_DATAFLASH_WRITE_256B, message,
+            jobs->append(new MPCommandJob(mpDev, MPCmd::WRITE_256B_TO_FLASH, message,
                               [curAddress, cbProgress, fileSize](const QByteArray &data, bool &) -> bool
                                   {
                                       Q_UNUSED(data);
@@ -1363,7 +1363,7 @@ void MPDeviceBleImpl::sendBundleToDevice(QString filePath, AsyncJobs *jobs, cons
     }
     if (byteCounter != BUNBLE_DATA_ADDRESS_SIZE)
     {
-        jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_DATAFLASH_WRITE_256B, message,
+        jobs->append(new MPCommandJob(mpDev, MPCmd::WRITE_256B_TO_FLASH, message,
                       [](const QByteArray &data, bool &) -> bool
                           {
                               Q_UNUSED(data);
@@ -1372,7 +1372,7 @@ void MPDeviceBleImpl::sendBundleToDevice(QString filePath, AsyncJobs *jobs, cons
                           }));
     }
 
-    jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_REINDEX_BUNDLE, bleProt->getDefaultFuncDone()));
+    jobs->append(new MPCommandJob(mpDev, MPCmd::END_BUNDLE_UPLOAD, bleProt->getDefaultFuncDone()));
 }
 
 void MPDeviceBleImpl::writeFetchData(QFile *file, MPCmd::Command cmd)

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -108,7 +108,7 @@ void MPDeviceBleImpl::flashMCU(const MessageHandlerCb &cb)
     mpDev->enqueueAndRunJob(jobs);
 }
 
-void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress)
+void MPDeviceBleImpl::uploadBundle(QString filePath, QString password, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress)
 {
     if (!isBundleFileReadable(filePath))
     {
@@ -119,8 +119,8 @@ void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb,
     QElapsedTimer *timer = new QElapsedTimer{};
     timer->start();
     auto *jobs = new AsyncJobs(QString("Upload bundle file"), this);
-    jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_ERASE_DATA_FLASH,
-                      [cbProgress, this] (const QByteArray &data, bool &) -> bool
+    jobs->append(new MPCommandJob(mpDev, MPCmd::START_BUNDLE_UPLOAD, createUploadPasswordMessage(password),
+                      [cbProgress, timer, jobs, filePath, this] (const QByteArray &data, bool &) -> bool
                     {
                         if (MSG_SUCCESS != bleProt->getFirstPayloadByte(data))
                         {
@@ -130,16 +130,12 @@ void MPDeviceBleImpl::uploadBundle(QString filePath, const MessageHandlerCb &cb,
                         QVariantMap progress = {
                             {"total", 0},
                             {"current", 0},
-                            {"msg", "Erasing device data..." }
+                            {"msg", "Erasing data finished." }
                         };
+                        qDebug() << "Erase done in: " << timer->nsecsElapsed() / 1000000 << " ms";
+                        delete timer;
+                        sendBundleToDevice(filePath, jobs, cbProgress);
                         cbProgress(progress);
-                        return true;
-                    }));
-
-    jobs->append(new MPCommandJob(mpDev, MPCmd::CMD_DBG_IS_DATA_FLASH_READY,
-                    [this, timer, jobs, filePath, cbProgress](const QByteArray &data, bool &) -> bool
-                    {
-                        checkDataFlash(data, timer, jobs, filePath, cbProgress);
                         return true;
                     }));
 
@@ -1260,6 +1256,41 @@ QByteArray MPDeviceBleImpl::createChangePasswordMsg(const QByteArray& address, Q
     msg.append(bleProt->toByteArray(pwd));
     msg.append(bleProt->toLittleEndianFromInt(static_cast<quint16>(0x0)));
     return msg;
+}
+
+QByteArray MPDeviceBleImpl::createUploadPasswordMessage(const QString &uploadPassword)
+{
+    if (uploadPassword.isEmpty())
+    {
+        return DEFAULT_BUNDLE_PASSWORD;
+    }
+
+    QByteArray passwordArray;
+    if (uploadPassword.size() == UPLOAD_PASSWORD_BYTE_SIZE * 2)
+    {
+        const int BASE = 16;
+        for (int i = 0; i < UPLOAD_PASSWORD_BYTE_SIZE; ++i)
+        {
+            bool ok = false;
+            auto passwordChar = uploadPassword.mid(i*2, 2).toUInt(&ok, BASE);
+            if (ok)
+            {
+                passwordArray.append(static_cast<char>(passwordChar));
+            }
+            else
+            {
+                qCritical() << "Invalid hex character";
+                return QByteArray{};
+            }
+        }
+    }
+    else
+    {
+        qCritical() << "Invalid length of upload password";
+        return QByteArray{};
+    }
+
+    return passwordArray;
 }
 
 void MPDeviceBleImpl::checkDataFlash(const QByteArray &data, QElapsedTimer *timer, AsyncJobs *jobs, QString filePath, const MPDeviceProgressCb &cbProgress)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -56,7 +56,7 @@ public:
     QVector<int> calcDebugPlatInfo(const QByteArray &platInfo);
 
     void flashMCU(const MessageHandlerCb &cb);
-    void uploadBundle(QString filePath, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress);
+    void uploadBundle(QString filePath, QString password, const MessageHandlerCb &cb, const MPDeviceProgressCb &cbProgress);
     void fetchData(QString filePath, MPCmd::Command cmd);
     inline void stopFetchData() { fetchState = Common::FetchState::STOPPED; }
 
@@ -158,6 +158,7 @@ private:
     QByteArray createCheckCredMessage(const BleCredential &cred);
     QByteArray createCredentialMessage(const CredMap &credMap);
     QByteArray createChangePasswordMsg(const QByteArray& address, QString pwd);
+    QByteArray createUploadPasswordMessage(const QString& uploadPassword);
 
     inline void flipBit();
     void resetFlipBit();
@@ -205,6 +206,8 @@ private:
     const static int STATUS_MSG_SIZE_WITH_BATTERY = 5;
     const static int BATTERY_BYTE = 1;
     const static int SECRET_KEY_LENGTH = 32;
+    static constexpr int UPLOAD_PASSWORD_BYTE_SIZE = 16;
+    const QByteArray DEFAULT_BUNDLE_PASSWORD = "\xb4\x07\x5f\x1b\xa2\xab\x52\x43\x30\x7b\x0a\x04\x83\x89\xad\xcb";
 };
 
 #endif // MPDEVICEBLEIMPL_H

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -356,6 +356,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::SET_KEYB_LAYOUT_ID    , 0x001D},
         {MPCmd::SET_USER_LANG         , 0x001E},
         {MPCmd::SET_DEVICE_LANG       , 0x001F},
+        {MPCmd::START_BUNDLE_UPLOAD   , 0x0029},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -357,6 +357,8 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::SET_USER_LANG         , 0x001E},
         {MPCmd::SET_DEVICE_LANG       , 0x001F},
         {MPCmd::START_BUNDLE_UPLOAD   , 0x0029},
+        {MPCmd::WRITE_256B_TO_FLASH   , 0x002A},
+        {MPCmd::END_BUNDLE_UPLOAD     , 0x002B},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -152,6 +152,7 @@ public:
             INFORM_UNLOCKED     ,
             SET_NODE_PASSWORD   ,
             STORE_TOTP_CRED     ,
+            START_BUNDLE_UPLOAD ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -153,6 +153,8 @@ public:
             SET_NODE_PASSWORD   ,
             STORE_TOTP_CRED     ,
             START_BUNDLE_UPLOAD ,
+            WRITE_256B_TO_FLASH ,
+            END_BUNDLE_UPLOAD   ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1052,7 +1052,8 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     else if (root["msg"] == "upload_bundle")
     {
         QJsonObject o = root["data"].toObject();
-        bleImpl->uploadBundle(o["file"].toString(), [this, root](bool success, QString errstr)
+        bleImpl->uploadBundle(o["file"].toString(), o["password"].toString(),
+                [this, root](bool success, QString errstr)
         {
             QJsonObject ores;
             QJsonObject oroot = root;


### PR DESCRIPTION
- Enlarged Upload Password field
- Handle upload passwords correctly
- Changed upload message to the new ones
- Changed QByteArray back calls to `size() - 1` for Qt backward compatibility