### PR TITLE
[BLE] Implement import files from mini backup

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -457,3 +457,14 @@ QString Common::toHexString(const QByteArray &array)
 {
     return array.toHex();
 }
+
+QByteArray Common::reverse(const QByteArray &array)
+{
+    QByteArray res;
+    res.reserve(array.size());
+    for(int i = array.size() - 1; i >= 0; --i)
+    {
+        res.append(array[i]);
+    }
+    return res;
+}

--- a/src/Common.h
+++ b/src/Common.h
@@ -247,6 +247,8 @@ public:
     static QByteArray toHexArray(const QString str);
     static QString toHexString(const QByteArray& array);
 
+    static QByteArray reverse(const QByteArray& array);
+
     typedef enum
     {
         MP_Classic = 0,

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5594,11 +5594,19 @@ bool MPDevice::readExportPayload(QJsonArray dataArray, QString &errorString)
 
     if (!isMooltiAppImportFile)
     {
-        /* Read service nodes */
-        readExportNodes(dataArray[EXPORT_MC_SERVICE_NODES_INDEX].toArray(), EXPORT_MC_SERVICE_NODES_INDEX, miniExportToBle, true);
+        if (miniExportToBle && bleImpl->get_bundleVersion() < 1 && !dataArray[EXPORT_MC_SERVICE_NODES_INDEX].toArray().isEmpty())
+        {
+            //Cannot import files, display warning information
+            emit displayMiniImportWarning();
+        }
+        else
+        {
+            /* Read service nodes */
+            readExportNodes(dataArray[EXPORT_MC_SERVICE_NODES_INDEX].toArray(), EXPORT_MC_SERVICE_NODES_INDEX, miniExportToBle, true);
 
-        /* Read service child nodes */
-        readExportDataChildNodes(dataArray[EXPORT_MC_SERVICE_CHILD_NODES_INDEX].toArray(), EXPORT_MC_SERVICE_CHILD_NODES_INDEX, miniExportToBle);
+            /* Read service child nodes */
+            readExportDataChildNodes(dataArray[EXPORT_MC_SERVICE_CHILD_NODES_INDEX].toArray(), EXPORT_MC_SERVICE_CHILD_NODES_INDEX, miniExportToBle);
+        }
 
         if (isBleExport)
         {

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -258,6 +258,7 @@ signals:
     void platformFailed();
     void filesCacheChanged();
     void dbChangeNumbersChanged(const int credentialsDbChangeNumber, const int dataDbChangeNumber);
+    void displayMiniImportWarning();
 
 private slots:
     void newDataRead(const QByteArray &data);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -335,7 +335,8 @@ private:
     bool addOrphanParentChildsToDB(MPNode *parentNodePt, bool isDataParent, Common::AddressType addrType = Common::CRED_ADDR_IDX);
     bool removeEmptyParentFromDB(MPNode* parentNodePt, bool isDataParent, Common::AddressType addrType = Common::CRED_ADDR_IDX);
     bool readExportFile(const QByteArray &fileData, QString &errorString);
-    void readExportNodes(QJsonArray &&nodes, ExportPayloadData id, bool fromMiniToBle = false);
+    void readExportNodes(QJsonArray &&nodes, ExportPayloadData id, bool fromMiniToBle = false, bool isData = false);
+    void readExportDataChildNodes(QJsonArray &&nodes, ExportPayloadData id, bool fromMiniToBle = false);
     bool readExportPayload(QJsonArray dataArray, QString &errorString);
     bool removeChildFromDB(MPNode* parentNodePt, MPNode* childNodePt, bool deleteEmptyParent, bool deleteFromList, Common::AddressType addrType = Common::CRED_ADDR_IDX);
     bool addChildToDB(MPNode* parentNodePt, MPNode* childNodePt, Common::AddressType addrType = Common::CRED_ADDR_IDX);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -645,7 +645,7 @@ void MPDeviceBleImpl::createBLEDataChildNodes(MPDevice::ExportPayloadData id, QB
     {
         QByteArray addr = firstAddr;
         QByteArray dataPacket = m_bleNodeConverter.convertDataChildNode(miniDataArray[i], totalSize, currentSize, firstAddr);
-        /* Recreate node and add it to the list of imported nodes */
+        /* Create node and add it to the list of imported data nodes */
         MPNode* importedNode = bleProt->createMPNode(qMove(dataPacket), mpDev, qMove(addr), 0);
         mpDev->importNodeMap[id]->append(importedNode);
     }
@@ -676,7 +676,7 @@ void MPDeviceBleImpl::readExportDataChildNodes(const QJsonArray &nodes, MPDevice
 
         if (hasNextAddress(dataCore[NEXT_ADDRESS_STARTING], dataCore[NEXT_ADDRESS_STARTING + 1]))
         {
-            // Checking next three
+            /* Collecting data child nodes, while they have next address */
             do
             {
                 qjobject = nodes[++i].toObject();
@@ -686,6 +686,7 @@ void MPDeviceBleImpl::readExportDataChildNodes(const QJsonArray &nodes, MPDevice
                 coreArray.append(dataCore);
             } while (hasNextAddress(dataCore[NEXT_ADDRESS_STARTING], dataCore[NEXT_ADDRESS_STARTING+1]));
         }
+        /* Create data child nodes for a given file */
         createBLEDataChildNodes(id, serviceAddr, coreArray);
     }
 }

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -86,6 +86,9 @@ public:
     QVector<QByteArray> processReceivedStartNodes(const QByteArray& data) const;
     QByteArray getDataStartNode(const QByteArray& data) const;
     bool readDataNode(AsyncJobs *jobs, const QByteArray& data);
+    void createBLEDataChildNodes(MPDevice::ExportPayloadData id, QByteArray& firstAddr, QVector<QByteArray>& miniDataArray);
+    bool hasNextAddress(char addr1, char addr2);
+    void readExportDataChildNodes(const QJsonArray& nodes, MPDevice::ExportPayloadData id);
 
     bool isAfterAuxFlash();
 
@@ -137,7 +140,7 @@ public:
     void addUserIdPlaceholder(QByteArray &array);
     void fillMiniExportPayload(QByteArray &unknownCardPayload);
 
-    void convertMiniToBleNode(QByteArray &array);
+    void convertMiniToBleNode(QByteArray &array, bool isData);
 
     void storeFileData(int current, AsyncJobs * jobs, const MPDeviceProgressCb &cbProgress);
 
@@ -238,6 +241,7 @@ private:
     static constexpr int UPLOAD_PASSWORD_BYTE_SIZE = 16;
     static constexpr int DATA_FETCH_NO_NEXT_ADDR_SIZE = 2;
     static constexpr int RECONDITION_RESPONSE_SIZE = 4;
+    static constexpr int NEXT_ADDRESS_STARTING = 2;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
 };
 

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -244,7 +244,7 @@ private:
     static constexpr int DATA_FETCH_NO_NEXT_ADDR_SIZE = 2;
     static constexpr int RECONDITION_RESPONSE_SIZE = 4;
     static constexpr int NEXT_ADDRESS_STARTING = 2;
-    static constexpr int MINI_FILE_SIZE_BYTES = 4;
+    static constexpr int MINI_FILE_FULL_SIZE_LENGTH = 4;
     static constexpr int MINI_FILE_BLOCK_SIZE = 128;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
 };

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -214,6 +214,8 @@ private:
 
     bool m_enforceLayout = false;
 
+    int m_miniFilePartCounter = 0;
+
     static int s_LangNum;
     static int s_LayoutNum;
 
@@ -242,6 +244,8 @@ private:
     static constexpr int DATA_FETCH_NO_NEXT_ADDR_SIZE = 2;
     static constexpr int RECONDITION_RESPONSE_SIZE = 4;
     static constexpr int NEXT_ADDRESS_STARTING = 2;
+    static constexpr int MINI_FILE_SIZE_BYTES = 4;
+    static constexpr int MINI_FILE_BLOCK_SIZE = 128;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
 };
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -480,6 +480,8 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         }
     });
 
