### PR TITLE
Do not display more recent backup prompt in MMM, fix #816

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -157,7 +157,7 @@ void DbBackupsTrackerController::askForExportBackup()
         }
     };
 
-    PromptMessage *message = new PromptMessage(tr("Credentials on the device are more recent. ") + "<br>" +
+    PromptMessage *message = new PromptMessage(PromptWidget::MORE_RECENT_BACKUP_PROMPT + "<br>" +
                                                   tr("Do you want to export your database?"),
                                                onAccept, onReject);
     window->showPrompt(message);

--- a/src/PromptWidget.cpp
+++ b/src/PromptWidget.cpp
@@ -9,6 +9,7 @@
 
 QString PromptWidget::MMM_ERROR = tr("Memory Management Error");
 QString PromptWidget::BACKUP_PROMPT = tr("You haven't made a backup of your database in a while. ");
+QString PromptWidget::MORE_RECENT_BACKUP_PROMPT = tr("Credentials on the device are more recent. ");
 
 PromptWidget::PromptWidget(QWidget *parent) :
     QFrame(parent),
@@ -85,7 +86,8 @@ bool PromptWidget::isMMMErrorPrompt() const
 
 bool PromptWidget::isBackupPrompt() const
 {
-    return m_promptMessage && m_messageLabel->text().contains(BACKUP_PROMPT);
+    return m_promptMessage && (m_messageLabel->text().contains(BACKUP_PROMPT) ||
+                               m_messageLabel->text().contains(MORE_RECENT_BACKUP_PROMPT));
 }
 
 void PromptWidget::onAccepted()

--- a/src/PromptWidget.h
+++ b/src/PromptWidget.h
@@ -56,6 +56,7 @@ public:
 
     static QString MMM_ERROR;
     static QString BACKUP_PROMPT;
+    static QString MORE_RECENT_BACKUP_PROMPT;
 
 signals:
     void accepted();


### PR DESCRIPTION
Previously we had a fix in #733 for an other prompt ("You haven't made a backup of your database in a while. "), with this PR "Credentials on the device are more recent. " prompt will not display in MMM as well.