### PR TITLE
[BLE] Fix multiple popups on recondition finish, fix #880

### DIFF
--- a/src/AsyncJobs.h
+++ b/src/AsyncJobs.h
@@ -87,6 +87,7 @@ public slots:
     virtual void start(const QByteArray &)
     {
         work();
+        emit this->done(QByteArray());
     }
 
 private:

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -114,7 +114,7 @@ public:
     void readBatteryPercent(const QByteArray& statusData);
     void getBattery();
 
-    void nihmReconditioning(const MessageHandlerCb &cb);
+    void nihmReconditioning();
     void getSecurityChallenge(const QString& key, const MessageHandlerCb &cb);
 
     void processDebugMsg(const QByteArray& data, bool& isDebugMsg);
@@ -175,6 +175,7 @@ signals:
     void batteryPercentChanged(int batteryPct);
     void userCategoriesFetched(QJsonObject categories);
     void notesFetched();
+    void nimhReconditionFinished(bool success, QString response);
 
 private slots:
     void handleLongMessageTimeout();
@@ -195,6 +196,8 @@ private:
     QByteArray createCredentialMessage(const CredMap &credMap);
     QByteArray createChangePasswordMsg(const QByteArray& address, QString pwd);
     QByteArray createUploadPasswordMessage(const QString& uploadPassword);
+
+    void createAndAddCustomJob(QString name, std::function<void()> fn);
 
     inline void flipBit();
     void resetFlipBit();
@@ -227,6 +230,7 @@ private:
     QList<QString> m_notes;
 
     bool m_enforceLayout = false;
+    QString m_nimhResponse = "";
 
     int m_miniFilePartCounter = 0;
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -606,6 +606,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
         connect(mpBle, &MPDeviceBleImpl::bundleVersionChanged, this, &WSServerCon::sendVersion);
         connect(mpBle, &MPDeviceBleImpl::notesFetched, this, &WSServerCon::sendNotes);
         connect(mpBle, &MPDeviceBleImpl::chargingStatusChanged, this, &WSServerCon::sendChargingStatus);
+        connect(mpBle, &MPDeviceBleImpl::nimhReconditionFinished, this, &WSServerCon::sendNimhReconditionFinished);
         connect(mpdevice, &MPDevice::displayMiniImportWarning, this, &WSServerCon::sendMiniImportWarning);
     }
 }
@@ -911,6 +912,16 @@ void WSServerCon::sendChargingStatus(bool charging)
     QJsonObject oroot = { {"msg", "send_charging_status"} };
     QJsonObject data;
     data.insert("charging_status", charging);
+    oroot["data"] = data;
+    sendJsonMessage(oroot);
+}
+
+void WSServerCon::sendNimhReconditionFinished(bool success, QString resposne)
+{
+    QJsonObject oroot = { {"msg", "nimh_reconditioning"} };
+    QJsonObject data;
+    data.insert("success", success);
+    data.insert("discharge_time", resposne);
     oroot["data"] = data;
     sendJsonMessage(oroot);
 }
@@ -1341,15 +1352,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     }
     else if (root["msg"] == "nimh_reconditioning")
     {
-        bleImpl->nihmReconditioning([this, root](bool success, QString response)
-        {
-            QJsonObject ores;
-            QJsonObject oroot = root;
-            ores["success"] = success;
-            ores["discharge_time"] = response;
-            oroot["data"] = ores;
-            sendJsonMessage(oroot);
-        });
+        bleImpl->nihmReconditioning();
     }
     else if (root["msg"] == "request_security_challenge")
     {

--- a/src/WSServerCon.h
+++ b/src/WSServerCon.h
@@ -72,6 +72,7 @@ private slots:
 
     void sendBatteryPercent(int batteryPct);
     void sendChargingStatus(bool charging);
+    void sendNimhReconditionFinished(bool success, QString resposne);
 
     void sendMiniImportWarning();
 private:


### PR DESCRIPTION
Nihm recondition takes more than 4 hours, during that time a messages arrive to daemon (mostly get random numbers) and waits for recondition finish.
On Windows when we send recondition response message to the gui for some reason instead of the other messages sending the same one for recondition every time. (Thats why multiple dialog was displayed)
I added a custom job for sending the result, which resolved the problem.