### PR TITLE
[BLE] Fix get/setLoginParent/ChildNodeData

### DIFF
--- a/src/Mooltipass/MPNode.cpp
+++ b/src/Mooltipass/MPNode.cpp
@@ -334,36 +334,13 @@ QByteArray MPNode::getNodeFlags() const
     return data.mid(NODE_FLAG_ADDR_START, ADDRESS_LENGTH);
 }
 
-QByteArray MPNode::getLoginNodeData() const
-{
-    // return core data, excluding linked lists and flags
-    if (!isValid()) return QByteArray();
-    return data.mid(DATA_ADDR_START);
-}
-
-void MPNode::setLoginNodeData(const QByteArray &flags, const QByteArray &d)
-{
-    // overwrite core data, excluding linked lists
-    if (isValid())
-    {
-        data.replace(DATA_ADDR_START, pMesProt->getParentNodeSize()-DATA_ADDR_START, d);
-        data.replace(0, ADDRESS_LENGTH, flags);
-    }
-}
-
-QByteArray MPNode::getLoginChildNodeData() const
-{
-    // return core data, excluding linked lists and flags
-    if (!isValid()) return QByteArray();
-    return data.mid(LOGIN_CHILD_NODE_DATA_ADDR_START);
-}
-
 void MPNode::setLoginChildNodeData(const QByteArray &flags, const QByteArray &d)
 {
     // overwrite core data, excluding linked lists
     if (isValid())
     {
-        data.replace(LOGIN_CHILD_NODE_DATA_ADDR_START, pMesProt->getChildNodeSize()-LOGIN_CHILD_NODE_DATA_ADDR_START, d);
+        const int childNodeDataAddrStart = getLoginChildNodeDataAddrStart();
+        data.replace(childNodeDataAddrStart, pMesProt->getChildNodeSize()-childNodeDataAddrStart, d);
         data.replace(0, ADDRESS_LENGTH, flags);
     }
 }

--- a/src/Mooltipass/MPNode.h
+++ b/src/Mooltipass/MPNode.h
@@ -110,10 +110,11 @@ public:
     QByteArray getNodeFlags() const;
 
     // Access node core data
-    void setLoginNodeData(const QByteArray &flags, const QByteArray &d);
-    QByteArray getLoginNodeData() const;
+    virtual void setLoginNodeData(const QByteArray &flags, const QByteArray &d) = 0;
+    virtual QByteArray getLoginNodeData() const = 0;
     void setLoginChildNodeData(const QByteArray &flags, const QByteArray &d);
-    QByteArray getLoginChildNodeData() const;
+    virtual QByteArray getLoginChildNodeData() const = 0;
+    virtual int getLoginChildNodeDataAddrStart() = 0;
     void setDataNodeData(const QByteArray &flags, const QByteArray &d);
     QByteArray getDataNodeData() const;
     void setDataChildNodeData(const QByteArray &flags, const QByteArray &d);
@@ -170,7 +171,6 @@ protected:
 
     static constexpr int NEXT_DATA_ADDR_START = 2;
     static constexpr int DATA_CHILD_DATA_ADDR_START = 4;
-    static constexpr int LOGIN_CHILD_NODE_DATA_ADDR_START = 6;
     static constexpr int DATA_ADDR_START = 8;
 
     static constexpr int SERVICE_ADDR_START = 8;

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -35,7 +35,33 @@ bool MPNodeBLE::isValid() const
     }
 
     return (data.size() == PARENT_NODE_LENGTH && (NodeParent == type || NodeParentData == type)) ||
