### PR TITLE
[BLE] Add enforce keyboard layout option, fix #807

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -124,7 +124,9 @@ const QString Common::SIMPLE_CRYPT = "SimpleCrypt";
 const QString Common::SIMPLE_CRYPT_V2 = "SimpleCryptV2";
 const QString Common::HEX_REGEXP = "[0-9A-Fa-f]{%1}";
 const QString Common::SETTING_USB_LAYOUT_ENFORCE = "settings/enforce_usb_layout";
+const QString Common::SETTING_USB_LAYOUT_ENFORCE_VALUE = "settings/enforce_usb_layout_value";
 const QString Common::SETTING_BT_LAYOUT_ENFORCE = "settings/enforce_bt_layout";
+const QString Common::SETTING_BT_LAYOUT_ENFORCE_VALUE = "settings/enforce_bt_layout_value";
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -123,6 +123,8 @@ const QString Common::ISODateWithMsFormat = "yyyy-MM-ddTHH:mm:ss.zzz";
 const QString Common::SIMPLE_CRYPT = "SimpleCrypt";
 const QString Common::SIMPLE_CRYPT_V2 = "SimpleCryptV2";
 const QString Common::HEX_REGEXP = "[0-9A-Fa-f]{%1}";
+const QString Common::SETTING_USB_LAYOUT_ENFORCE = "settings/enforce_usb_layout";
+const QString Common::SETTING_BT_LAYOUT_ENFORCE = "settings/enforce_bt_layout";
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/Common.h
+++ b/src/Common.h
@@ -313,7 +313,9 @@ public:
     static const QString SIMPLE_CRYPT_V2;
     static const QString HEX_REGEXP;
     static const QString SETTING_USB_LAYOUT_ENFORCE;
+    static const QString SETTING_USB_LAYOUT_ENFORCE_VALUE;
     static const QString SETTING_BT_LAYOUT_ENFORCE;
+    static const QString SETTING_BT_LAYOUT_ENFORCE_VALUE;
     static const int DEFAULT_PASSWORD_LENGTH = 16;
 };
 

--- a/src/Common.h
+++ b/src/Common.h
@@ -312,6 +312,8 @@ public:
     static const QString SIMPLE_CRYPT;
     static const QString SIMPLE_CRYPT_V2;
     static const QString HEX_REGEXP;
