### PR TITLE
Fix exit MMM error message, fix #971

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -127,6 +127,7 @@ const QString Common::SETTING_USB_LAYOUT_ENFORCE = "settings/enforce_usb_layout"
 const QString Common::SETTING_USB_LAYOUT_ENFORCE_VALUE = "settings/enforce_usb_layout_value";
 const QString Common::SETTING_BT_LAYOUT_ENFORCE = "settings/enforce_bt_layout";
 const QString Common::SETTING_BT_LAYOUT_ENFORCE_VALUE = "settings/enforce_bt_layout_value";
+const QString Common::MMM_CREDENTIAL_STORE_FAILED = "Credential store failed";
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/Common.h
+++ b/src/Common.h
@@ -337,6 +337,7 @@ public:
     static const QString SETTING_USB_LAYOUT_ENFORCE_VALUE;
     static const QString SETTING_BT_LAYOUT_ENFORCE;
     static const QString SETTING_BT_LAYOUT_ENFORCE_VALUE;
+    static const QString MMM_CREDENTIAL_STORE_FAILED;
     static const int DEFAULT_PASSWORD_LENGTH = 16;
     static const int BLE_LATEST_BUNDLE_VERSION = 4;
 };

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -385,7 +385,7 @@ void CredentialsManagement::on_addCredentialButton_clicked()
                                         ui->addCredPasswordInput->text());
 
         auto conn = std::make_shared<QMetaObject::Connection>();
-        *conn = connect(wsClient, &WSClient::credentialsUpdated, [this, conn](const QString & service, const QString & login, const QString &, bool success)
+        *conn = connect(wsClient, &WSClient::credentialsUpdated, [this, conn](const QString & service, const QString & login, const QString &, bool success, const QString &)
         {
             disconnect(*conn);
             ui->addCredentialButton->setEnabled(true);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -419,8 +419,8 @@ void MPDeviceBleImpl::storeCredential(const BleCredential &cred, MessageHandlerC
            }
            else
            {
-               qWarning() << "Credential store failed";
-               cb(false, "Credential store failed");
+               qWarning() << Common::MMM_CREDENTIAL_STORE_FAILED;
+               cb(false, Common::MMM_CREDENTIAL_STORE_FAILED);
            }
            return true;
        }));

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1102,12 +1102,21 @@ void MainWindow::wantSaveCredentialManagement()
     connect(wsClient, &WSClient::progressChanged, this, &MainWindow::loadingProgress);
 
     auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn = connect(wsClient, &WSClient::credentialsUpdated, [this, conn](const QString & , const QString &, const QString &, bool success)
+    *conn = connect(wsClient, &WSClient::credentialsUpdated, [this, conn](const QString & , const QString &, const QString &, bool success, const QString& msg)
     {
         disconnect(*conn);
         if (!success)
         {
-            QMessageBox::warning(this, tr("Failure"), tr("Couldn't save credentials, please contact the support team with moolticute's log"));
+            QString errorMessage;
+            if (Common::MMM_CREDENTIAL_STORE_FAILED == msg)
+            {
+                errorMessage = tr("Couldn't change all passwords, please approve prompts on the device");
+            }
+            else
+            {
+                errorMessage = tr("Couldn't change all passwords, please approve prompts on the device");
+            }
+            QMessageBox::warning(this, tr("Failure"), errorMessage);
             ui->stackedWidget->setCurrentWidget(ui->pageCredentials);
         }
 

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -272,14 +272,14 @@ void WSClient::onTextMessageReceived(const QString &message)
         {
             emit showExportPrompt();
         }
-        emit credentialsUpdated(o["service"].toString(), o["login"].toString(), o["description"].toString(), success);
+        emit credentialsUpdated(o["service"].toString(), o["login"].toString(), o["description"].toString(), success, message);
     }
     else if (rootobj["msg"] == "set_credentials")
     {
         QJsonObject o = rootobj["data"].toObject();
         bool success = !o.contains("failed") || !o["failed"].toBool();
         auto message = success ? o["description"].toString() : o["error_message"].toString();
-        emit credentialsUpdated(o["service"].toString(), o["login"].toString(), o["description"].toString(), success);
+        emit credentialsUpdated(o["service"].toString(), o["login"].toString(), o["description"].toString(), success, message);
     }
     else if (rootobj["msg"] == "show_app")
     {

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -136,7 +136,7 @@ signals:
     void wsDisconnected();
     void memoryDataChanged();
     void passwordUnlocked(const QString & service, const QString & login, const QString & password, bool success);
-    void credentialsUpdated(const QString & service, const QString & login, const QString & description, bool success);
+    void credentialsUpdated(const QString & service, const QString & login, const QString & description, bool success, const QString& msg);
     void showAppRequested();
     void progressChanged(int total, int current, QString statusMsg);
     void memcheckFinished(bool success, int freeBlocks = 0, int totalBlocks = 0);


### PR DESCRIPTION
Display the correct error message when confirmation prompt denied during exit MMM after a password change:
![kép](https://user-images.githubusercontent.com/11043249/150015995-f80b81d5-b5b9-48cb-a781-78052c18166c.png)
Fix #971.