-           (data.size() == CHILD_NODE_LENGTH && (NodeChild == type || NodeChildData == type));
+            (data.size() == CHILD_NODE_LENGTH && (NodeChild == type || NodeChildData == type));
+}
+
+QByteArray MPNodeBLE::getLoginNodeData() const
+{
+    // return core data, excluding linked lists, flags and last child node used address
+    if (!isValid()) return QByteArray();
+    return data.mid(DATA_ADDR_START, LAST_CHILD_NODE_USED_ADDR_START - DATA_ADDR_START);
+}
+
+void MPNodeBLE::setLoginNodeData(const QByteArray &flags, const QByteArray &d)
+{
+    // overwrite core data, excluding linked lists and last child node used address
+    if (isValid())
+    {
+        const auto parentNodeSize = pMesProt->getParentNodeSize();
+        const auto bytesAfterLastUsed = parentNodeSize - LAST_CHILD_NODE_USED_ADDR_START;
+        data.replace(DATA_ADDR_START, parentNodeSize - DATA_ADDR_START - bytesAfterLastUsed, d);
+        data.replace(0, ADDRESS_LENGTH, flags);
+    }
+}
+
+QByteArray MPNodeBLE::getLoginChildNodeData() const
+{
+    // return core data, excluding linked lists, flags and pointed to child address
+    if (!isValid()) return QByteArray();
+    return data.mid(LOGIN_CHILD_NODE_DATA_ADDR_START);
 }
 
 QString MPNodeBLE::getService() const

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -15,6 +15,11 @@ public:
     bool isDataLengthValid() const override;
     bool isValid() const override;
 
+    QByteArray getLoginNodeData() const override;
+    void setLoginNodeData(const QByteArray &flags, const QByteArray &d) override;
+    QByteArray getLoginChildNodeData() const override;
+    int getLoginChildNodeDataAddrStart() override { return LOGIN_CHILD_NODE_DATA_ADDR_START; }
+
     QString getService() const override;
     void setService(const QString& service) override;
     QByteArray getStartDataCtr() const override;
@@ -74,6 +79,8 @@ protected:
     static constexpr int TOTP_CODE_SIZE = 468;
     static constexpr int KEY_AFTER_LENGTH = 2;
     static constexpr int POINTED_TO_CHILD_START = 6;
+    static constexpr int LAST_CHILD_NODE_USED_ADDR_START = 260;
+    static constexpr int LOGIN_CHILD_NODE_DATA_ADDR_START = 8;
     static constexpr char BLANK_CHAR = 0x01;
 };
 

--- a/src/Mooltipass/MPNodeMini.cpp
+++ b/src/Mooltipass/MPNodeMini.cpp
@@ -37,6 +37,30 @@ bool MPNodeMini::isValid() const
             (static_cast<quint8>(data[1]) & 0x20) == 0;
 }
 
+QByteArray MPNodeMini::getLoginNodeData() const
+{
+    // return core data, excluding linked lists and flags
+    if (!isValid()) return QByteArray();
+    return data.mid(DATA_ADDR_START);
+}
+
+void MPNodeMini::setLoginNodeData(const QByteArray &flags, const QByteArray &d)
+{
+    // overwrite core data, excluding linked lists
+    if (isValid())
+    {
+        data.replace(DATA_ADDR_START, pMesProt->getParentNodeSize()-DATA_ADDR_START, d);
+        data.replace(0, ADDRESS_LENGTH, flags);
+    }
+}
+
+QByteArray MPNodeMini::getLoginChildNodeData() const
+{
+    // return core data, excluding linked lists and flags
+    if (!isValid()) return QByteArray();
+    return data.mid(LOGIN_CHILD_NODE_DATA_ADDR_START);
+}
+
 QString MPNodeMini::getService() const
 {
     if (!isValid()) return QString();

--- a/src/Mooltipass/MPNodeMini.h
+++ b/src/Mooltipass/MPNodeMini.h
@@ -16,6 +16,11 @@ public:
     bool isDataLengthValid() const override;
     bool isValid() const override;
 
+    QByteArray getLoginNodeData() const override;
+    void setLoginNodeData(const QByteArray &flags, const QByteArray &d) override;
+    QByteArray getLoginChildNodeData() const override;
+    int getLoginChildNodeDataAddrStart() override { return LOGIN_CHILD_NODE_DATA_ADDR_START; }
+
     QString getService() const override;
     void setService(const QString& service) override;
     QByteArray getStartDataCtr() const override;
@@ -39,6 +44,7 @@ protected:
     static constexpr int PWD_ENC_LENGTH = 32;
     static constexpr int DATE_CREATED_ADDR_START = 30;
     static constexpr int DATE_LASTUSED_ADDR_START = 32;
+    static constexpr int LOGIN_CHILD_NODE_DATA_ADDR_START = 6;
 };
 
 #endif // MPNODEMINI_H


### PR DESCRIPTION
For parent node "last child node used addr" and for child node "pointed to child address" was included.