### PR TITLE
Fix Gnome on Wayland crash

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -792,6 +792,12 @@ void AppGui::createMainWindow()
     Q_ASSERT(dbMasterController);
 
     win = new MainWindow(wsClient, dbMasterController);
+
+    // Force resize and reset maximumWidth
+    // This fixes a crash on some Gnome+Wayland platforms
+    win->resize(0,0);
+    win->setMaximumWidth(win->width());
+
     connect(win, &MainWindow::destroyed, [this](QObject *)
     {
         win = nullptr;


### PR DESCRIPTION
On some Gnome on Wayland platforms, moolticute wouldn't launch with a
protocol error: "Invalid min/max size". This seems to be caused by an
invalid maximum width value. This patch resets this value.

Fixes #872 