### PR TITLE
Add AppStream metainfo file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ test:
 	cd build; $(MAKE) check
 
 install:
-	install -m 755 -d "$(DESTDIR)$(PREFIX)/bin" "$(DESTDIR)/lib/udev/rules.d" "$(DESTDIR)$(PREFIX)/share/applications" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps"
+	install -m 755 -d "$(DESTDIR)$(PREFIX)/bin" "$(DESTDIR)/lib/udev/rules.d" "$(DESTDIR)$(PREFIX)/share/applications" "$(DESTDIR)$(PREFIX)/share/metainfo" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps" "$(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps"
 	install -m 755 build/moolticute "$(DESTDIR)$(PREFIX)/bin/"
 	install -m 755 build/moolticuted "$(DESTDIR)$(PREFIX)/bin/"
 	install -m 644 69-mooltipass.rules "$(DESTDIR)/lib/udev/rules.d/"
 	install -m 644 data/moolticute.desktop "$(DESTDIR)$(PREFIX)/share/applications/"
+	install -m 644 data/moolticute.metainfo.xml "$(DESTDIR)$(PREFIX)/share/metainfo/"
 	install -m 644 img/AppIcon.svg "$(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/moolticute.svg"
 	install -m 644 img/AppIcon_32.png "$(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps/moolticute.png"
 	install -m 644 img/AppIcon_128.png "$(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps/moolticute.png"

--- a/data/moolticute.metainfo.xml
+++ b/data/moolticute.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>moolticute.desktop</id>
+
+  <name>Moolticute</name>
+  <summary>Companion GUI application for Mooltipass password manager devices</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+
+  <description>
+    <p>
+      Moolticute is an easy to use companion app to your Mooltipass device and
+      extends the power of the device to more platform/tools. It allows you to
+      manage your Mooltipass with a cross-platform app and daemon service that
+      handles all USB communication with the device.
+    </p>
+    <p>
+      Moolticute comes with a daemon that runs in the background, and a user
+      interface app to control your Mooltipass. Other clients can also connect
+      and talk to the daemon (it uses a WebSocket connection and simple JSON messages).
+    </p>
+  </description>
+
+  <launchable type="desktop-id">moolticute.desktop</launchable>
+  <url type="homepage">https://www.mymooltipass.com/</url>
+  <url type="bugtracker">https://github.com/mooltipass/moolticute/</url>
+</component>


### PR DESCRIPTION
This adds support for software centers. [More information](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps). 

If moolticute is available in a distribution's repository, the metainfo makes sure users can find it within their software centers (gnome-software, discover, ...). This is useful if they are not familiar with command line tools.

A lot more information could be added. For example screenshots (they need to be available on a url). [Gajim](https://dev.gajim.org/gajim/gajim/-/blob/master/data/org.gajim.Gajim.appdata.xml.in) is a good example which uses a lot of the features.

![gnome-software example](https://user-images.githubusercontent.com/16706228/122906592-9d040f00-d352-11eb-932f-a4b6f1820afe.png)