### PR TITLE
[BLE] Add tutorial for Moolticute

### DIFF
--- a/gui.pro
+++ b/gui.pro
@@ -29,6 +29,7 @@ SOURCES += src/main_gui.cpp \
     src/ParseDomain.cpp \
     src/Common.cpp \
     src/TOTPCredential.cpp \
+    src/TutorialWidget.cpp \
     src/WSClient.cpp \
     src/RotateSpinner.cpp \
     src/AppGui.cpp \
@@ -82,6 +83,7 @@ HEADERS  += src/MainWindow.h \
     src/Common.h \
     src/QtHelper.h \
     src/TOTPCredential.h \
+    src/TutorialWidget.h \
     src/WSClient.h \
     src/RotateSpinner.h \
     src/utils/GridLayoutUtil.h \

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2274,3 +2274,8 @@ void MainWindow::on_checkBoxBackupNotification_stateChanged(int)
     QSettings s;
     s.setValue("settings/backup_notification", isBackupNotification());
 }
+
+void MainWindow::on_checkBoxTutorial_stateChanged(int arg1)
+{
+    ui->tutorialWidget->changeTutorialFinished(Qt::Checked == arg1);
+}

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1149,8 +1149,11 @@ void MainWindow::handleBackupImported()
 
 void MainWindow::showPrompt(PromptMessage * message)
 {
-    ui->promptWidget->setPromptMessage(message);
-    ui->promptWidget->show();
+    if (ui->tutorialWidget->isTutorialFinished())
+    {
+        ui->promptWidget->setPromptMessage(message);
+        ui->promptWidget->show();
+    }
 }
 
 void MainWindow::hidePrompt()
@@ -1607,6 +1610,13 @@ void MainWindow::updateTabButtons()
             }
         }
     };