+    static const QString SETTING_USB_LAYOUT_ENFORCE;
+    static const QString SETTING_BT_LAYOUT_ENFORCE;
     static const int DEFAULT_PASSWORD_LENGTH = 16;
 };
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3661,11 +3661,7 @@ void MPDevice::processStatusChange(const QByteArray &data)
             if (isBLE())
             {
                 bleImpl->fetchDataFiles();
-                QSettings s;
-                bool btLayoutEnforced = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
-                qDebug() << "BT Layout enforced: " << btLayoutEnforced;
-                bool usbLayoutEnforced = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
-                qDebug() << "USB Layout enforced: " << usbLayoutEnforced;
+                bleImpl->enforceLayout();
             }
 
             /*

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3661,7 +3661,7 @@ void MPDevice::processStatusChange(const QByteArray &data)
             if (isBLE())
             {
                 bleImpl->fetchDataFiles();
-                bleImpl->enforceLayout();
+                bleImpl->activateEnforceLayout();
             }
 
             /*

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3661,6 +3661,11 @@ void MPDevice::processStatusChange(const QByteArray &data)
             if (isBLE())
             {
                 bleImpl->fetchDataFiles();
+                QSettings s;
+                bool btLayoutEnforced = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
+                qDebug() << "BT Layout enforced: " << btLayoutEnforced;
+                bool usbLayoutEnforced = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
+                qDebug() << "USB Layout enforced: " << usbLayoutEnforced;
             }
 
             /*

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1402,12 +1402,11 @@ void MPDeviceBleImpl::enforceLayout()
         return;
     }
     AsyncJobs *jobs = new AsyncJobs("Enforce layout", mpDev);
-    auto* bleSettings = static_cast<DeviceSettingsBLE*>(mpDev->settings());
     if (usbLayoutEnforced)
     {
         QByteArray layoutUsbData;
         layoutUsbData.append(DeviceSettingsBLE::USB_LAYOUT_ID);
-        layoutUsbData.append(bleSettings->get_keyboard_usb_layout());
+        layoutUsbData.append(s.value(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE).toInt());
         jobs->append(new MPCommandJob(mpDev,
                        MPCmd::SET_TMP_KEYB_LAYOUT,
                        layoutUsbData,
@@ -1419,7 +1418,7 @@ void MPDeviceBleImpl::enforceLayout()
     {
         QByteArray layoutBtData;
         layoutBtData.append(DeviceSettingsBLE::BT_LAYOUT_ID);
-        layoutBtData.append(bleSettings->get_keyboard_bt_layout());
+        layoutBtData.append(s.value(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE).toInt());
         jobs->append(new MPCommandJob(mpDev,
                        MPCmd::SET_TMP_KEYB_LAYOUT,
                        layoutBtData,

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1390,11 +1390,13 @@ void MPDeviceBleImpl::handleFirstBluetoothMessage(MPCommand &cmd)
 
 void MPDeviceBleImpl::enforceLayout()
 {
+    if (!m_enforceLayout)
+    {
+        return;
+    }
     QSettings s;
     bool btLayoutEnforced = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
-    qDebug() << "BT Layout enforced: " << btLayoutEnforced;
     bool usbLayoutEnforced = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
-    qDebug() << "USB Layout enforced: " << usbLayoutEnforced;
     if (!btLayoutEnforced && !usbLayoutEnforced)
     {
         return;
@@ -1426,6 +1428,7 @@ void MPDeviceBleImpl::enforceLayout()
     }
 
     mpDev->enqueueAndRunJob(jobs);
+    m_enforceLayout = false;
 }
 
 void MPDeviceBleImpl::handleLongMessageTimeout()

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -148,6 +148,8 @@ public:
     bool isFirstMessageWritten() const { return m_isFirstMessageWritten; }
     void handleFirstBluetoothMessage(MPCommand& cmd);
 
+    void enforceLayout();
+
 signals:
     void userSettingsChanged(QJsonObject settings);
     void bleDeviceLanguage(const QJsonObject& langs);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -148,6 +148,7 @@ public:
     bool isFirstMessageWritten() const { return m_isFirstMessageWritten; }
     void handleFirstBluetoothMessage(MPCommand& cmd);
 
+    void activateEnforceLayout() { m_enforceLayout = true; }
     void enforceLayout();
 
 signals:
@@ -205,6 +206,8 @@ private:
 
     bool m_isFirstMessageWritten = false;
     QList<QString> m_dataFiles;
+
+    bool m_enforceLayout = false;
 
     static int s_LangNum;
     static int s_LayoutNum;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -564,8 +564,10 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(ui->checkBoxLockDevice, &QCheckBox::toggled, this, &MainWindow::onLockDeviceSystemEventsChanged);
 
     m_keyboardBTLayoutOrigValue = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
+    m_keyboardBTLayoutActualValue = m_keyboardBTLayoutOrigValue;
     ui->checkBoxEnforceBTLayout->setChecked(m_keyboardBTLayoutOrigValue);
     m_keyboardUsbLayoutOrigValue = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
+    m_keyboardUsbLayoutActualValue = m_keyboardUsbLayoutOrigValue;
     ui->checkBoxEnforceUSBLayout->setChecked(m_keyboardUsbLayoutOrigValue);
 
     wsClient->settingsHelper()->setMainWindow(this);
@@ -2078,18 +2080,10 @@ void MainWindow::onReconditionFinished(bool success, double dischargeTime)
 
 void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
 {
-    QSettings s;
-    bool checked = Qt::Checked == arg1;
-    s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, checked);
+    m_keyboardBTLayoutActualValue = Qt::Checked == arg1;
     const auto btLayout = ui->comboBoxBtLayout->currentData().toInt();
-    if (arg1 == Qt::Checked)
-    {
-        // On Gui start bt layout is not fetched yet (0) so we should not set enforce value to that
-        if (btLayout != 0)
-        {
-            s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE, btLayout);
-        }
-    }
+
+    // On Gui start bt layout is not fetched yet (0) so we should not check settings
     if (btLayout != 0)
     {
         checkSettingsChanged();
@@ -2098,18 +2092,10 @@ void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
 
 void MainWindow::on_checkBoxEnforceUSBLayout_stateChanged(int arg1)
 {
-    QSettings s;
-    bool checked = Qt::Checked == arg1;
-    s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, checked);
+    m_keyboardUsbLayoutActualValue = Qt::Checked == arg1;
     const auto usbLayout = ui->comboBoxUsbLayout->currentData().toInt();
-    if (arg1 == Qt::Checked)
-    {
-        // On Gui start usb layout is not fetched yet (0) so we should not set enforce value to that
-        if (usbLayout != 0)
-        {
-            s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE, usbLayout);
-        }
-    }
+
+    // On Gui start usb layout is not fetched yet (0) so we should not check settings
     if (usbLayout != 0)
     {
         checkSettingsChanged();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2077,11 +2077,41 @@ void MainWindow::onReconditionFinished(bool success, double dischargeTime)
 void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
 {
     QSettings s;
-    s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, Qt::Checked == arg1);
+    bool checked = Qt::Checked == arg1;
+    s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, checked);
+    if (arg1 == Qt::Checked)
+    {
+        const auto btLayout = ui->comboBoxBtLayout->currentData().toInt();
+        // On Gui start bt layout is not fetched yet (0) so we should not set enforce value to that
+        if (btLayout != 0)
+        {
+            s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE, btLayout);
+            qDebug() << "bt layout enforce value stored: " << btLayout;
+        }
+    }
+    else
+    {
+        s.remove(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE);
+    }
 }
 
 void MainWindow::on_checkBoxEnforceUSBLayout_stateChanged(int arg1)
 {
     QSettings s;
-    s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, Qt::Checked == arg1);
+    bool checked = Qt::Checked == arg1;
+    s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, checked);
+    if (arg1 == Qt::Checked)
+    {
+        const auto usbLayout = ui->comboBoxUsbLayout->currentData().toInt();
+        // On Gui start usb layout is not fetched yet (0) so we should not set enforce value to that
+        if (usbLayout != 0)
+        {
+            s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE, usbLayout);
+            qDebug() << "usb layout enforce value stored: " << usbLayout;
+        }
+    }
+    else
+    {
+        s.remove(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE);
+    }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1725,6 +1725,14 @@ void MainWindow::handleNoBundleDisconnected()
     updatePage();
 }
 
+void MainWindow::sendChangedParam(const QString &paramName, int value)
+{
+    QJsonObject o;
+    o[paramName] = value;
+    // After enforce is disabled send the current layout to device
+    wsClient->sendJsonData({{ "msg", "param_set" }, { "data", o }});
+}
+
 void MainWindow::on_toolButton_clearBackupFilePath_released()
 {
     ui->lineEdit_dbBackupFilePath->clear();
@@ -2079,9 +2087,9 @@ void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
     QSettings s;
     bool checked = Qt::Checked == arg1;
     s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, checked);
+    const auto btLayout = ui->comboBoxBtLayout->currentData().toInt();
     if (arg1 == Qt::Checked)
     {
-        const auto btLayout = ui->comboBoxBtLayout->currentData().toInt();
         // On Gui start bt layout is not fetched yet (0) so we should not set enforce value to that
         if (btLayout != 0)
         {
@@ -2092,6 +2100,7 @@ void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
     else
     {
         s.remove(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE);
+        sendChangedParam("keyboard_bt_layout", btLayout);
     }
 }
 
@@ -2100,9 +2109,9 @@ void MainWindow::on_checkBoxEnforceUSBLayout_stateChanged(int arg1)
     QSettings s;
     bool checked = Qt::Checked == arg1;
     s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, checked);
+    const auto usbLayout = ui->comboBoxUsbLayout->currentData().toInt();
     if (arg1 == Qt::Checked)
     {
-        const auto usbLayout = ui->comboBoxUsbLayout->currentData().toInt();
         // On Gui start usb layout is not fetched yet (0) so we should not set enforce value to that
         if (usbLayout != 0)
         {
@@ -2113,5 +2122,6 @@ void MainWindow::on_checkBoxEnforceUSBLayout_stateChanged(int arg1)
     else
     {
         s.remove(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE);
+        sendChangedParam("keyboard_usb_layout", usbLayout);
     }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -563,6 +563,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->checkBoxLockDevice->setChecked(s.value("settings/LockDeviceOnSystemEvents", true).toBool());
     connect(ui->checkBoxLockDevice, &QCheckBox::toggled, this, &MainWindow::onLockDeviceSystemEventsChanged);
 
+    ui->checkBoxEnforceBTLayout->setChecked(s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool());
+    ui->checkBoxEnforceUSBLayout->setChecked(s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool());
+
     wsClient->settingsHelper()->setMainWindow(this);
 #ifdef Q_OS_WIN
     const auto keyboardLayoutWidth = 150;
@@ -2069,4 +2072,16 @@ void MainWindow::onReconditionFinished(bool success, double dischargeTime)
         QMessageBox::critical(this, tr("NiMH Recondition Error"),
                      tr("Recondition finished with error"));
     }
+}
+
+void MainWindow::on_checkBoxEnforceBTLayout_stateChanged(int arg1)
+{
+    QSettings s;
+    s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, Qt::Checked == arg1);
+}
+
+void MainWindow::on_checkBoxEnforceUSBLayout_stateChanged(int arg1)
+{
+    QSettings s;
+    s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, Qt::Checked == arg1);
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -213,6 +213,8 @@ private:
 
     void handleNoBundleDisconnected();
 
+    void sendChangedParam(const QString& paramName, int value);
+
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -59,6 +59,8 @@ public:
     bool isDebugLogChecked();
     bool getOriginalBTKeyboardLayout() const { return m_keyboardBTLayoutOrigValue; }
     bool getOriginalUsbKeyboardLayout() const { return m_keyboardUsbLayoutOrigValue; }
+    bool getActualBTKeyboardLayout() const { return m_keyboardBTLayoutActualValue; }
+    bool getActualUsbKeyboardLayout() const { return m_keyboardUsbLayoutActualValue; }
     void setOriginalBTKeyboardLayout(bool val) { m_keyboardBTLayoutOrigValue = val; }
     void setOriginalUsbKeyboardLayout(bool val) { m_keyboardUsbLayoutOrigValue = val; }
 
@@ -250,6 +252,8 @@ private:
 
     bool m_keyboardUsbLayoutOrigValue = false;
     bool m_keyboardBTLayoutOrigValue = false;
+    bool m_keyboardUsbLayoutActualValue = false;
+    bool m_keyboardBTLayoutActualValue = false;
 
     bool m_computerUnlocked = true;
     struct LockUnlockItem

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -176,6 +176,10 @@ private slots:
 
     void onReconditionFinished(bool success, double dischargeTime);
     
+    void on_checkBoxEnforceBTLayout_stateChanged(int arg1);
+
+    void on_checkBoxEnforceUSBLayout_stateChanged(int arg1);
+
 private:
     void setUIDRequestInstructionsWithId(const QString &id = "XXXX");
     void setSecurityChallengeText(const QString &id = "XXXX");

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -57,6 +57,10 @@ public:
 
     bool isHttpDebugChecked();
     bool isDebugLogChecked();
+    bool getOriginalBTKeyboardLayout() const { return m_keyboardBTLayoutOrigValue; }
+    bool getOriginalUsbKeyboardLayout() const { return m_keyboardUsbLayoutOrigValue; }
+    void setOriginalBTKeyboardLayout(bool val) { m_keyboardBTLayoutOrigValue = val; }
+    void setOriginalUsbKeyboardLayout(bool val) { m_keyboardUsbLayoutOrigValue = val; }
 
     void updateBackupControlsVisibility(bool visible);
 
@@ -213,8 +217,6 @@ private:
 
     void handleNoBundleDisconnected();
 
-    void sendChangedParam(const QString& paramName, int value);
-
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 
@@ -245,6 +247,9 @@ private:
 
     QJsonObject m_keyboardLayoutCache;
     QJsonObject m_languagesCache;
+
+    bool m_keyboardUsbLayoutOrigValue = false;
+    bool m_keyboardBTLayoutOrigValue = false;
 
     bool m_computerUnlocked = true;
     struct LockUnlockItem

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -778,6 +778,9 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                   </item>
                   <item>
                    <widget class="QCheckBox" name="checkBoxEnforceBTLayout">
+                    <property name="toolTip">
+                     <string>If enabled Bluetooth Keyboard Layout value is used from Moolticute instead of the device.</string>
+                    </property>
                     <property name="text">
                      <string>Enforce at connection</string>
                     </property>
@@ -836,6 +839,9 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                   </item>
                   <item>
                    <widget class="QCheckBox" name="checkBoxEnforceUSBLayout">
+                    <property name="toolTip">
+                     <string>If enabled USB Keyboard Layout value is used from Moolticute instead of the device.</string>
+                    </property>
                     <property name="text">
                      <string>Enforce at connection</string>
                     </property>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -777,6 +777,13 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    </widget>
                   </item>
                   <item>
+                   <widget class="QCheckBox" name="checkBoxEnforceBTLayout">
+                    <property name="text">
+                     <string>Enforce at connection</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <spacer name="horizontalSpacer_51">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -824,6 +831,13 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                       <width>200</width>
                       <height>0</height>
                      </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="checkBoxEnforceUSBLayout">
+                    <property name="text">
+                     <string>Enforce at connection</string>
                     </property>
                    </widget>
                   </item>
@@ -4198,7 +4212,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
        </layout>
       </widget>
       <widget class="QWidget" name="pageFido">
-       <layout class="QHBoxLayout" name="horizontalLayout_50">
+       <layout class="QHBoxLayout" name="horizontalLayout_64">
         <property name="leftMargin">
          <number>0</number>
         </property>

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -356,6 +356,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::GET_LANG_DESC         , 0x001B},
         {MPCmd::GET_LAYOUT_DESC       , 0x001C},
         {MPCmd::SET_KEYB_LAYOUT_ID    , 0x001D},
+        {MPCmd::SET_TMP_KEYB_LAYOUT   , 0x0037},
         {MPCmd::SET_USER_LANG         , 0x001E},
         {MPCmd::SET_DEVICE_LANG       , 0x001F},
         {MPCmd::NIMH_RECONDITION      , 0x0028},

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -3,6 +3,7 @@
 #include "MPDevice.h"
 #include "IMessageProtocol.h"
 #include "WSServerCon.h"
+#include "MPDeviceBleImpl.h"
 
 MPSettingsBLE::MPSettingsBLE(MPDevice *parent, IMessageProtocol *mesProt)
     : DeviceSettingsBLE(parent),
@@ -89,6 +90,8 @@ void MPSettingsBLE::loadParameters()
                         const auto layoutId = pMesProt->getFirstPayloadByte(data);
                         qDebug() << "Keyboard Bluetooth layout: " << layoutId;
                         set_keyboard_bt_layout(layoutId);
+                        //Enforce layout after bt and usb layouts are fetched
+                        mpDevice->ble()->enforceLayout();
                         return true;
                     }
     ));

--- a/src/Mooltipass/MPSettingsBLE.cpp
+++ b/src/Mooltipass/MPSettingsBLE.cpp
@@ -164,6 +164,13 @@ void MPSettingsBLE::setSettings()
                    QByteArray(1, get_user_language()),
                    pMesProt->getDefaultFuncDone()
     ));
+    QSettings s;
+    bool usbLayoutEnforced = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
+    if (usbLayoutEnforced)
+    {
+        s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE, get_keyboard_usb_layout());
+        qDebug() << "usb layout enforce set to: " << get_keyboard_usb_layout();
+    }
     QByteArray layoutUsbData;
     layoutUsbData.append(USB_LAYOUT_ID);
     layoutUsbData.append(get_keyboard_usb_layout());
@@ -172,6 +179,12 @@ void MPSettingsBLE::setSettings()
                    layoutUsbData,
                    pMesProt->getDefaultFuncDone()
     ));
+    bool btLayoutEnforced = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
+    if (btLayoutEnforced)
+    {
+        s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE, get_keyboard_bt_layout());
+        qDebug() << "bt layout enforce set to: " << get_keyboard_bt_layout();
+    }
     QByteArray layoutBtData;
     layoutBtData.append(BT_LAYOUT_ID);
     layoutBtData.append(get_keyboard_bt_layout());

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -149,6 +149,7 @@ public:
             GET_LANG_DESC       ,
             GET_LAYOUT_DESC     ,
             SET_KEYB_LAYOUT_ID  ,
+            SET_TMP_KEYB_LAYOUT ,
             SET_USER_LANG       ,
             SET_DEVICE_LANG     ,
             INFORM_LOCKED       ,

--- a/src/Settings/SettingsGuiBLE.cpp
+++ b/src/Settings/SettingsGuiBLE.cpp
@@ -17,6 +17,7 @@ void SettingsGuiBLE::loadParameters()
 
 void SettingsGuiBLE::updateParam(MPParams::Param param, int val)
 {
+    checkEnforceLayout(param, val);
     setProperty(getParamName(param), val);
 }
 
@@ -77,4 +78,19 @@ void SettingsGuiBLE::updateUI()
 void SettingsGuiBLE::setupKeyboardLayout(bool onlyCheck)
 {
     m_mw->wsClient->requestBleKeyboardLayout(onlyCheck);
+}
+
+void SettingsGuiBLE::checkEnforceLayout(MPParams::Param param, int &val)
+{
+    QSettings s;
+    if (param == MPParams::KEYBOARD_USB_LAYOUT && s.value(Common::SETTING_USB_LAYOUT_ENFORCE).toBool())
+    {
+        val = s.value(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE).toInt();
+        qDebug() << "Using usb layout value from enforce: " << val;
+    }
+    if (param == MPParams::KEYBOARD_BT_LAYOUT && s.value(Common::SETTING_BT_LAYOUT_ENFORCE).toBool())
+    {
+        val = s.value(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE).toInt();
+        qDebug() << "Using bt layout value from enforce: " << val;
+    }
 }

--- a/src/Settings/SettingsGuiBLE.h
+++ b/src/Settings/SettingsGuiBLE.h
@@ -22,6 +22,16 @@ public:
     static const int ENTER_INDEX = 10;
     static const int SPACE_INDEX = 32;
     static const int DEFAULT_INDEX = 0xFFFF;
+
+private:
+    /**
+     * @brief checkEnforceLayout
+     * If enforce layout is enabled then using layout value
+     * from MC setting instead of the fetched value from device.
+     * @param param type, checked for usb/bt layout
+     * @param val Fetched value from device
+     */
+    inline void checkEnforceLayout(MPParams::Param param, int &val);
 };
 
 #endif // SETTINGSGUIBLE_H

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -119,6 +119,13 @@ void SettingsGuiHelper::createSettingUIMapping()
 bool SettingsGuiHelper::checkSettingsChanged()
 {
     auto* metaObj = m_settings->getMetaObject();
+    if (m_wsClient->isMPBLE())
+    {
+        if (checkEnforceLayoutChanged())
+        {
+            return true;
+        }
+    }
     while (nullptr != metaObj && QString{metaObj->className()} != "QObject")
     {
         for (int i = metaObj->propertyOffset(); i < metaObj->propertyCount(); ++i)
@@ -160,6 +167,10 @@ void SettingsGuiHelper::resetSettings()
         qDebug() << "Cannot reset, settings is not inited yet";
         return;
     }
+    if (m_wsClient->isMPBLE())
+    {
+        resetEnforceLayout();
+    }
     auto* metaObj = m_settings->getMetaObject();
     while (nullptr != metaObj && QString{metaObj->className()} != "QObject")
     {
@@ -188,6 +199,10 @@ void SettingsGuiHelper::resetSettings()
 void SettingsGuiHelper::getChangedSettings(QJsonObject &o)
 {
     auto* metaObj = m_settings->getMetaObject();
+    if (m_wsClient->isMPBLE())
+    {
+        saveEnforceLayout();
+    }
     while (nullptr != metaObj && QString{metaObj->className()} != "QObject")
     {
         for (int i = metaObj->propertyOffset(); i < metaObj->propertyCount(); ++i)
@@ -280,6 +295,61 @@ void SettingsGuiHelper::initKnockSetting()
     {
         m_mw->enableKnockSettings(m_wsClient->get_status() == Common::NoCardInserted);
     }
+}
+
+bool SettingsGuiHelper::checkEnforceLayoutChanged()
+{
+    QSettings s;
+    bool btLayoutEnforceChanged = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalBTKeyboardLayout();
+    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    return btLayoutEnforceChanged || usbLayoutEnforceChanged;
+}
+
+void SettingsGuiHelper::resetEnforceLayout()
+{
+    QSettings s;
+    bool btLayoutEnforceChanged = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalBTKeyboardLayout();
+    if (btLayoutEnforceChanged)
+    {
+        ui->checkBoxEnforceBTLayout->setChecked(m_mw->getOriginalBTKeyboardLayout());
+    }
+    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    if (usbLayoutEnforceChanged)
+    {
+        ui->checkBoxEnforceUSBLayout->setChecked(m_mw->getOriginalUsbKeyboardLayout());
+    }
+
+}
+
+void SettingsGuiHelper::saveEnforceLayout()
+{
+    QSettings s;
+    bool actualBtLayoutEnforce = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
+    bool btLayoutEnforceChanged = actualBtLayoutEnforce != m_mw->getOriginalBTKeyboardLayout();
+    if (btLayoutEnforceChanged)
+    {
+        if (!actualBtLayoutEnforce)
+        {
+            // When disable bt enforce value set the current layout
+            s.remove(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE);
+            m_wsClient->sendChangedParam("keyboard_bt_layout", ui->comboBoxBtLayout->currentData().toInt());
+        }
+        m_mw->setOriginalBTKeyboardLayout(actualBtLayoutEnforce);
+    }
+
+    bool actualUsbLayoutEnforce = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
+    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    if (usbLayoutEnforceChanged)
+    {
+        if (!actualUsbLayoutEnforce)
+        {
+            // When disable usb enforce value set the current layout
+            s.remove(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE);
+            m_wsClient->sendChangedParam("keyboard_usb_layout", ui->comboBoxUsbLayout->currentData().toInt());
+        }
+        m_mw->setOriginalUsbKeyboardLayout(actualUsbLayoutEnforce);
+    }
+    m_mw->checkSettingsChanged();
 }
 
 void SettingsGuiHelper::checkKeyboardLayout()

--- a/src/Settings/SettingsGuiHelper.cpp
+++ b/src/Settings/SettingsGuiHelper.cpp
@@ -300,20 +300,20 @@ void SettingsGuiHelper::initKnockSetting()
 bool SettingsGuiHelper::checkEnforceLayoutChanged()
 {
     QSettings s;
-    bool btLayoutEnforceChanged = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalBTKeyboardLayout();
-    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    bool btLayoutEnforceChanged = m_mw->getActualBTKeyboardLayout() != m_mw->getOriginalBTKeyboardLayout();
+    bool usbLayoutEnforceChanged = m_mw->getActualUsbKeyboardLayout() != m_mw->getOriginalUsbKeyboardLayout();
     return btLayoutEnforceChanged || usbLayoutEnforceChanged;
 }
 
 void SettingsGuiHelper::resetEnforceLayout()
 {
     QSettings s;
-    bool btLayoutEnforceChanged = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalBTKeyboardLayout();
+    bool btLayoutEnforceChanged = m_mw->getActualBTKeyboardLayout() != m_mw->getOriginalBTKeyboardLayout();
     if (btLayoutEnforceChanged)
     {
         ui->checkBoxEnforceBTLayout->setChecked(m_mw->getOriginalBTKeyboardLayout());
     }
-    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    bool usbLayoutEnforceChanged = m_mw->getActualUsbKeyboardLayout() != m_mw->getOriginalUsbKeyboardLayout();
     if (usbLayoutEnforceChanged)
     {
         ui->checkBoxEnforceUSBLayout->setChecked(m_mw->getOriginalUsbKeyboardLayout());
@@ -324,29 +324,41 @@ void SettingsGuiHelper::resetEnforceLayout()
 void SettingsGuiHelper::saveEnforceLayout()
 {
     QSettings s;
-    bool actualBtLayoutEnforce = s.value(Common::SETTING_BT_LAYOUT_ENFORCE, false).toBool();
+    bool actualBtLayoutEnforce = m_mw->getActualBTKeyboardLayout();
     bool btLayoutEnforceChanged = actualBtLayoutEnforce != m_mw->getOriginalBTKeyboardLayout();
     if (btLayoutEnforceChanged)
     {
-        if (!actualBtLayoutEnforce)
+        const auto btLayout = ui->comboBoxBtLayout->currentData().toInt();
+        if (actualBtLayoutEnforce)
+        {
+            s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE, btLayout);
+        }
+        else
         {
             // When disable bt enforce value set the current layout
             s.remove(Common::SETTING_BT_LAYOUT_ENFORCE_VALUE);
-            m_wsClient->sendChangedParam("keyboard_bt_layout", ui->comboBoxBtLayout->currentData().toInt());
+            m_wsClient->sendChangedParam("keyboard_bt_layout", btLayout);
         }
+        s.setValue(Common::SETTING_BT_LAYOUT_ENFORCE, actualBtLayoutEnforce);
         m_mw->setOriginalBTKeyboardLayout(actualBtLayoutEnforce);
     }
 
-    bool actualUsbLayoutEnforce = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool();
-    bool usbLayoutEnforceChanged = s.value(Common::SETTING_USB_LAYOUT_ENFORCE, false).toBool() != m_mw->getOriginalUsbKeyboardLayout();
+    bool actualUsbLayoutEnforce = m_mw->getActualUsbKeyboardLayout();
+    bool usbLayoutEnforceChanged = actualUsbLayoutEnforce != m_mw->getOriginalUsbKeyboardLayout();
     if (usbLayoutEnforceChanged)
     {
-        if (!actualUsbLayoutEnforce)
+        const auto usbLayout = ui->comboBoxUsbLayout->currentData().toInt();
+        if (actualUsbLayoutEnforce)
+        {
+            s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE, usbLayout);
+        }
+        else
         {
             // When disable usb enforce value set the current layout
             s.remove(Common::SETTING_USB_LAYOUT_ENFORCE_VALUE);
-            m_wsClient->sendChangedParam("keyboard_usb_layout", ui->comboBoxUsbLayout->currentData().toInt());
+            m_wsClient->sendChangedParam("keyboard_usb_layout", usbLayout);
         }
+        s.setValue(Common::SETTING_USB_LAYOUT_ENFORCE, actualUsbLayoutEnforce);
         m_mw->setOriginalUsbKeyboardLayout(actualUsbLayoutEnforce);
     }
     m_mw->checkSettingsChanged();

--- a/src/Settings/SettingsGuiHelper.h
+++ b/src/Settings/SettingsGuiHelper.h
@@ -33,6 +33,9 @@ private slots:
 
 private:
     void initKnockSetting();
+    bool checkEnforceLayoutChanged();
+    void resetEnforceLayout();
+    void saveEnforceLayout();
 
     WSClient* m_wsClient = nullptr;
     DeviceSettings* m_settings = nullptr;

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -816,6 +816,14 @@ void WSClient::sendSecurityChallenge(QString str)
                  });
 }
 
+void WSClient::sendChangedParam(const QString &paramName, int value)
+{
+    QJsonObject o;
+    o[paramName] = value;
+    // After enforce is disabled send the current layout to device
+    sendJsonData({{ "msg", "param_set" }, { "data", o }});
+}
+
 void WSClient::requestBleKeyboardLayout(bool onlyCheck)
 {
     QJsonObject o;

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -111,6 +111,8 @@ public:
     void sendNiMHReconditioning();
     void sendSecurityChallenge(QString str);
 
+    void sendChangedParam(const QString& paramName, int value);
+
     inline bool isFw12() const { return isFwVersion(12); }
     inline bool isFw13() const { return isFwVersion(13); }
 


### PR DESCRIPTION
Added "Enforce at connection" checkbox for keyboard layouts:
![image](https://user-images.githubusercontent.com/11043249/113614797-3f193280-9653-11eb-9435-f3564962b43e.png)
If they are enabled then after user login when layouts are fetched sending the new 0x0037 message to enforce the layout.
