### PR TITLE
[BLE] Add Current Category setting

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1315,6 +1315,7 @@ void CredentialsManagement::on_pushButtonSaveCategories_clicked()
     wsClient->sendSetUserCategories(cat1, cat2, cat3, cat4);
     ui->pushButtonSaveCategories->hide();
     m_pCredModel->updateCategories(cat1, cat2, cat3, cat4);
+    emit wsClient->updateCurrentCategories(cat1, cat2, cat3, cat4);
     ui->credDisplayCategoryInput->setItemText(1, cat1);
     ui->credDisplayCategoryInput->setItemText(2, cat2);
     ui->credDisplayCategoryInput->setItemText(3, cat3);

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -68,6 +68,17 @@ void MPDeviceBleImpl::getPlatInfo()
     mpDev->enqueueAndRunJob(jobs);
 }
 
+void MPDeviceBleImpl::enforceCategory(int category)
+{
+    auto *jobs = new AsyncJobs("Set current category", mpDev);
+
+    QByteArray catArr;
+    catArr.append(static_cast<char>(category));
+    jobs->append(new MPCommandJob(mpDev, MPCmd::SET_CUR_CATEGORY, catArr, bleProt->getDefaultSizeCheckFuncDone()));
+
+    mpDev->enqueueAndRunJob(jobs);
+}
+
 void MPDeviceBleImpl::getDebugPlatInfo(const MessageHandlerCbData &cb)
 {
     auto *jobs = new AsyncJobs("Get Debug PlatInfo", mpDev);

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -53,6 +53,7 @@ public:
     bool isLastPacket(const QByteArray &data);
 
     void getPlatInfo();
+    void enforceCategory(int category);
     void getDebugPlatInfo(const MessageHandlerCbData &cb);
     QVector<int> calcDebugPlatInfo(const QByteArray &platInfo);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -226,6 +226,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
                 auto currentCategoryIndex = ui->comboBoxBleCurrentCategory->currentIndex();
                 if (currentCategoryIndex != 0)
                 {
+                    // When enforce current category is set sending category number to device
                     wsClient->sendCurrentCategory(currentCategoryIndex);
                 }
             }
@@ -1895,12 +1896,12 @@ void MainWindow::fillInitialCurrentCategories()
     QSettings s;
     ui->comboBoxBleCurrentCategory->blockSignals(true);
     ui->comboBoxBleCurrentCategory->clear();
-    ui->comboBoxBleCurrentCategory->addItem(tr("Disable"), 0);
+    ui->comboBoxBleCurrentCategory->addItem(tr("Disabled"), 0);
     ui->comboBoxBleCurrentCategory->addItem("1", 1);
     ui->comboBoxBleCurrentCategory->addItem("2", 2);
     ui->comboBoxBleCurrentCategory->addItem("3", 3);
     ui->comboBoxBleCurrentCategory->addItem("4", 4);
-    ui->comboBoxBleCurrentCategory->setCurrentIndex(s.value("settings/current_category", 0).toInt());
+    ui->comboBoxBleCurrentCategory->setCurrentIndex(s.value("settings/enforced_category", 0).toInt());
     ui->comboBoxBleCurrentCategory->blockSignals(false);
 }
 
@@ -2352,7 +2353,7 @@ void MainWindow::sendRequestNotes(int bundle)
 void MainWindow::on_comboBoxBleCurrentCategory_currentIndexChanged(int index)
 {
     QSettings s;
-    s.setValue("settings/current_category", index);
+    s.setValue("settings/enforced_category", index);
 }
 
 void MainWindow::setCurrentCategoryOptions(const QString &cat1, const QString &cat2, const QString &cat3, const QString &cat4)
