### PR TITLE
Do not display Bundle Version text for Mini on About tab

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1889,6 +1889,7 @@ void MainWindow::onDeviceConnected()
         wsClient->sendUserSettingsRequest();
         wsClient->sendBatteryRequest();
     }
+    displayBundleVersion();
     updateDeviceDependentUI();
 }
 


### PR DESCRIPTION
Previously Bundle Version text was displayed for the original mini too:
![image](https://user-images.githubusercontent.com/11043249/101953523-c94c0f80-3bfa-11eb-8d5d-0e404fcfb0f7.png)
With this fix it is removed.