### PR TITLE
[BLE] Fix Fido credential deletion issue, when data nodes were fetched earlier

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4854,11 +4854,12 @@ void MPDevice::deleteFidoAndLeave(QList<FidoCredential> fidoCredentials, Message
     }
 
     /* Check our DB */
-    if(!checkLoadedNodes(false, true, false, true))
+    if(!checkLoadedNodes(false, false, false, true))
     {
         exitMemMgmtMode(true);
         qCritical() << "Error in our internal algo";
         cb(false, "Moolticute Internal Error (DDNAL#2)");
+        return;
     }
 
     /* Generate save packets */
@@ -5652,6 +5653,8 @@ void MPDevice::cleanMMMVars(void)
         clearAndDelete(webAuthnLoginNodesClone);
         bleImpl->getFreeAddressProvider().cleanFreeAddresses();
     }
+    startDataNode = MPNode::EmptyAddress;
+    startNode = {{MPNode::EmptyAddress},{MPNode::EmptyAddress}};
 }
 
 void MPDevice::startImportFileMerging(const MPDeviceProgressCb &cbProgress, MessageHandlerCb cb, bool noDelete)


### PR DESCRIPTION
The original problem that during deleting fido nodes `checkLoadedNodes` was checking dataNodes as well, which would not cause an issue, but previously startNodes/startDataNodes were not cleared after exiting MMM.
So when database was exported or Files Credentials entered before deleting Fido Credential then the checkLoadedNodes returned false because there is the previously used startDataNode, but dataNodes are not fetched for Fido Credentials.