### PR TITLE
Set Lock Unlock Feature values to originals after BLE device disconnection

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1974,6 +1974,7 @@ void MainWindow::onDeviceDisconnected()
             handleNoBundleDisconnected();
         }
         ui->pushButtonFido->setVisible(false);
+        noPasswordPromptChanged(false);
     }
     ui->groupBox_UserSettings->hide();
     wsClient->set_cardId("");


### PR DESCRIPTION
Previously Lock Unlock Features was not reset to the original values if No Password Input Prompt was enabled:
![image](https://user-images.githubusercontent.com/11043249/112682219-18e3dd80-8e70-11eb-9128-8ba709dba79e.png)
In this case for the values a bitmask is applied and when I disconnected BLE and connected an original Mini then Lock Unlock Feature was not working correctly because of the values from BLE.