### PR TITLE
[BLE] Only fetch data files, when device is unlocked

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -114,7 +114,6 @@ void MPDevice::sendInitMessages()
             writeCancelRequest();
         }
         bleImpl->getPlatInfo();
-        bleImpl->fetchDataFiles();
     }
     else
     {
@@ -3643,6 +3642,10 @@ void MPDevice::processStatusChange(const QByteArray &data)
         {
             /* If v1.2 firmware, query user change number */
             QTimer::singleShot(50, this, &MPDevice::handleDeviceUnlocked);
+            if (isBLE())
+            {
+                bleImpl->fetchDataFiles();
+            }
         }
     }
 }

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -185,6 +185,14 @@ void MPDeviceBleImpl::fetchData(QString filePath, MPCmd::Command cmd)
 
 void MPDeviceBleImpl::fetchDataFiles()
 {
+    if (mpDev->get_status() != Common::Unlocked)
+    {
+        if (AppDaemon::isDebugDev())
+        {
+            qWarning() << "Device is not unlocked, cannot fetch data files";
+        }
+        return;
+    }
     auto *jobs = new AsyncJobs(QString("Fetch data files"), this);
     m_dataFiles.clear();
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -213,7 +213,14 @@ void MPDeviceBleImpl::fetchDataFiles(AsyncJobs *jobs, QByteArray addr)
                             {
                                 m_dataFiles.append(fileName);
                             }
-                            if (bleProt->getMessageSize(data) != 2)
+
+                            if (bleProt->getMessageSize(data) < DATA_FETCH_NO_NEXT_ADDR_SIZE)
+                            {
+                                qCritical() << "Invalid response size for fetch data nodes";
+                                return false;
+                            }
+
+                            if (bleProt->getMessageSize(data) != DATA_FETCH_NO_NEXT_ADDR_SIZE)
                             {
                                 fetchDataFiles(jobs, bleProt->getPayloadBytes(data, 0, 2));
                             }

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -229,6 +229,7 @@ private:
     const static int BATTERY_BYTE = 1;
     const static int SECRET_KEY_LENGTH = 64;
     static constexpr int UPLOAD_PASSWORD_BYTE_SIZE = 16;
+    static constexpr int DATA_FETCH_NO_NEXT_ADDR_SIZE = 2;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
 };
 


### PR DESCRIPTION
When device was locked fetch data nodes response's size was 1 which was causing an infinite loop with fetching.
Moved fetch data files from device connection to unlocked status message arrival.
Also handled when `FETCH_DATA_NODES (0x0031)` response has an invalid size.