### PR TITLE
Simpler key combination for secret tabs on Mac, fix #979

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -160,7 +160,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->pushButtonNotes->setIcon(AppGui::qtAwesome()->icon(fa::newspapero));
     ui->pushButtonNotes->setVisible(false);
 
-    auto keyModifiers = Qt::SHIFT;
+    unsigned int keyModifiers = Qt::SHIFT;
 #ifndef Q_OS_MACOS
     keyModifiers |= Qt::CTRL;
 #endif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -160,12 +160,17 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->pushButtonNotes->setIcon(AppGui::qtAwesome()->icon(fa::newspapero));
     ui->pushButtonNotes->setVisible(false);
 
-    m_FilesAndSSHKeysTabsShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_F1), this);
+    auto keyModifiers = Qt::SHIFT;
+#ifndef Q_OS_MACOS
+    keyModifiers |= Qt::CTRL;
+#endif
+
+    m_FilesAndSSHKeysTabsShortcut = new QShortcut(QKeySequence(keyModifiers | Qt::Key_F1), this);
     setKeysTabVisibleOnDemand(bSSHKeysTabVisibleOnDemand);
     connect(ui->radioButtonSSHTabAlways, &QRadioButton::toggled, this, &MainWindow::onRadioButtonSSHTabsAlwaysToggled);
-    m_advancedTabShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_F2), this);
+    m_advancedTabShortcut = new QShortcut(QKeySequence(keyModifiers | Qt::Key_F2), this);
     connect(m_advancedTabShortcut, SIGNAL(activated()), this, SLOT(onAdvancedTabShortcutActivated()));
-    m_BleDevTabShortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_F3), this);
+    m_BleDevTabShortcut = new QShortcut(QKeySequence(keyModifiers | Qt::Key_F3), this);
     ui->pushButtonBleDev->setIcon(AppGui::qtAwesome()->icon(fa::wrench));
     ui->pushButtonBleDev->setVisible(false);
     connect(m_BleDevTabShortcut, SIGNAL(activated()), this, SLOT(onBleDevTabShortcutActivated()));


### PR DESCRIPTION
On Mac we only need to push SHIFT+F1/F2/F3 for secret tabs.