### PR TITLE
[BLE] Handle NoBundle status on device

### DIFF
--- a/src/AsyncJobs.h
+++ b/src/AsyncJobs.h
@@ -195,6 +195,7 @@ public:
     void insertAfter(AsyncJob *j, int pos);
 
     QString getJobsId() { return jobsid; }
+    void failCurrent() { emit failed(currentJob); }
 
     //user data attached to this job queue
     QVariant user_data;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -75,7 +75,8 @@ QHash<Common::MPStatus, QString> Common::MPStatusUserString = {
     { Common::Error7, QObject::tr("Error 7 (should not happen)") },
     { Common::Error8, QObject::tr("Error 8 (should not happen)") },
     { Common::UnknownSmartcard, QObject::tr("Unknown smartcard inserted") },
-    { Common::MMMMode, QObject::tr("Device in management mode") }
+    { Common::MMMMode, QObject::tr("Device in management mode") },
+    { Common::NoBundle, QObject::tr("No bundle on the device") }
 };
 
 QHash<Common::MPStatus, QString> Common::MPStatusString = {
@@ -90,7 +91,8 @@ QHash<Common::MPStatus, QString> Common::MPStatusString = {
     { Common::Error7, "Error7" },
     { Common::Error8, "Error8" },
     { Common::UnknownSmartcard, "UnknownSmartcard" },
-    { Common::MMMMode, "MMMMode" }
+    { Common::MMMMode, "MMMMode" },
+    { Common::NoBundle, "NoBundle" }
 };
 
 QMap<int, QString> Common::BLE_CATEGORY_COLOR = {

--- a/src/Common.h
+++ b/src/Common.h
@@ -212,7 +212,8 @@ public:
         Error7 = 7,
         Error8 = 8,
         UnknownSmartcard = 9,
-        MMMMode = 21
+        MMMMode = 21,
+        NoBundle = 32
     } MPStatus;
     static QHash<MPStatus, QString> MPStatusUserString, MPStatusString;
     static QMap<int, QString> BLE_CATEGORY_COLOR;

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3602,6 +3602,11 @@ void MPDevice::processStatusChange(const QByteArray &data)
     {
         qDebug() << "received MPCmd::MOOLTIPASS_STATUS: " << static_cast<int>(s);
 
+        if (bleImpl)
+        {
+            bleImpl->checkNoBundle(s, prevStatus);
+        }
+
         /* Update status */
         set_status(s);
 
@@ -3626,11 +3631,6 @@ void MPDevice::processStatusChange(const QByteArray &data)
         {
             /* If v1.2 firmware, query user change number */
             QTimer::singleShot(50, this, &MPDevice::handleDeviceUnlocked);
-        }
-
-        if (bleImpl)
-        {
-            bleImpl->checkNoBundle(s, prevStatus);
         }
     }
 }

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3530,7 +3530,10 @@ void MPDevice::setCurrentDate()
     connect(jobs, &AsyncJobs::failed, [this](AsyncJob *)
     {
         qWarning() << "Failed to set date on device";
-        //setCurrentDate(); // memory: does it get piled on?
+        if (!isBLE())
+        {
+            setCurrentDate(); // memory: does it get piled on?
+        }
     });
 
     jobsQueue.enqueue(jobs);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -22,7 +22,8 @@ MPDeviceBleImpl::MPDeviceBleImpl(MessageProtocolBLE* mesProt, MPDevice *dev):
         MPCmd::END_BUNDLE_UPLOAD,
         MPCmd::CANCEL_USER_REQUEST,
         MPCmd::INFORM_LOCKED,
-        MPCmd::INFORM_UNLOCKED};
+        MPCmd::INFORM_UNLOCKED,
+        MPCmd::SET_DATE};
 }
 
 bool MPDeviceBleImpl::isFirstPacket(const QByteArray &data)
