### PR TITLE
[BLE] Remove zero bytes from end of BLE name setting

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1913,6 +1913,11 @@ void MPDeviceBleImpl::getBleName(const MessageHandlerCbData &cb)
             bleNameArr = DEFAULT_BLE_NAME.toUtf8();
             qWarning() << "Invalid character in BLE name";
         }
+        if (bleNameArr.contains(ZERO_BYTE))
+        {
+            // Cut zero bytes from the end of the array
+            bleNameArr = bleNameArr.left(bleNameArr.indexOf(ZERO_BYTE));
+        }
         cb(true, "", bleNameArr);
     });
 


### PR DESCRIPTION
Behavior changed between Qt5 and Qt6, QString(QByteArray) constructor is not cutting the zero bytes anymore, need to handle it.
https://bugreports.qt.io/browse/QTBUG-97451