### PR TITLE
Use QLabel pixmap by const ptr for backward compatibility

### DIFF
--- a/src/NotesManagement.cpp
+++ b/src/NotesManagement.cpp
@@ -60,7 +60,7 @@ void NotesManagement::addNewIcon(const QString &name)
     labelIcon->setAlignment(Qt::AlignCenter);
     labelIcon->setPixmap(QString::fromUtf8(":/note.png"));
     labelIcon->setMaximumSize(200,200);
-    labelIcon->setPixmap(labelIcon->pixmap(Qt::ReturnByValue).scaled(200,200, Qt::KeepAspectRatio));
+    labelIcon->setPixmap(labelIcon->pixmap()->scaled(200,200, Qt::KeepAspectRatio));
     labelIcon->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     labelIcon->setAlignment(Qt::AlignCenter);
 


### PR DESCRIPTION
It was changed in #850, but realized it is causing backward compatibility issue with older Qt versions, because they does not contain the new function for pixmap.