### PR TITLE
[BLE] Display Database Backup Monitor more recent dialog only once

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -8,12 +8,17 @@
 
 void DbBackupsTrackerController::connectDbBackupsTracker()
 {
+    if (signalsConnected)
+    {
+        return;
+    }
     connect(&dbBackupsTracker, &DbBackupsTracker::greaterDbBackupChangeNumber,
             this, &DbBackupsTrackerController::handleGreaterDbBackupChangeNumber);
     connect(&dbBackupsTracker, &DbBackupsTracker::lowerDbBackupChangeNumber,
             this, &DbBackupsTrackerController::handleLowerDbBackupChangeNumber);
     connect(&dbBackupsTracker, &DbBackupsTracker::newTrack,
             this, &DbBackupsTrackerController::handleNewTrack);
+    signalsConnected = true;
 }
 
 void DbBackupsTrackerController::disconnectDbBackupsTracker()
@@ -24,6 +29,7 @@ void DbBackupsTrackerController::disconnectDbBackupsTracker()
                this, &DbBackupsTrackerController::handleLowerDbBackupChangeNumber);
     disconnect(&dbBackupsTracker, &DbBackupsTracker::newTrack,
                this, &DbBackupsTrackerController::handleNewTrack);
+    signalsConnected = false;
 }
 
 DbBackupsTrackerController::DbBackupsTrackerController(MainWindow *window, WSClient *wsClient, const QString &settingsFilePath, QObject *parent):

--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -45,6 +45,7 @@ private:
     WSClient *wsClient;
     bool isExportRequestMessageVisible;
     QMessageBox *askImportMessage;
+    bool signalsConnected = false;
 
     void askForImportBackup();
     void askForExportBackup();


### PR DESCRIPTION
Fix for #809 
Signals and slots for `DbBackupsTrackerController` was connected multiple time, because of fwVersion changes (from NONE to actual firmware fetched), which caused the dialog appears multiple times.
With the fix I ensured it appears only once.