### PR TITLE
Issue #953 Monospaced notes

### DIFF
--- a/src/NotesManagement.ui
+++ b/src/NotesManagement.ui
@@ -53,7 +53,7 @@ border-right: none;
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="pageListNotes">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -83,7 +83,7 @@ border-right: none;
             <x>0</x>
             <y>0</y>
             <width>572</width>
-            <height>418</height>
+            <height>396</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/src/NotesManagement.ui
+++ b/src/NotesManagement.ui
@@ -53,7 +53,7 @@ border-right: none;
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="pageListNotes">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -83,7 +83,7 @@ border-right: none;
             <x>0</x>
             <y>0</y>
             <width>572</width>
-            <height>396</height>
+            <height>418</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -205,7 +205,13 @@ border-right: none;
         </widget>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="textEditNote"/>
+        <widget class="QPlainTextEdit" name="textEditNote">
+         <property name="font">
+          <font>
+           <family>Courier</family>
+          </font>
+         </property>
+        </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
## Fixes mooltipass/moolticute#953
Using the _courier_ font in the Notes editor.

The notesmanagement.ui file was changed in the QT designer instead of a text editor, which generated a _height_ change and increment of the _stackedWidget_ _number_.

Tested in WIndows 10 only.