@@ -2365,11 +2366,11 @@ void MainWindow::setCurrentCategoryOptions(const QString &cat1, const QString &c
     QSettings s;
     ui->comboBoxBleCurrentCategory->blockSignals(true);
     ui->comboBoxBleCurrentCategory->clear();
-    ui->comboBoxBleCurrentCategory->addItem(tr("Disable"), 0);
+    ui->comboBoxBleCurrentCategory->addItem(tr("Disabled"), 0);
     ui->comboBoxBleCurrentCategory->addItem(cat1, 1);
     ui->comboBoxBleCurrentCategory->addItem(cat2, 2);
     ui->comboBoxBleCurrentCategory->addItem(cat3, 3);
     ui->comboBoxBleCurrentCategory->addItem(cat4, 4);
-    ui->comboBoxBleCurrentCategory->setCurrentIndex(s.value("settings/current_category", 0).toInt());
+    ui->comboBoxBleCurrentCategory->setCurrentIndex(s.value("settings/enforced_category", 0).toInt());
     ui->comboBoxBleCurrentCategory->blockSignals(false);
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -408,6 +408,15 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     }
     ui->comboBoxSystrayIcon->blockSignals(false);
 
+    ui->comboBoxBleCurrentCategory->blockSignals(true);
+    ui->comboBoxBleCurrentCategory->addItem(tr("Disable"), 0);
+    ui->comboBoxBleCurrentCategory->addItem("1", 1);
+    ui->comboBoxBleCurrentCategory->addItem("2", 2);
+    ui->comboBoxBleCurrentCategory->addItem("3", 3);
+    ui->comboBoxBleCurrentCategory->addItem("4", 4);
+    ui->comboBoxBleCurrentCategory->setCurrentIndex(s.value("settings/current_category", 0).toInt());
+    ui->comboBoxBleCurrentCategory->blockSignals(false);
+
     ui->cbLoginPrompt->setDisabled(true);
     ui->cbPinForMMM->setDisabled(true);
     ui->cbStoragePrompt->setDisabled(true);
@@ -2125,6 +2134,11 @@ void MainWindow::onDeviceConnected()
         }
         wsClient->sendUserSettingsRequest();
         wsClient->sendBatteryRequest();
+        auto currentCategoryIndex = ui->comboBoxBleCurrentCategory->currentIndex();
+        if (currentCategoryIndex != 0)
+        {
+            wsClient->sendCurrentCategory(currentCategoryIndex);
+        }
     }
     displayBundleVersion();
     updateDeviceDependentUI();
@@ -2323,4 +2337,11 @@ void MainWindow::sendRequestNotes(int bundle)
         m_notesFetched = true;
         wsClient->sendFetchNotes();
     }
