### PR TITLE
Improved clarity of low battery system notification.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -280,7 +280,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
                 ui->pbBleBattery->setValue(battery);
                 if (battery < BATTERY_WARNING_LIMIT && !ui->label_charging->isVisible())
                 {
-                    SystemNotification::instance().createNotification(tr("Low Battery"), tr("Battery is below %1%, please charge your device.").arg(BATTERY_WARNING_LIMIT));
+                    SystemNotification::instance().createNotification(tr("Low Battery"), tr("Battery is below %1%, please charge your Mooltipass.").arg(BATTERY_WARNING_LIMIT));
                 }
             });
 


### PR DESCRIPTION
Minor text modification on the system notification to improve clarity about exactly what device is low on battery, for operating systems and desktop environments that don't readily indicate what application has generated a notification.

Closes #959.