### PR TITLE
[BLE] Fix buffer size, when BLE is connected with bluetooth

### DIFF
--- a/src/MPDevice_linux.cpp
+++ b/src/MPDevice_linux.cpp
@@ -68,8 +68,9 @@ MPDevice_linux::~MPDevice_linux()
 void MPDevice_linux::readyRead(int fd)
 {
     QByteArray recvData;
-    recvData.resize(64);
-    ssize_t sz = ::read(fd, recvData.data(), 64);
+    int bufferSize = isBluetooth ? BT_BUFFER_SIZE : USB_BUFFER_SIZE;
+    recvData.resize(bufferSize);
+    ssize_t sz = ::read(fd, recvData.data(), bufferSize);
 
     if (sz < 0)
     {

--- a/src/MPDevice_linux.h
+++ b/src/MPDevice_linux.h
@@ -72,6 +72,9 @@ private:
     //Bufferize the data sent by sending 64bytes packet at a time
     QQueue<QByteArray> sendBuffer;
     bool failToWriteLogged = false;
+
+    const static int USB_BUFFER_SIZE = 64;
+    const static int BT_BUFFER_SIZE = USB_BUFFER_SIZE + 1;
 };
 
 #endif // MPDEVICE_LINUX_H


### PR DESCRIPTION
With bluetooth we receive an extra byte at the beginning during read, so need to increase the buffer size by 1 to read the entire packet.