### PR TITLE
About tab improvements

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -568,6 +568,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
         ui->labelSecurityChallengeIcon->setVisible(false);
     });
 
+    ui->UIDRequestGB->hide();
+    ui->groupBoxSecurityChallenge->hide();
+
     ui->lineEditChallengeString->setValidator(new QRegularExpressionValidator(
                                                   QRegularExpression(Common::HEX_REGEXP.arg(SECURITY_CHALLENGE_LENGTH)),
                                                   ui->UIDRequestKeyInput));

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -2878,16 +2878,42 @@ Hint: keep your mouse positioned over an option to get more details.</string>
          <number>40</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_26">
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Moolticute (c) The Mooltipass Team</string>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout_65">
+          <item>
+           <widget class="QLabel" name="label_26">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Moolticute (c) The Mooltipass Team</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_28">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/mooltipass/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;( https://github.com/mooltipass/moolticute )&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -3410,16 +3436,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_28">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/mooltipass/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/mooltipass/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
         </item>
         <item>
          <spacer name="verticalSpacer_11">


### PR DESCRIPTION
When no device connected:
![image](https://user-images.githubusercontent.com/11043249/130862505-c4362942-7bc1-42ff-80a0-edcc53992b02.png)
When BLE is connected:
![image](https://user-images.githubusercontent.com/11043249/130862660-915b2b72-f08c-4df6-9ea7-61093a26c575.png)