@@ -1248,7 +1249,6 @@ void MPDeviceBleImpl::sendInitialStatusRequest()
     auto *statusJob = new AsyncJobs(QString("Getting initial status"), this);
     statusJob->append(new MPCommandJob(mpDev, MPCmd::MOOLTIPASS_STATUS, [this](const QByteArray &data, bool &)
     {
-        mpDev->statusTimer->stop();
         mpDev->processStatusChange(data);
         return true;
     }));

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1277,7 +1277,6 @@ bool MPDeviceBleImpl::isNoBundle(MPCmd::Command cmd)
 {
     if (m_noBundle && !m_noBundleCommands.contains(cmd))
     {
-        qCritical() << "Remove command";
         mpDev->currentJobs->failCurrent();
         mpDev->commandQueue.dequeue();
         mpDev->sendDataDequeue();

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1255,7 +1255,7 @@ void MPDeviceBleImpl::sendInitialStatusRequest()
     mpDev->enqueueAndRunJob(statusJob);
 }
 
-void MPDeviceBleImpl::checkNoBundle(Common::MPStatus status, Common::MPStatus prevStatus)
+void MPDeviceBleImpl::checkNoBundle(Common::MPStatus& status, Common::MPStatus prevStatus)
 {
     if (status != Common::UnknownStatus &&
             status&Common::NoBundle)
@@ -1264,7 +1264,7 @@ void MPDeviceBleImpl::checkNoBundle(Common::MPStatus status, Common::MPStatus pr
         mpDev->resetCommunication();
         if (status != Common::NoBundle)
         {
-            mpDev->set_status(Common::NoBundle);
+            status = Common::NoBundle;
         }
     }
     if (prevStatus == Common::NoBundle)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -137,6 +137,9 @@ public:
 
     void storeFileData(int current, AsyncJobs * jobs, const MPDeviceProgressCb &cbProgress);
 
+    void checkNoBundle(Common::MPStatus status, Common::MPStatus prevStatus);
+    bool isNoBundle(MPCmd::Command cmd);
+
 signals:
     void userSettingsChanged(QJsonObject settings);
     void bleDeviceLanguage(const QJsonObject& langs);
@@ -185,6 +188,9 @@ private:
 
     static constexpr int INVALID_BATTERY = -1;
     int m_battery = INVALID_BATTERY;
+
+    bool m_noBundle = false;
+    QList<MPCmd::Command> m_noBundleCommands;
 
     static int s_LangNum;
     static int s_LayoutNum;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -138,7 +138,7 @@ public:
     void storeFileData(int current, AsyncJobs * jobs, const MPDeviceProgressCb &cbProgress);
 
     void sendInitialStatusRequest();
-    void checkNoBundle(Common::MPStatus status, Common::MPStatus prevStatus);
+    void checkNoBundle(Common::MPStatus& status, Common::MPStatus prevStatus);
     bool isNoBundle(MPCmd::Command cmd);
 
 signals:

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -137,6 +137,7 @@ public:
 
     void storeFileData(int current, AsyncJobs * jobs, const MPDeviceProgressCb &cbProgress);
 
+    void sendInitialStatusRequest();
     void checkNoBundle(Common::MPStatus status, Common::MPStatus prevStatus);
     bool isNoBundle(MPCmd::Command cmd);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -718,11 +718,25 @@ void MainWindow::updatePage()
 {
     const auto status = wsClient->get_status();
     bool isCardUnknown = status == Common::UnknownSmartcard;
-    if (wsClient->isMPBLE() && Common::MMMMode == status)
+    if (wsClient->isMPBLE())
     {
-        // Do not update pages when BLE is in MMM Mode
-        return;
+        if (Common::MMMMode == status)
+        {
+            // Do not update pages when BLE is in MMM Mode
+            return;
+        }
+
+        if (Common::NoBundle == status)
+        {
+            bBleDevTabVisible = true;
+            ui->pushButtonBleDev->setVisible(bBleDevTabVisible);
+            previousWidget = ui->stackedWidget->currentWidget();
+            ui->stackedWidget->setCurrentWidget(ui->pageBleDev);
+
+            return;
+        }
     }
+
 
     ui->label_13->setVisible(!isCardUnknown);
     ui->label_14->setVisible(!isCardUnknown);
@@ -1471,6 +1485,12 @@ void MainWindow::updateTabButtons()
     };
 
     if (ui->stackedWidget->currentWidget() == ui->pageWaiting)
+    {
+        setEnabledToAllTabButtons(false);
+        return;
+    }
+
+    if (wsClient->get_status() == Common::NoBundle)
     {
         setEnabledToAllTabButtons(false);
         return;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -732,7 +732,7 @@ void MainWindow::updatePage()
             ui->pushButtonBleDev->setVisible(bBleDevTabVisible);
             previousWidget = ui->stackedWidget->currentWidget();
             ui->stackedWidget->setCurrentWidget(ui->pageBleDev);
-
+            updateTabButtons();
             return;
         }
     }
@@ -1917,6 +1917,14 @@ void MainWindow::onDeviceDisconnected()
     if (wsClient->isMPBLE())
     {
         ui->pbBleBattery->hide();
+        if (wsClient->get_status() == Common::NoBundle)
+        {
+            bBleDevTabVisible = false;
+            ui->pushButtonBleDev->setVisible(bBleDevTabVisible);
+            ui->stackedWidget->setCurrentWidget(previousWidget);
+            wsClient->set_status(Common::UnknownStatus);
+            updatePage();
+        }
     }
     ui->groupBox_UserSettings->hide();
     wsClient->set_cardId("");

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1921,6 +1921,10 @@ void MainWindow::onDeviceDisconnected()
         {
             bBleDevTabVisible = false;
             ui->pushButtonBleDev->setVisible(bBleDevTabVisible);
+            if (previousWidget == ui->pageBleDev)
+            {
+                previousWidget = ui->pageSettings;
+            }
             ui->stackedWidget->setCurrentWidget(previousWidget);
             wsClient->set_status(Common::UnknownStatus);
             updatePage();


### PR DESCRIPTION
When there is no bundle on the device: 
- Filter and only accept allowed messages in this case.
- Display BleDev tab for uploading bundle and disable other tabs:
![image](https://user-images.githubusercontent.com/11043249/101952063-56da3000-3bf8-11eb-8f84-5a32646d0f34.png)
- Drop messages, when no bundle status received
- For BLE ensured the first message is a status request
