### PR TITLE
[BLE] Accept 64 chars long login and password from CSV import, fix #839

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6833,14 +6833,14 @@ void MPDevice::importFromCSV(const QJsonArray &creds, const MPDeviceProgressCb &
         QJsonObject qjobject = creds[i].toObject();
 
         /* Check login size */
-        if (qjobject["login"].toString().length() >= pMesProt->getLoginMaxLength()-1)
+        if (qjobject["login"].toString().length() > pMesProt->getLoginMaxLength())
         {
             cb(false, "Couldn't import CSV file: " + qjobject["login"].toString() + " has longer than supported length");
             return;
         }
 
         /* Check password size */
-        if (qjobject["password"].toString().length() >= pMesProt->getPwdMaxLength()-1)
+        if (qjobject["password"].toString().length() > pMesProt->getPwdMaxLength())
         {
             cb(false, "Couldn't import CSV file: " + qjobject["password"].toString() + " has longer than supported length");
             return;

--- a/src/MessageProtocol/MessageProtocolMini.h
+++ b/src/MessageProtocol/MessageProtocolMini.h
@@ -53,7 +53,7 @@ public:
 
 private:
     static constexpr uint CRED_PACKAGE_SIZE = 6;
-    static constexpr int PWD_MAX_LENGTH = 32;
+    static constexpr int PWD_MAX_LENGTH = 31;
     static constexpr int LOGIN_MAX_LENGTH = 63;
     static constexpr int CPZ_START = 0;
     static constexpr uint DATA_NODE_ENC_SIZE = 128;


### PR DESCRIPTION
Until now 63 and 64 characters long logins and passwords were rejected during CSV import.