### PR TITLE
[BLE] Add last used child node and pointed to address check for import

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -129,6 +129,7 @@ const QString Common::SETTING_BT_LAYOUT_ENFORCE = "settings/enforce_bt_layout";
 const QString Common::SETTING_BT_LAYOUT_ENFORCE_VALUE = "settings/enforce_bt_layout_value";
 const QString Common::MMM_CREDENTIAL_STORE_FAILED = "Credential store failed";
 const QString Common::DUPLICATE_SERVICE_DETECTED = "Duplicate service detected";
+QByteArray Common::NOT_SET_ADDR = QByteArray{2, Common::ZERO_BYTE};
 
 static void _messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/Common.h
+++ b/src/Common.h
@@ -356,6 +356,7 @@ public:
     static const int BLE_BUNDLE_WITH_BLE_NAME = 9;
     static const int BLE_BUNDLE_WITH_MIRRORING = 11;
     static const char ZERO_BYTE = static_cast<char>(0x00);
+    static QByteArray NOT_SET_ADDR;
 };
 
 struct FidoCredential

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6782,6 +6782,9 @@ bool MPDevice::checkImportedLoginLastChildNodeUsedAddr()
         qCritical() << "Last child node used address is only available for BLE";
         return false;
     }
+
+    static QByteArray NOT_SET_ADDR = QByteArray{2, Common::ZERO_BYTE};
+
     for (auto* loginNode : qAsConst(loginNodes))
     {
         // If service is not tagged for merge it will be removed, so do not need to check
@@ -6796,8 +6799,8 @@ bool MPDevice::checkImportedLoginLastChildNodeUsedAddr()
                 if (serviceName == importedLoginNodes[i]->getService())
                 {
                     auto* importedLoginNode = static_cast<MPNodeBLE*>(importedLoginNodes[i]);
-                    // If last child node used address is different, need to find and set the correct address
-                    if (bleLoginNode->getLastChildNodeUsedAddr() != importedLoginNode->getLastChildNodeUsedAddr())
+                    // If the imported last child node used address is set, find the same login in local list
+                    if (NOT_SET_ADDR != importedLoginNode->getLastChildNodeUsedAddr())
                     {
                         // First find the login name of the last child node used from imported list
                         auto* importedLastUsedChildNode = findNodeWithAddressWithGivenParentInList(importedLoginChildNodes, importedLoginNode, importedLoginNode->getLastChildNodeUsedAddr(), 0);
@@ -6813,6 +6816,10 @@ bool MPDevice::checkImportedLoginLastChildNodeUsedAddr()
                                 bleLoginNode->setLastChildNodeUsedAddr(lastUsedChild->getAddress());
                             }
                         }
+                    }
+                    else if (NOT_SET_ADDR != bleLoginNode->getLastChildNodeUsedAddr())
+                    {
+                        bleLoginNode->setLastChildNodeUsedAddr(NOT_SET_ADDR);
                     }
                     break;
                 }

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -319,6 +319,7 @@ private:
     void startImportFileMerging(const MPDeviceProgressCb &progressCb, MessageHandlerCb cb, bool noDelete);
     bool checkImportedLoginNodes(const MessageHandlerCb &cb, Common::AddressType addrType);
     bool checkImportedDataNodes(const MessageHandlerCb &cb, Common::DataAddressType addrType);
+    bool checkImportedLoginLastChildNodeUsedAddr();
     void loadFreeAddresses(AsyncJobs *jobs, const QByteArray &addressFrom, bool discardFirstAddr, const MPDeviceProgressCb &cbProgress);
     void incrementNeededAddresses(MPNode::NodeType type);
     MPNode *findNodeWithAddressWithGivenParentInList(NodeList list,  MPNode *parent, const QByteArray &address, const quint32 virt_addr);

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -314,12 +314,13 @@ private:
     // Functions added by mathieu for MMM
     void memMgmtModeReadFlash(AsyncJobs *jobs, bool fullScan, const MPDeviceProgressCb &cbProgress, bool getCreds, bool getData, bool getDataChilds, bool getFido = false);
     MPNode *findNodeWithAddressInList(NodeList list, const QByteArray &address, const quint32 virt_addr = 0);
-    MPNode* findCredParentNodeGivenChildNodeAddr(const QByteArray &address, const quint32 virt_addr);
+    MPNode* findCredParentNodeGivenChildNodeAddr(const QByteArray &address, const quint32 virt_addr, bool isImportedList = false);
     void addWriteNodePacketToJob(AsyncJobs *jobs, const QByteArray &address, const QByteArray &data, std::function<void(void)> writeCallback);
     void startImportFileMerging(const MPDeviceProgressCb &progressCb, MessageHandlerCb cb, bool noDelete);
     bool checkImportedLoginNodes(const MessageHandlerCb &cb, Common::AddressType addrType);
     bool checkImportedDataNodes(const MessageHandlerCb &cb, Common::DataAddressType addrType);
     bool checkImportedLoginLastChildNodeUsedAddr();
+    bool checkImportedPointedToAddresses();
     void loadFreeAddresses(AsyncJobs *jobs, const QByteArray &addressFrom, bool discardFirstAddr, const MPDeviceProgressCb &cbProgress);
     void incrementNeededAddresses(MPNode::NodeType type);
     MPNode *findNodeWithAddressWithGivenParentInList(NodeList list,  MPNode *parent, const QByteArray &address, const quint32 virt_addr);

--- a/src/Mooltipass/MPNodeBLE.cpp
+++ b/src/Mooltipass/MPNodeBLE.cpp
@@ -285,3 +285,21 @@ QByteArray MPNodeBLE::getPointedToChildAddr() const
     if (nextVirtualAddressSet) return QByteArray();
     return data.mid(POINTED_TO_CHILD_START, ADDRESS_LENGTH);
 }
+
+QByteArray MPNodeBLE::getLastChildNodeUsedAddr() const
+{
+    if (!isValid()) return QByteArray();
+    if (nextVirtualAddressSet) return QByteArray();
+    return data.mid(LAST_CHILD_NODE_USED_ADDR_START, ADDRESS_LENGTH);
+}
+
+void MPNodeBLE::setLastChildNodeUsedAddr(const QByteArray &d)
+{
+    if (d.size() < 2)
+    {
+        qCritical() << "Invalid address for setLastChildNodeUsedAddr";
+        return;
+    }
+    data[LAST_CHILD_NODE_USED_ADDR_START] = d[0];
+    data[LAST_CHILD_NODE_USED_ADDR_START + 1] = d[1];
+}

--- a/src/Mooltipass/MPNodeBLE.h
+++ b/src/Mooltipass/MPNodeBLE.h
@@ -51,6 +51,9 @@ public:
     quint32 getPointedToChildVirtualAddress() const;
     QByteArray getPointedToChildAddr() const;
 
+    QByteArray getLastChildNodeUsedAddr() const;
+    void setLastChildNodeUsedAddr(const QByteArray &d);
+
     static constexpr int PARENT_NODE_LENGTH = 264;
     static constexpr int CHILD_NODE_LENGTH = 528;
     static constexpr int SERVICE_LENGTH = 252;


### PR DESCRIPTION
Check the addresses from the imported DB and find the correct service/login for them in the device's DB.