### PR TITLE
[BLE] Update firmware with password from filename, fix #973

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -84,8 +84,6 @@ void BleDev::initUITexts()
     const auto browseText = tr("Browse");
     ui->label_DevTab->setText(tr("BLE Developer Tab"));
 
-    ui->groupBoxUploadBundle->setTitle(tr("Bundle Settings"));
-
     ui->groupBoxFetchData->setTitle(tr("Data Fetch"));
     ui->label_FetchDataFile->setText(tr("Storage file:"));
     ui->btnFetchDataBrowse->setText(browseText);

--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -7,6 +7,11 @@
 
 const QString BleDev::HEXA_CHAR_REGEXP = "[^A-Fa-f0-9*]";
 const QByteArray BleDev::START_BUNDLE_BYTES = "\x78\x56\x34\x12";
+const QStringList BleDev::ACCEPTED_BUNDLE_FILENAMES = {
+    "bundle_not_numbered.img",
+    "bundle_numbered_with_white_silkscreen.img",
+    "miniblebundle.img"
+  };
 
 BleDev::BleDev(QWidget *parent) :
     QWidget(parent),
@@ -34,8 +39,6 @@ BleDev::BleDev(QWidget *parent) :
     ui->horizontalLayout_Fetch->setAlignment(Qt::AlignLeft);
     ui->progressBarFetchData->setMinimum(0);
     ui->progressBarFetchData->setMaximum(0);
-    ui->labelInvalidBundle->setStyleSheet("QLabel { color : red; }");
-    ui->labelInvalidBundle->hide();
 
 #if defined(Q_OS_LINUX)
     ui->label_FetchDataFile->setMaximumWidth(150);
@@ -56,7 +59,6 @@ void BleDev::setWsClient(WSClient *c)
 
 void BleDev::clearWidgets()
 {
-    ui->lineEditBundlePassword->clear();
     ui->progressBarUpload->hide();
     ui->label_UploadProgress->hide();
 }
@@ -134,6 +136,39 @@ bool BleDev::isValidBundleFile(QFile* file) const
     return true;
 }
 
+bool BleDev::checkBundleFilePassword(const QFileInfo& fileInfo, QString &password)
+{
+    const auto baseFilename = fileInfo.baseName();
+    const auto baseNameWithExt = fileInfo.fileName();
+    if (!ACCEPTED_BUNDLE_FILENAMES.contains(baseNameWithExt))
+    {
+        const auto INVALID_BUNDLE_TEXT = tr("Invalid bundle file is selected");
+        auto fileParts = baseFilename.split("_");
+        if (fileParts.size() != BUNDLE_FILE_PARTS_SIZE)
+        {
+            QMessageBox::warning(this, INVALID_BUNDLE_TEXT,
+                                 tr("The given bundle file name is not correct."));
+            return false;
+        }
+        const auto serial = fileParts[SERIAL_FILE_PART].toUInt();
+        if (wsClient->get_hwSerial() != serial)
+        {
+            QMessageBox::warning(this, INVALID_BUNDLE_TEXT,
+                                 tr("The device serial number is not correct in bundle filename."));
+            return false;
+        }
+        const auto bundleVersion = fileParts[BUNDLE_FILE_PART].toInt();
+        if (wsClient->get_bundleVersion() != bundleVersion)
+        {
+            QMessageBox::warning(this, INVALID_BUNDLE_TEXT,
+                                 tr("The bundle version is not correct in bundle filename."));
+            return false;
+        }
+        password = fileParts.last();
+    }
+    return true;
+}
+
 void BleDev::on_btnFileBrowser_clicked()
 {
     if (wsClient->get_status() != Common::NoBundle &&
@@ -177,6 +212,12 @@ void BleDev::on_btnFileBrowser_clicked()
         return;
     }
 
+    QString password = "";
+    if (!checkBundleFilePassword(QFileInfo{file}, password))
+    {
+        return;
+    }
+
     connect(wsClient, &WSClient::progressChanged, this, &BleDev::updateProgress);
     ui->progressBarUpload->show();
     ui->progressBarUpload->setMinimum(0);
@@ -184,7 +225,7 @@ void BleDev::on_btnFileBrowser_clicked()
     ui->progressBarUpload->setValue(0);
     ui->label_UploadProgress->setText(tr("Starting upload bundle file."));
     ui->label_UploadProgress->show();
-    wsClient->sendUploadBundle(fileName, ui->lineEditBundlePassword->text());
+    wsClient->sendUploadBundle(fileName, password);
 }
 
 void BleDev::displayUploadBundleResultReceived(bool success)
