### PR TITLE
[BLE] Bypass battery check for bundle upload if ctrl is pressed

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -61,6 +61,22 @@ void BleDev::clearWidgets()
     ui->label_UploadProgress->hide();
 }
 
+void BleDev::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Control)
+    {
+        DeviceDetector::instance().ctrlPressed();
+    }
+}
+
+void BleDev::keyReleaseEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Control)
+    {
+        DeviceDetector::instance().ctrlReleased();
+    }
+}
+
 void BleDev::initUITexts()
 {
     const auto browseText = tr("Browse");
@@ -122,7 +138,7 @@ void BleDev::on_btnFileBrowser_clicked()
 {
     if (wsClient->get_status() != Common::NoBundle &&
         (DeviceDetector::instance().isConnectedWithBluetooth() ||
-        DeviceDetector::instance().getBattery() < MIN_BATTERY_PCT_FOR_UPLOAD))
+        (DeviceDetector::instance().getBattery() < MIN_BATTERY_PCT_FOR_UPLOAD && !DeviceDetector::instance().isCtrlPressed())))
     {
         QMessageBox::warning(this, tr("Battery too low for bundle upload"),
                              tr("Please have your device connected through USB and fully charged"));
@@ -133,6 +149,8 @@ void BleDev::on_btnFileBrowser_clicked()
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select bundle file"),
                                             s.value("last_used_path/bundle_dir", QDir::homePath()).toString(),
                                             "*.img");
+
+    DeviceDetector::instance().ctrlReleased();
 
     if (fileName.isEmpty())
     {

--- a/src/BleDev.h
+++ b/src/BleDev.h
@@ -21,6 +21,10 @@ public:
     void setWsClient(WSClient *c);
     void clearWidgets();
 
+protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
+
 private slots:
     void on_btnFileBrowser_clicked();
 

--- a/src/DeviceDetector.h
+++ b/src/DeviceDetector.h
@@ -37,6 +37,9 @@ public:
     void setIsConnectedWithBluetooth(bool bt) { m_isConnectedWithBluetooth = bt; }
     quint8 getBattery() const { return m_battery; }
     void setBattery(quint8 battery) { m_battery = battery; }
+    void ctrlPressed() { m_isCtrlPressed = true; }
+    void ctrlReleased() { m_isCtrlPressed = false; }
+    bool isCtrlPressed() const { return m_isCtrlPressed; }
 
 signals:
     void deviceChanged(Common::MPHwVersion newDevType);
@@ -49,6 +52,7 @@ private:
     bool m_advancedMode = false;
     bool m_isConnectedWithBluetooth = false;
     quint8 m_battery = 0;
+    bool m_isCtrlPressed = false;
 };
 
 #endif // DEVICEDETECTOR_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2197,3 +2197,19 @@ void MainWindow::displayNotePage()
     ui->stackedWidget->setCurrentWidget(ui->pageNotes);
     updateTabButtons();
 }
+
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Control)
+    {
+        DeviceDetector::instance().ctrlPressed();
+    }
+}
+
+void MainWindow::keyReleaseEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Control)
+    {
+        DeviceDetector::instance().ctrlReleased();
+    }
+}

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -191,6 +191,10 @@ private slots:
 
     void displayNotePage();
 
+protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
+
 private:
     void setUIDRequestInstructionsWithId(const QString &id = "XXXX");
     void setSecurityChallengeText(const QString &id = "XXXX");


### PR DESCRIPTION
It was not enough to handle keyPressed/Released only in BleDev widget, because if I simple change to BleDev tab from another tab, until a UI element is selected MainWindow is catching the key events.