### PR TITLE
Added additional fedora dnf intall command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ curl https://raw.githubusercontent.com/mooltipass/mooltipass-udev/master/udev/69
 sudo udevadm control --reload-rules
 ```
 
+##### Fedora Linux (33 and >)
+```bash
+sudo dnf install gcc-c++ qt5-qtbase qt5-qtwebsockets qt5-qtwebsockets-devel qt5-qttools-devel systemd-devel
+curl https://raw.githubusercontent.com/mooltipass/mooltipass-udev/master/udev/69-mooltipass.rules | sudo tee /etc/udev/rules.d/69-mooltipass.rules
+sudo udevadm control --reload-rules
+```
+
 ### How to build
 
 For now, no binary releases are out yet. You will need to build the software by following the next step.


### PR DESCRIPTION
Fedora 33 and > uses `qt5-qtbase` rather than `qt5` for the qt5 base package.
I wasn't sure the best way to change the README.md file while still making it copy-and-pastable, so I just added the updated
string in a new code fence.