+    connect(wsClient, &WSClient::displayMiniImportWarning, this, &MainWindow::displayMiniImportWarning);
+
     QRegularExpressionValidator* uidKeyValidator = new QRegularExpressionValidator(QRegularExpression(Common::HEX_REGEXP.arg(UID_REQUEST_LENGTH)), ui->UIDRequestKeyInput);
     ui->UIDRequestKeyInput->setValidator(uidKeyValidator);
     ui->UIDRequestValidateBtn->setEnabled(false);
@@ -1731,6 +1733,13 @@ void MainWindow::handleNoBundleDisconnected()
     ui->widgetBleDev->clearWidgets();
     wsClient->set_status(Common::UnknownStatus);
     updatePage();
+}
+
+void MainWindow::displayMiniImportWarning()
+{
+    PromptMessage *message = new PromptMessage("<b>"+tr("Import Warning") + "</b><br>" +
+                                                  tr("Files were not imported from mini backup."));
+    showPrompt(message);
 }
 
 void MainWindow::on_toolButton_clearBackupFilePath_released()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -221,6 +221,8 @@ private:
 
     void handleNoBundleDisconnected();
 
+    void displayMiniImportWarning();
+
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 

--- a/src/Mooltipass/MPMiniToBleNodeConverter.cpp
+++ b/src/Mooltipass/MPMiniToBleNodeConverter.cpp
@@ -80,6 +80,7 @@ QByteArray MPMiniToBleNodeConverter::convertMiniParentNodeToBle(const QByteArray
     }
     if (isData)
     {
+        // For data parent node setting the ASCII flag
         bleArray[0] = bleArray[0]|(1<<ASCII_FLAG);
     }
     // Fill remaining service name

