### PR TITLE
[BLE] Fix Fido credential delete crash when website is selected fix #821

### DIFF
--- a/src/FidoManagement.cpp
+++ b/src/FidoManagement.cpp
@@ -36,6 +36,8 @@ FidoManagement::FidoManagement(QWidget *parent) :
     connect(ui->fidoTreeView, &CredentialView::collapsed, this, &FidoManagement::onItemCollapsed);
 
     connect(ui->pushButtonDiscard, &AnimatedColorButton::actionValidated, this, &FidoManagement::on_pushButtonDiscard_clicked);
+    connect(ui->fidoTreeView->selectionModel(), &QItemSelectionModel::currentChanged,
+            this, &FidoManagement::onCredentialSelected);
 }
 
 void FidoManagement::setWsClient(WSClient *c)
@@ -199,4 +201,27 @@ void FidoManagement::setFidoManagementClean(bool isClean)
 void FidoManagement::on_pushButtonExitFidoMMM_clicked()
 {
     wsClient->sendLeaveMMRequest();
+}
+
+void FidoManagement::onCredentialSelected(const QModelIndex &current, const QModelIndex &previous)
+{
+    if (current == previous)
+    {
+        return;
+    }
+
+    const QItemSelectionModel *pSelectionModel = ui->fidoTreeView->selectionModel();
+    const QModelIndex realCurrent = pSelectionModel->currentIndex();
+
+    if (realCurrent.isValid())
+    {
+        auto sourceIndex = getSourceIndexFromProxyIndex(realCurrent);
+        auto pFidoUser  = m_pCredModel->getLoginItemByIndex(sourceIndex);
+        // Only display delete button, when login item is selected
+        ui->pushButtonDelete->setVisible(pFidoUser != nullptr);
+    }
+    else
+    {
+        ui->pushButtonDelete->setVisible(false);
+    }
 }

--- a/src/FidoManagement.h
+++ b/src/FidoManagement.h
@@ -42,6 +42,8 @@ private slots:
 
     void on_pushButtonExitFidoMMM_clicked();
 
+    void onCredentialSelected(const QModelIndex &current, const QModelIndex &previous);
+
 private:
     QModelIndex getSourceIndexFromProxyIndex(const QModelIndex &proxyIndex);
     QModelIndex getProxyIndexFromSourceIndex(const QModelIndex &srcIndex);


### PR DESCRIPTION
fix for #821
Only when a fido credential is selected display Delete button, else hide it:
![fidoDeleteCrashFix](https://user-images.githubusercontent.com/11043249/111832034-8af87780-88f0-11eb-9587-6df334ac42c5.gif)