+
+    if (!ui->tutorialWidget->isTutorialFinished())
+    {
+        setEnabledToAllTabButtons(false);
+        ui->tutorialWidget->displayCurrentTab();
+        return;
+    }
 
     if (ui->stackedWidget->currentWidget() == ui->pageWaiting)
     {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -195,6 +195,8 @@ private slots:
 
     void on_checkBoxBackupNotification_stateChanged(int arg1);
 
+    void on_checkBoxTutorial_stateChanged(int arg1);
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -77,6 +77,7 @@ public:
     friend class SettingsGuiHelper;
     friend class SettingsGuiMini;
     friend class SettingsGuiBLE;
+    friend class TutorialWidget;
 
 signals:
     void windowCloseRequested();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4753,6 +4753,16 @@ Hint: keep your mouse positioned over an option to get more details.</string>
       </property>
      </widget>
     </item>
+    <item>
+     <widget class="TutorialWidget" name="tutorialWidget">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
  </widget>
@@ -4798,6 +4808,12 @@ Hint: keep your mouse positioned over an option to get more details.</string>
    <class>PromptWidget</class>
    <extends>QFrame</extends>
    <header>PromptWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>TutorialWidget</class>
+   <extends>QFrame</extends>
+   <header>TutorialWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4107,6 +4107,49 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </layout>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_37">
+              <item>
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>Display Moolticute Tutorial</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelTutorialRestart">
+                <property name="font">
+                 <font>
+                  <italic>true</italic>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>(Restart Needed)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_36">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkBoxTutorial">
+                <property name="text">
+                 <string>Display tutorial</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_44">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/src/TutorialWidget.cpp
+++ b/src/TutorialWidget.cpp
@@ -34,7 +34,6 @@ TutorialWidget::TutorialWidget(QWidget *parent) :
     m_messageLabel->setTextFormat(Qt::RichText);
     m_messageLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
     m_messageLabel->setOpenExternalLinks(true);
-    //m_messageLabel->setWordWrap(true);
 
     m_nextButton->setText(tr("Next"));
     m_nextButton->setStyleSheet(CSS_BLUE_BUTTON);

--- a/src/TutorialWidget.cpp
+++ b/src/TutorialWidget.cpp
@@ -92,13 +92,14 @@ void TutorialWidget::onNextClicked()
 {
     if (m_current_index != -1)
     {
-        m_mw->ui->widgetHeader->setEnabled(true);
         m_tabs[m_current_index].button()->setEnabled(false);
     }
+    m_mw->ui->widgetHeader->setEnabled(true);
     m_current_index++;
     if (m_current_index >= m_tabs.size())
     {
         qCritical() << "No more tutorial page";
+        QMessageBox::information(this, tr("Tutorial finished"), tr("Congratulation, you have completed the tutorial..."));
         onExitClicked();
         return;
     }

--- a/src/TutorialWidget.cpp
+++ b/src/TutorialWidget.cpp
@@ -1,0 +1,66 @@
+#include "TutorialWidget.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include "Common.h"
+
+TutorialWidget::TutorialWidget(QWidget *parent) :
+    QFrame(parent),
+    m_messageLabel{new QLabel},
+    m_nextButton{new QPushButton},
+    m_exitButton{new QPushButton}
+{
+    QHBoxLayout *lay = new QHBoxLayout(this);
+    setLayout(lay);
+
+    lay->addStretch();
+    lay->addWidget(m_messageLabel);
+    lay->addWidget(m_nextButton);
+    lay->addWidget(m_exitButton);
+    lay->addStretch();
+
+    setStyleSheet("TutorialWidget {border: 15px solid #60B1C7;}");
+
+    m_messageLabel->setAlignment(Qt::AlignCenter);
+    m_messageLabel->setTextFormat(Qt::RichText);
+    m_messageLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    m_messageLabel->setOpenExternalLinks(true);
+    //m_messageLabel->setWordWrap(true);
+
+    m_nextButton->setText(tr("Next"));
+    m_nextButton->setStyleSheet(CSS_BLUE_BUTTON);
+
+    m_exitButton->setText(tr("Exit"));
+    m_exitButton->setStyleSheet(CSS_BLUE_BUTTON);
+    connect(m_exitButton, &QPushButton::clicked, this, &TutorialWidget::onExitClicked);
+    QSettings s;
+    m_tutorialFinished = s.value("settings/tutorial_finished", false).toBool();
+    if (m_tutorialFinished)
+    {
+        hide();
+    }
+    else
+    {
+        m_messageLabel->setText("<b>Moolticute Tutorial</b><br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum venenatis sollicitudin erat, eget gravida mi elementum vel.<br>Integer sit amet faucibus lorem. Pellentesque mattis congue massa, vel laoreet ligula vulputate nec.<br>Curabitur pellentesque vitae neque vel placerat. Suspendisse erat ipsum, sodales et pulvinar non, iaculis eget ligula.<br>Sed vitae velit ultricies, dapibus nisl eu, malesuada magna. Phasellus sit amet pellentesque dolor, quis suscipit eros.");
+        show();
+    }
+}
+
+TutorialWidget::~TutorialWidget()
+{
+
+}
+
+void TutorialWidget::setText(const QString &text)
+{
+    m_messageLabel->setText(text);
+}
+
+void TutorialWidget::onExitClicked()
+{
+    QSettings s;
+    s.setValue("settings/tutorial_finished", true);
+    hide();
+}

--- a/src/TutorialWidget.cpp
+++ b/src/TutorialWidget.cpp
@@ -8,6 +8,7 @@
 #include "ui_MainWindow.h"
 
 const QString TutorialWidget::TUTORIAL_HEADER_TEXT = tr("<b>Moolticute Tutorial - %1</b><br><br>");
+const QString TutorialWidget::TUTORIAL_FINISHED_SETTING = "settings/tutorial_finished";
 
 TutorialWidget::TutorialWidget(QWidget *parent) :
     QFrame(parent),
@@ -44,7 +45,7 @@ TutorialWidget::TutorialWidget(QWidget *parent) :
     connect(m_nextButton, &QPushButton::clicked, this, &TutorialWidget::onNextClicked);
 
     QSettings s;
-    m_tutorialFinished = s.value("settings/tutorial_finished", false).toBool();
+    m_tutorialFinished = s.value(TUTORIAL_FINISHED_SETTING, false).toBool();
     m_mw = static_cast<MainWindow*>(parent->parent());
     if (m_tutorialFinished)
     {
@@ -84,10 +85,16 @@ void TutorialWidget::displayCurrentTab()
     }
 }
 
+void TutorialWidget::changeTutorialFinished(bool enabled)
+{
+    QSettings s;
+    s.setValue(TUTORIAL_FINISHED_SETTING, !enabled);
+}
+
 void TutorialWidget::onExitClicked()
 {
     QSettings s;
-    s.setValue("settings/tutorial_finished", true);
+    s.setValue(TUTORIAL_FINISHED_SETTING, true);
     m_tutorialFinished = true;
     hide();
     disconnect(m_mw->wsClient, &WSClient::deviceConnected, this, &TutorialWidget::onDeviceConnected);

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -1,0 +1,33 @@
+#ifndef TUTORIALWIDGET_H
+#define TUTORIALWIDGET_H
+
+#include <QFrame>
+#include <functional>
+
+class QLabel;
+class QPushButton;
+
+class TutorialWidget : public QFrame
+{
+    Q_OBJECT
+public:
+    explicit TutorialWidget(QWidget *parent = nullptr);
+    ~TutorialWidget();
+
+    void setText(const QString &text);
+    bool isTutorialFinished() const { return m_tutorialFinished; }
+
+signals:
+
+public slots:
+    void onExitClicked();
+
+
+private:
+    QLabel *m_messageLabel;
+    QPushButton *m_nextButton;
+    QPushButton *m_exitButton;
+    bool m_tutorialFinished;
+};
+
+#endif // TUTORIALWIDGET_H

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -39,8 +39,6 @@ public:
     void displayCurrentTab();
     void changeTutorialFinished(bool enabled);
 
-signals:
-
 public slots:
     void onExitClicked();
     void onNextClicked();

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -44,6 +44,8 @@ signals:
 public slots:
     void onExitClicked();
     void onNextClicked();
+    void onDeviceConnected();
+    void onDeviceDisconnected();
 
 
 private:

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -2,7 +2,8 @@
 #define TUTORIALWIDGET_H
 
 #include <QFrame>
-#include <functional>
+
+#include "Common.h"
 
 class QLabel;
 class QPushButton;
@@ -20,8 +21,6 @@ class TutorialWidget : public QFrame
             m_tabButton {button},
             m_text{text}
         {}
-
-        TutorialPage operator=(TutorialPage other) { return TutorialPage{other.button(), other.text()};}
 
         QPushButton* button() const { return m_tabButton; }
         QString text() const { return m_text; }
@@ -46,6 +45,7 @@ public slots:
     void onNextClicked();
     void onDeviceConnected();
     void onDeviceDisconnected();
+    void onStatusChanged(Common::MPStatus status);
 
 
 private:

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -37,6 +37,7 @@ public:
     void setText(const QString &text);
     bool isTutorialFinished() const { return m_tutorialFinished; }
     void displayCurrentTab();
+    void changeTutorialFinished(bool enabled);
 
 signals:
 
@@ -62,6 +63,7 @@ private:
     int m_current_index = 0;
 
     static const QString TUTORIAL_HEADER_TEXT;
+    static const QString TUTORIAL_FINISHED_SETTING;
 };
 
 #endif // TUTORIALWIDGET_H

--- a/src/TutorialWidget.h
+++ b/src/TutorialWidget.h
@@ -6,28 +6,60 @@
 
 class QLabel;
 class QPushButton;
+class MainWindow;
 
 class TutorialWidget : public QFrame
 {
     Q_OBJECT
+
+    class TutorialPage {
+
+    public:
+
+        TutorialPage(QPushButton* button, QString text) :
+            m_tabButton {button},
+            m_text{text}
+        {}
+
+        TutorialPage operator=(TutorialPage other) { return TutorialPage{other.button(), other.text()};}
+
+        QPushButton* button() const { return m_tabButton; }
+        QString text() const { return m_text; }
+
+    private:
+        QPushButton *m_tabButton;
+        QString m_text;
+    };
+
 public:
     explicit TutorialWidget(QWidget *parent = nullptr);
     ~TutorialWidget();
 
     void setText(const QString &text);
     bool isTutorialFinished() const { return m_tutorialFinished; }
+    void displayCurrentTab();
 
 signals:
 
 public slots:
     void onExitClicked();
+    void onNextClicked();
 
 
 private:
+    void initTutorial();
+    void startTutorial();
+
+
+    MainWindow *m_mw;
     QLabel *m_messageLabel;
     QPushButton *m_nextButton;
     QPushButton *m_exitButton;
+    QList<TutorialPage> m_tabs;
     bool m_tutorialFinished;
+    int m_current_index = 0;
+
+    static const QString TUTORIAL_HEADER_TEXT;
 };
 
 #endif // TUTORIALWIDGET_H


### PR DESCRIPTION
Implemented a tutorial for Moolticute which is going through all the tabs for a newly installed MC. (based on setting config)
Only displayed for BLE.
![tutorialMC](https://user-images.githubusercontent.com/11043249/141696525-4a584131-bbaf-4477-849c-c1a3f2d9045c.gif)
