### PR TITLE
[BLE] Fix fallback service get credential crash

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -511,8 +511,11 @@ void MPDeviceBleImpl::getFallbackServiceCredential(AsyncJobs *jobs, const QStrin
             qWarning() << "Credential get for fallback service failed";
             cb(false, "Get credential failed", QByteArray{});
         }
-        qDebug() << "Credential for fallback service got successfully";
-        cb(true, "", bleProt->getFullPayload(data));
+        else
+        {
+            qDebug() << "Credential for fallback service got successfully";
+            cb(true, "", bleProt->getFullPayload(data));
+        }
         return true;
     }));
 }


### PR DESCRIPTION
When get credential prompt for fallback service was denied the callback was called with true value too, which caused the crash later during it tried to retrieve the credential from empty response array.