### PR TITLE
Do not save not confirmed changes when exiting MMM

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -313,6 +313,8 @@ void CredentialsManagement::on_buttonDiscard_pressed()
         wsClient->sendLeaveMMRequest();
         m_pCredModel->clear();
     }
+    // Enable add credential fields when exiting MMM
+    enableNonCredentialEditWidgets();
 }
 
 void CredentialsManagement::onButtonDiscard_confirmed()
@@ -323,12 +325,12 @@ void CredentialsManagement::onButtonDiscard_confirmed()
 
 void CredentialsManagement::on_buttonSaveChanges_clicked()
 {
-    saveSelectedCredential();
-
     ui->stackedWidget->setCurrentWidget(ui->pageLocked);
     wsClient->sendCredentialsMM(m_pCredModel->getJsonChanges());
     emit wantSaveMemMode(); //waits for the daemon to process the data
     m_pCredModel->clear();
+    // Enable add credential fields when exiting MMM
+    enableNonCredentialEditWidgets();
 }
 
 void CredentialsManagement::requestPasswordForSelectedItem()


### PR DESCRIPTION
When I remove a credential then "Discard all changes" and "Save all changes" displayed on the bottom, I choose an other credential and e.g. add a description. Now "Discard Changes" and "Confirm changes" is displayed for the credential.
If select "Save all changes" the not confirmed description will be also saved.
With this fix the not confirmed changes are not saved.

Also enable add credential fields on the top when exiting MMM during a credential edit.