### PR TITLE
Minimize MC with cmd + Q on Mac

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -388,46 +388,13 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     // Close behavior
 #ifdef Q_OS_MAC
-    ui->closeBehaviorComboBox->addItem(
-        tr("Close Application"), static_cast<int>(CloseBehavior::CloseApp));
-    ui->closeBehaviorComboBox->addItem(
-        tr("Hide Window"), static_cast<int>(CloseBehavior::HideWindow));
-    ui->closeBehaviorComboBox->setCurrentIndex(
-        s.value("settings/CloseBehavior",
-                static_cast<int>(CloseBehavior::CloseApp)).toInt());
-
-    connect(ui->closeBehaviorComboBox,
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            [this](int index)
-    {
-        Q_UNUSED(index);
-        const auto behavior = ui->closeBehaviorComboBox->currentData().toInt();
-        QSettings s;
-        s.setValue("settings/CloseBehavior", behavior);
-    });
 
     // On macOS Command+Q will terminate the program without calling the proper destructors if not
     // the following is defined.
     auto *fileMenu = menuBar()->addMenu(tr("&File"));
     auto *actionExit = fileMenu->addAction(tr("&Quit"));
     connect(actionExit, &QAction::triggered, this, [this]
-    {
-        const auto behavior =
-            static_cast<CloseBehavior>(ui->closeBehaviorComboBox->currentData().toInt());
-        switch (behavior)
-        {
-            case CloseBehavior::CloseApp:
-                qApp->quit();
-                break;
-
-            case CloseBehavior::HideWindow:
-                close();
-                break;
-        }
-    });
-#else
-    ui->closeBehaviorLabel->setVisible(false);
-    ui->closeBehaviorComboBox->setVisible(false);
+               { close(); });
 #endif
 
     fillLockUnlockItems();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4299,39 +4299,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                </layout>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="closeBehaviorLayout">
-                <item>
-                 <widget class="QLabel" name="closeBehaviorLabel">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Behavior of ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="closeBehaviorSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="closeBehaviorComboBox"/>
-                </item>
-               </layout>
-              </item>
-              <item>
                <layout class="QHBoxLayout" name="horizontalLayout_37">
                 <item>
                  <widget class="QLabel" name="label_12">


### PR DESCRIPTION
Remove option to customize cmd + Q for terminate application. Now it will only minimize Moolticute.