@@ -254,20 +295,4 @@ void BleDev::on_btnFetchAccData_clicked()
 void BleDev::on_btnFetchRandomData_clicked()
 {
     fetchData(Common::FetchType::RANDOM_BYTES);
-}
-
-void BleDev::on_lineEditBundlePassword_textChanged(const QString &arg1)
-{
-    auto size = arg1.size();
-    if ((size == 0 || size == UPLOAD_PASSWORD_SIZE) &&
-            !arg1.contains(RegExp(HEXA_CHAR_REGEXP)))
-    {
-        ui->btnFileBrowser->setEnabled(true);
-        ui->labelInvalidBundle->hide();
-    }
-    else
-    {
-        ui->btnFileBrowser->setEnabled(false);
-        ui->labelInvalidBundle->show();
-    }
 }

--- a/src/BleDev.h
+++ b/src/BleDev.h
@@ -38,12 +38,11 @@ private slots:
 
     void on_btnFetchRandomData_clicked();
 
-    void on_lineEditBundlePassword_textChanged(const QString &arg1);
-
 private:
     void initUITexts();
     void fetchData(const Common::FetchType &fetchType);
     bool isValidBundleFile(QFile* file) const;
+    bool checkBundleFilePassword(const QFileInfo& fileInfo, QString& password);
 
     Ui::BleDev *ui;
     WSClient *wsClient = nullptr;
@@ -54,6 +53,10 @@ private:
     static const QByteArray START_BUNDLE_BYTES;
     static constexpr int UPLOAD_PASSWORD_SIZE = 32;
     static constexpr int MIN_BATTERY_PCT_FOR_UPLOAD = 60;
+    static constexpr int BUNDLE_FILE_PARTS_SIZE = 8;
+    static constexpr int SERIAL_FILE_PART = 1;
+    static constexpr int BUNDLE_FILE_PART = 4;
+    const static QStringList ACCEPTED_BUNDLE_FILENAMES;
 };
 
 #endif // BLEDEV_H

--- a/src/BleDev.ui
+++ b/src/BleDev.ui
@@ -18,7 +18,6 @@
   </property>
   <property name="font">
    <font>
-    <weight>75</weight>
     <bold>true</bold>
    </font>
   </property>
@@ -52,7 +51,6 @@
      <property name="font">
       <font>
        <pointsize>12</pointsize>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -74,7 +72,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>50</weight>
        <bold>false</bold>
       </font>
      </property>
@@ -99,12 +96,11 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
      <property name="title">
-      <string>Upload Bundle</string>
+      <string>Firmware Upgrade</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
@@ -135,51 +131,6 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="labelUploadPassword">
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Upload Password:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEditBundlePassword">
-          <property name="minimumSize">
-           <size>
-            <width>280</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="maxLength">
-           <number>32</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <widget class="QPushButton" name="btnFileBrowser">
           <property name="minimumSize">
            <size>
@@ -195,7 +146,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -220,22 +170,6 @@
        </layout>
       </item>
       <item>
-       <widget class="QLabel" name="labelInvalidBundle">
-        <property name="font">
-         <font>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Invalid Upload Password</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_7">
         <property name="leftMargin">
          <number>30</number>
@@ -256,7 +190,6 @@
        <widget class="QLabel" name="label_UploadProgress">
         <property name="font">
          <font>
-          <weight>50</weight>
           <bold>false</bold>
          </font>
         </property>
@@ -310,7 +243,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -338,7 +270,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -363,7 +294,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -411,7 +341,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -436,7 +365,6 @@
           </property>
           <property name="font">
            <font>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>

--- a/src/Common.h
+++ b/src/Common.h
@@ -339,7 +339,7 @@ public:
     static const QString SETTING_BT_LAYOUT_ENFORCE_VALUE;
     static const QString MMM_CREDENTIAL_STORE_FAILED;
     static const int DEFAULT_PASSWORD_LENGTH = 16;
-    static const int BLE_LATEST_BUNDLE_VERSION = 4;
+    static const int BLE_LATEST_BUNDLE_VERSION = 7;
 };
 
 struct FidoCredential


### PR DESCRIPTION
Check password, serial number, bundle version from filename.
For 3 special filename start the update with the default password.
![kép](https://user-images.githubusercontent.com/11043249/150689878-5b84f4c4-60da-4ecd-a7ef-00f11d103db5.png)
Implemented #973 
