### PR TITLE
[BLE] Fix export prompt errors, fix #813

### DIFF
--- a/src/DbBackupsTracker.cpp
+++ b/src/DbBackupsTracker.cpp
@@ -295,12 +295,25 @@ void DbBackupsTracker::checkDbBackupSynchronization()
             return;
 
         qDebug () << "Backup file changed: " << backupCCN << " - " << backupDCN;
+        bool changeSinceBackup = false;
 
         if (isDbBackupChangeNumberGreater(backupCCN, backupDCN))
+        {
+            changeSinceBackup = true;
             emit greaterDbBackupChangeNumber();
+        }
 
         if (isDbBackupChangeNumberLower(backupCCN, backupDCN))
+        {
+            changeSinceBackup = true;
             emit lowerDbBackupChangeNumber();
+        }
+
+        if (!changeSinceBackup)
+        {
+            emit hideBackupPrompt();
+        }
+
     }
     catch (DbBackupsTrackerNoBackupFileSet)
     {

--- a/src/DbBackupsTracker.h
+++ b/src/DbBackupsTracker.h
@@ -65,6 +65,7 @@ signals:
 
     void greaterDbBackupChangeNumber();
     void lowerDbBackupChangeNumber();
+    void hideBackupPrompt();
 
     void dataDbChangeNumberChanged(int dataDbChangeNumber);
 

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -16,6 +16,8 @@ void DbBackupsTrackerController::connectDbBackupsTracker()
             this, &DbBackupsTrackerController::handleGreaterDbBackupChangeNumber);
     connect(&dbBackupsTracker, &DbBackupsTracker::lowerDbBackupChangeNumber,
             this, &DbBackupsTrackerController::handleLowerDbBackupChangeNumber);
+    connect(&dbBackupsTracker, &DbBackupsTracker::hideBackupPrompt,
+            this, &DbBackupsTrackerController::onHideBackupPrompt);
     connect(&dbBackupsTracker, &DbBackupsTracker::newTrack,
             this, &DbBackupsTrackerController::handleNewTrack);
     signalsConnected = true;
@@ -183,6 +185,12 @@ void DbBackupsTrackerController::handleLowerDbBackupChangeNumber()
     hideImportRequestIfVisible();
     hideExportRequestIfVisible();
     askForExportBackup();
+}
+
+void DbBackupsTrackerController::onHideBackupPrompt()
+{
+    hideImportRequestIfVisible();
+    hideExportRequestIfVisible();
 }
 
 void DbBackupsTrackerController::writeDbBackup(QString file, const QByteArray& d)

--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -48,6 +48,8 @@ DbBackupsTrackerController::DbBackupsTrackerController(MainWindow *window, WSCli
 
     connect(wsClient, &WSClient::fwVersionChanged,
             this, &DbBackupsTrackerController::handleFirmwareVersionChange);
+    connect(wsClient, &WSClient::showExportPrompt,
+            this, &DbBackupsTrackerController::handleLowerDbBackupChangeNumber);
 
     handleFirmwareVersionChange(wsClient->get_fwVersion());
     handleDeviceStatusChanged(wsClient->get_status());

--- a/src/DbBackupsTrackerController.h
+++ b/src/DbBackupsTrackerController.h
@@ -36,6 +36,7 @@ public slots:
 protected slots:
     void handleGreaterDbBackupChangeNumber();
     void handleLowerDbBackupChangeNumber();
+    void onHideBackupPrompt();
     void handleNewTrack(const QString &cardId, const QString &path);
     void handleFirmwareVersionChange(const QString &version);
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4605,6 +4605,7 @@ void MPDevice::setDataNode(QString service, const QByteArray &nodeData,
         if (isBLE())
         {
             bleImpl->addDataFile(service);
+            return;
         }
         else
         {

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3658,11 +3658,19 @@ void MPDevice::processStatusChange(const QByteArray &data)
 
         if (s == Common::Unlocked)
         {
-            /* If v1.2 firmware, query user change number */
-            QTimer::singleShot(50, this, &MPDevice::handleDeviceUnlocked);
             if (isBLE())
             {
                 bleImpl->fetchDataFiles();
+            }
+
+            /*
+             * For BLE there is a MMMMode, but do not need to call
+             * handleDeviceUnlocked when only exiting MMM.
+             */
+            if (!isBLE() || prevStatus != Common::MMMMode)
+            {
+                /* If v1.2 firmware, query user change number */
+                QTimer::singleShot(50, this, &MPDevice::handleDeviceUnlocked);
             }
         }
     }

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -268,6 +268,10 @@ void WSClient::onTextMessageReceived(const QString &message)
         QJsonObject o = rootobj["data"].toObject();
         bool success = !o.contains("failed") || !o["failed"].toBool();
         auto message = success ? o["description"].toString() : o["error_message"].toString();
+        if (success && isMPBLE())
+        {
+            emit showExportPrompt();
+        }
         emit credentialsUpdated(o["service"].toString(), o["login"].toString(), o["description"].toString(), success);
     }
     else if (rootobj["msg"] == "set_credentials")
@@ -336,6 +340,10 @@ void WSClient::onTextMessageReceived(const QString &message)
     {
         QJsonObject o = rootobj["data"].toObject();
         bool success = !o.contains("failed") || !o.value("failed").toBool();
+        if (success && isMPBLE())
+        {
+            emit showExportPrompt();
+        }
         emit dataFileSent(o["service"].toString(), success);
     }
     else if (rootobj["msg"] == "delete_data_node")

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -159,6 +159,7 @@ signals:
     void challengeResultFailed();
     void reconditionFinished(bool success, double dischargeTime);
     void deleteFidoNodesFailed();
+    void showExportPrompt();
 
 public slots:
     void sendJsonData(const QJsonObject &data);


### PR DESCRIPTION
There were 3 issues with export prompt:
### 1. After saving a credential not prompting to export:
Issue:
![IssueAfterExportMonitoredFile](https://user-images.githubusercontent.com/11043249/112536783-2cc70b00-8dae-11eb-95f7-6dcd8c4a5fed.gif)
After Fix:
![IssueAfterExportMonitoredFileFixed](https://user-images.githubusercontent.com/11043249/112536815-351f4600-8dae-11eb-9cf8-c0403c0a2102.gif)

### 2. Import dialog was displayed after saving file:
After saving a file outside of MMM a case was not handled for BLE and every time dataChangeNumber was set to 0, so import dialog was displayed.

### 3. Export prompt was not displayed after saving file/credential outside of MMM:
Fix:
![image](https://user-images.githubusercontent.com/11043249/112537142-a52dcc00-8dae-11eb-84fa-8cafe016bb10.png)
Displaying export prompt right after file/credential saved.