--- a/src/Mooltipass/MPMiniToBleNodeConverter.h
+++ b/src/Mooltipass/MPMiniToBleNodeConverter.h
@@ -8,9 +8,10 @@ class MPMiniToBleNodeConverter
 {
 public:
     MPMiniToBleNodeConverter();
-    void convert(QByteArray &dataArray);
+    void convert(QByteArray &dataArray, bool isData);
+    QByteArray convertDataChildNode(const QByteArray& packet, int totalSize, int& current, QByteArray& addr);
 private:
-    QByteArray convertMiniParentNodeToBle(const QByteArray& dataArray);
+    QByteArray convertMiniParentNodeToBle(const QByteArray& dataArray, bool isData);
     QByteArray convertMiniChildNodeToBle(const QByteArray& dataArray);
 
     const static char ZERO_BYTE = static_cast<char>(0x00);
@@ -32,6 +33,9 @@ private:
     const static quint16 MINI_PWD_SIZE = 32;
     const static quint16 FLAGS_BYTE_NOT_VALID_SET = 264;
     const static quint16 THIRD_FIELD_SIZE = 72;
+    const static quint16 DATA_FLAGS_AND_NEXT_ADDR = 4;
+    const static quint16 PACKET_ENCRYPTED_SIZE = 512;
+    const static quint16 DATA_NEXT_ADDR_STARTING = 2;
 };
 
 #endif // MPMINITOBLENODECONVERTER_H

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -549,6 +549,10 @@ void WSClient::onTextMessageReceived(const QString &message)
             emit deleteFidoNodesFailed();
         }
     }
+    else if (rootobj["msg"] == "display_mini_import_warning")
+    {
+        emit displayMiniImportWarning();
+    }
 
 }
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -162,6 +162,7 @@ signals:
     void reconditionFinished(bool success, double dischargeTime);
     void deleteFidoNodesFailed();
     void showExportPrompt();
+    void displayMiniImportWarning();
 
 public slots:
     void sendJsonData(const QJsonObject &data);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -594,6 +594,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
         connect(mpBle, &MPDeviceBleImpl::batteryPercentChanged, this, &WSServerCon::sendBatteryPercent);
         connect(mpBle, &MPDeviceBleImpl::userCategoriesFetched, this, &WSServerCon::sendUserCategories);
         connect(mpBle, &MPDeviceBleImpl::bundleVersionChanged, this, &WSServerCon::sendVersion);
+        connect(mpdevice, &MPDevice::displayMiniImportWarning, this, &WSServerCon::sendMiniImportWarning);
     }
 }
 
@@ -856,6 +857,12 @@ void WSServerCon::sendBatteryPercent(int batteryPct)
     QJsonObject data;
     data.insert("battery", batteryPct);
     oroot["data"] = data;
+    sendJsonMessage(oroot);
+}
+
+void WSServerCon::sendMiniImportWarning()
+{
+    QJsonObject oroot = { {"msg", "display_mini_import_warning"} };
     sendJsonMessage(oroot);
 }
 

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -70,6 +70,8 @@ private slots:
     void sendUserCategories(QJsonObject categories);
 
     void sendBatteryPercent(int batteryPct);
+
+    void sendMiniImportWarning();
 private:
     bool checkMemModeEnabled(const QJsonObject &root);
     bool processSetCredential(QJsonObject &root, QJsonObject &o);


### PR DESCRIPTION
Import and converting mini data nodes to BLE data nodes.
Special retrieve of mini files are implemented as well.

Only import files from mini backup, if the bundle >=1 otherwise display a warning information for the user during importing:
![importWarning](https://user-images.githubusercontent.com/11043249/121247258-53231f80-c8a2-11eb-8771-271cd0ed03f2.jpg)
