### PR TITLE
Handle when Export prompt is denied on the device, fix #806

### DIFF
--- a/src/DbBackupsTrackerController.cpp
+++ b/src/DbBackupsTrackerController.cpp
@@ -219,6 +219,7 @@ void DbBackupsTrackerController::handleExportDbResult(const QByteArray &d, bool 
     if (! success)
     {
         QMessageBox::warning(window, tr("Error"), tr(d));
+        window->handleBackupExported();
         return;
     }
 


### PR DESCRIPTION
Displaying the previous page after a denied export prompt, instead of the stuck on waiting screen.