### PR TITLE
Fix crash during service name change, fix #984

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -471,6 +471,12 @@ void CredentialsManagement::saveCredential(const QModelIndex currentSelectionInd
         {
             pLoginItem->parentItem()->setName(newServiceName);
             const QModelIndex serviceIdx = m_pCredModel->getServiceIndexByName(newServiceName);
+            const auto filterText = ui->lineEditFilterCred->text();
+            if (!filterText.isEmpty() && !newServiceName.contains(filterText))
+            {
+                //Remove filter if new service name does not contain filter text
+                ui->lineEditFilterCred->clear();
+            }
             //Service name changed, sort to the correct order
             m_pCredModel->dataChanged(serviceIdx, serviceIdx);
         }
@@ -1019,6 +1025,11 @@ void CredentialsManagement::clearMMMUi()
 
 void CredentialsManagement::updateBleFavs(const QModelIndex &srcIndex)
 {
+    if (!srcIndex.isValid())
+    {
+        qCritical() << "Invalid ModelIndex, cannot update BLE favorites";
+        return;
+    }
     const auto category = getCategory(srcIndex);
     int i = 0;
     int from = category * MAX_BLE_CAT_NUM  + 1;


### PR DESCRIPTION
When in MMM a filter was applied and a service name were changed it disappeared from the treeview. The name change procedure tried to update credentials information on the right side, which caused the crash due to invalid ModelIndex.
**Fix**: Remove filter if new service name does not contain filter text.