### PR TITLE
Fix credential management button sizes, fix #889

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -63,7 +63,6 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     setFilterCredLayout();
 
     ui->pushButtonCancel->setText(tr("Discard changes"));
-    ui->pushButtonCancel->setFixedWidth(108);
     connect(ui->pushButtonCancel, &AnimatedColorButton::actionValidated, this, &CredentialsManagement::on_pushButtonCancel_clicked);
 
     ui->pushButtonDelete->setStyleSheet(CSS_BLUE_BUTTON);

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -868,7 +868,7 @@ border-right: none;
           <item>
            <widget class="AnimatedColorButton" name="buttonDiscard">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -2765,7 +2765,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <widget class="QLabel" name="labelWait">
             <property name="maximumSize">
              <size>
-              <width>300</width>
+              <width>400</width>
               <height>16777215</height>
              </size>
             </property>


### PR DESCRIPTION
Discard credential changes:
![image](https://user-images.githubusercontent.com/11043249/130678415-d6963627-a56c-409c-bfc8-e83c37b18990.png)
Discard all changes:
![image](https://user-images.githubusercontent.com/11043249/130678445-5810bc75-8027-4f3d-957e-e750cbebf85f.png)

Also fix for #899, but I was not able to test it, because "Please Approve Request On Device" text were never cut off for me.