+}
+
+void MainWindow::on_comboBoxBleCurrentCategory_currentIndexChanged(int index)
+{
+    QSettings s;
+    s.setValue("settings/current_category", index);
+    qCritical() << "Category index: " << index;
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -415,6 +415,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     fillInitialCurrentCategories();
     connect(wsClient, &WSClient::displayUserCategories, this, &MainWindow::setCurrentCategoryOptions);
+    connect(wsClient, &WSClient::updateCurrentCategories, this, &MainWindow::setCurrentCategoryOptions);
 
     ui->cbLoginPrompt->setDisabled(true);
     ui->cbPinForMMM->setDisabled(true);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -199,6 +199,8 @@ private slots:
 
     void sendRequestNotes(int bundle);
 
+    void on_comboBoxBleCurrentCategory_currentIndexChanged(int index);
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -201,6 +201,8 @@ private slots:
 
     void on_comboBoxBleCurrentCategory_currentIndexChanged(int index);
 
+    void setCurrentCategoryOptions(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;
@@ -241,6 +243,8 @@ private:
     void displayMiniImportWarning();
 
     void fillBLEBrightnessComboBox(QComboBox * cb);
+
+    void fillInitialCurrentCategories();
 
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4078,8 +4078,11 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <layout class="QHBoxLayout" name="horizontalLayout_70">
                 <item>
                  <widget class="QLabel" name="label_bleCurrentCategory">
+                  <property name="toolTip">
+                   <string>when selected, you can set moolticute to set a given category upon device connection</string>
+                  </property>
                   <property name="text">
-                   <string>BLE current category</string>
+                   <string>Upon connection, force category:</string>
                   </property>
                  </widget>
                 </item>
@@ -4103,6 +4106,9 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                     <width>80</width>
                     <height>0</height>
                    </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>when selected, you can set moolticute to set a given category upon device connection</string>
                   </property>
                  </widget>
                 </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4097,7 +4097,14 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                  </spacer>
                 </item>
                 <item>
-                 <widget class="QComboBox" name="comboBoxBleCurrentCategory"/>
+                 <widget class="QComboBox" name="comboBoxBleCurrentCategory">
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4075,6 +4075,33 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                </layout>
               </item>
               <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_70">
+                <item>
+                 <widget class="QLabel" name="label_bleCurrentCategory">
+                  <property name="text">
+                   <string>BLE current category</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_60">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="comboBoxBleCurrentCategory"/>
+                </item>
+               </layout>
+              </item>
+              <item>
                <layout class="QHBoxLayout" name="horizontalLayout_43">
                 <item>
                  <widget class="QLabel" name="label_11">

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -373,6 +373,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::DELETE_DATA_FILE      , 0x003B},
         {MPCmd::DELETE_NOTE_FILE      , 0x003C},
         {MPCmd::GET_TOTP_CODE         , 0x0041},
+        {MPCmd::SET_CUR_CATEGORY      , 0x003E},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -169,6 +169,7 @@ public:
             DELETE_DATA_FILE    ,
             DELETE_NOTE_FILE    ,
             GET_TOTP_CODE       ,
+            SET_CUR_CATEGORY    ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -877,6 +877,14 @@ void WSClient::sendBatteryRequest()
     sendJsonData({{ "msg", "get_battery" }});
 }
 
+void WSClient::sendCurrentCategory(int category)
+{
+    QJsonObject o;
+    o["category"] = category;
+    sendJsonData({{ "msg", "enforce_current_category" },
+                  {"data", o}});
+}
+
 void WSClient::sendNiMHReconditioning()
 {
     sendJsonData({{ "msg", "nimh_reconditioning" }});

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -157,6 +157,7 @@ signals:
     void displayUploadBundleResult(bool success);
     void displayAvailableUsers(const QString& num);
     void displayUserCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
+    void updateCurrentCategories(const QString& cat1, const QString& cat2, const QString& cat3, const QString& cat4);
     void updateUserSettingsOnUI(const QJsonObject& userSettings);
     void deviceConnected();
     void deviceDisconnected();

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -114,6 +114,7 @@ public:
     void sendUserSettingsRequest();
     void sendLoadParams();
     void sendBatteryRequest();
+    void sendCurrentCategory(int category);
     void sendNiMHReconditioning();
     void sendSecurityChallenge(QString str);
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1523,6 +1523,11 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
             sendJsonMessage(oroot);
         });
     }
+    else if (root["msg"] == "enforce_current_category")
+    {
+        QJsonObject o = root["data"].toObject();
+        bleImpl->enforceCategory(o["category"].toInt());
+    }
     else
     {
         qDebug() << root["msg"] << " message have not implemented yet for BLE";

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1525,6 +1525,12 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     }
     else if (root["msg"] == "enforce_current_category")
     {
+        static constexpr int ENFORCE_CATEGORY_SUPPORT_FW = 9;
+        if (bleImpl->get_bundleVersion() < ENFORCE_CATEGORY_SUPPORT_FW)
+        {
+            qWarning() << "Enforce category is not supported in the current bundle version";
+            return;
+        }
         QJsonObject o = root["data"].toObject();
         bleImpl->enforceCategory(o["category"].toInt());
     }


### PR DESCRIPTION
![kép](https://user-images.githubusercontent.com/11043249/166316889-9275f059-8996-45ec-92e2-edbb9c8da638.png)
- If a category is selected setting it as current category, when BLE device is connected and unlocked.
- Using category names from connected BLE device's categories.