### PR TITLE
[BLE] Fix notes fetch condition, fix #1020

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -343,6 +343,7 @@ public:
     static const QString DUPLICATE_SERVICE_DETECTED;
     static const int DEFAULT_PASSWORD_LENGTH = 16;
     static const int BLE_LATEST_BUNDLE_VERSION = 7;
+    static const int BLE_BUNDLE_WITH_NOTES = 1;
 };
 
 struct FidoCredential

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -3988,10 +3988,6 @@ void MPDevice::processStatusChange(const QByteArray &data)
             {
                 bleImpl->fetchDataFiles();
                 bleImpl->activateEnforceLayout();
-                if (bleImpl->isNoteAvailable())
-                {
-                    bleImpl->fetchNotes();
-                }
             }
 
             /*

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -362,7 +362,7 @@ void MPDeviceBleImpl::getNoteNode(QString note, std::function<void (bool, QStrin
 
 bool MPDeviceBleImpl::isNoteAvailable() const
 {
-    return get_bundleVersion() >= 1;
+    return get_bundleVersion() >= Common::BLE_BUNDLE_WITH_NOTES;
 }
 
 void MPDeviceBleImpl::loadNotes(AsyncJobs *jobs, const MPDeviceProgressCb &cbProgress)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2339,7 +2339,8 @@ void MainWindow::on_checkBoxTutorial_stateChanged(int arg1)
 
 void MainWindow::sendRequestNotes(int bundle)
 {
-    if (!m_notesFetched && bundle >= Common::BLE_BUNDLE_WITH_NOTES && wsClient->isMPBLE())
+    if (!m_notesFetched && bundle >= Common::BLE_BUNDLE_WITH_NOTES &&
+            wsClient->isMPBLE() && wsClient->get_status() == Common::Unlocked)
     {
         m_notesFetched = true;
         wsClient->sendFetchNotes();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -197,6 +197,8 @@ private slots:
 
     void on_checkBoxTutorial_stateChanged(int arg1);
 
+    void sendRequestNotes(int bundle);
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;
@@ -273,6 +275,8 @@ private:
     bool m_keyboardBTLayoutOrigValue = false;
     bool m_keyboardUsbLayoutActualValue = false;
     bool m_keyboardBTLayoutActualValue = false;
+
+    bool m_notesFetched = false;
 
     bool m_computerUnlocked = true;
     struct LockUnlockItem


### PR DESCRIPTION
Device is connected and unlocked then MC was started and notes were not fetched.
**Issue**: During starting MC gui is started first, which is starting the daemon process. When gui is detecting the connected BLE it is sending a notes request to daemon, but at this moment bundle version and status have not been fetched from the device on daemon side, hence notes were not fetched.
**Fix**: Only send the fetch request from GUI, when bundle version fetched and status is Unlocked.