### PR TITLE
Disable dark mode till it's supported

### DIFF
--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -20,5 +20,7 @@
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSRequiresAquaSystemAppearance</key>
+    <string>true</string>
 </dict>
 </plist>


### PR DESCRIPTION
Temporarily disable dark mode in moolticute till it's officially supported to prevent inputs from going dark.
(https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app)