### PR TITLE
[BLE] Send BLE Name Request for the correct bundle version

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -486,6 +486,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(wsClient, &WSClient::hwMemoryChanged, this, &MainWindow::updateSerialInfos);
     connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::displayBundleVersion);
     connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::sendRequestNotes);
+    connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::onBundleVersionChanged);
 
     connect(wsClient, &WSClient::memMgmtModeFailed, this, &MainWindow::memMgmtModeFailed);
 
@@ -1835,6 +1836,14 @@ void MainWindow::displayBundleVersion()
     }
 }
 
+void MainWindow::onBundleVersionChanged(int bundle)
+{
+    if (wsClient->isMPBLE() && bundle >= Common::BLE_BUNDLE_WITH_BLE_NAME)
+    {
+        wsClient->sendBleNameRequest();
+    }
+}
+
 void MainWindow::updateBLEComboboxItems(QComboBox *cb, const QJsonObject& items)
 {
     cb->clear();
@@ -2157,10 +2166,6 @@ void MainWindow::onDeviceConnected()
         }
         wsClient->sendUserSettingsRequest();
         wsClient->sendBatteryRequest();
-        if (wsClient->get_bundleVersion() >= Common::BLE_BUNDLE_WITH_BLE_NAME)
-        {
-            wsClient->sendBleNameRequest();
-        }
     }
     displayBundleVersion();
     updateDeviceDependentUI();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -240,6 +240,8 @@ private:
 
     void displayBundleVersion();
 
+    void onBundleVersionChanged(int bundle);
+
     void updateBLEComboboxItems(QComboBox *cb, const QJsonObject& items);
 
     bool shouldUpdateItems(QJsonObject& cache, const QJsonObject& received);


### PR DESCRIPTION
When `onDeviceConnected` is called bundle version is not fetched yet.