### PR TITLE
[BLE] Add option to correct serial number

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -357,6 +357,7 @@ public:
     static const int BLE_BUNDLE_WITH_MIRRORING = 11;
     static const int BLE_BUNDLE_WITH_MULT_DOMAINS = 11;
     static const char ZERO_BYTE = static_cast<char>(0x00);
+    static const int ALPHABET_SIZE = 26;
     static QByteArray NOT_SET_ADDR;
 };
 

--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -1971,6 +1971,26 @@ QString MPDeviceBleImpl::getBleNameFromArray(const QByteArray &arr) const
     return bleProt->toQString(arr);
 }
 
+void MPDeviceBleImpl::setSerialNumber(quint32 serialNum, std::function<void (bool)> cb)
+{
+    QByteArray serialNumArr = bleProt->toLittleEndianFromInt32(serialNum);
+    auto *jobs = new AsyncJobs(QString("Set Serial number"), this);
+    jobs->append(new MPCommandJob(mpDev, MPCmd::SET_SERIAL_NUMBER,
+                                  serialNumArr,
+                                  [this, serialNum, cb](const QByteArray &data, bool &) -> bool
+    {
+        if (bleProt->getFirstPayloadByte(data) != MSG_SUCCESS)
+        {
+            qWarning() << "Set serial number to: " << serialNum << " failed";
+            cb(false);
+            return false;
+        }
+        cb(true);
+        return true;
+    }));
+    mpDev->enqueueAndRunJob(jobs);
+}
+
 Common::SubdomainSelection MPDeviceBleImpl::getForceSubdomainSelection() const
 {
     QSettings s;

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -27,6 +27,7 @@ class MPDeviceBleImpl: public QObject
     QT_WRITABLE_PROPERTY(bool, bluetoothEnabled, false)
     QT_WRITABLE_PROPERTY(bool, knockDisabled, false)
     QT_WRITABLE_PROPERTY(bool, chargingStatus, false)
+    QT_WRITABLE_PROPERTY(quint32, platformSerialNumber, 0)
 
     enum UserSettingsMask : quint8
     {
@@ -280,6 +281,7 @@ private:
     static constexpr int FORCE_SUBDOMAIN_BUNDLE_VERSION = 8;
     static constexpr int SET_BLE_NAME_BUNDLE_VERSION = 9;
     static constexpr int POINTED_TO_ADDR_SIZE = 2;
+    static constexpr int PLATFORM_SERIAL_NUM_FIRST_BYTE = 16;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
     const QString DEFAULT_BLE_NAME = "Mooltipass Mini BLE";
 };

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -178,6 +178,8 @@ public:
     void getBleName(const MessageHandlerCbData &cb);
     QString getBleNameFromArray(const QByteArray& arr) const;
 
+    void setSerialNumber(quint32 serialNum, std::function<void(bool)> cb);
+
     Common::SubdomainSelection getForceSubdomainSelection() const;
 
 signals:

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -28,7 +28,6 @@
 #include "SettingsGuiHelper.h"
 #include "DeviceDetector.h"
 #include "SystemNotifications/SystemNotification.h"
-#include <limits>
 
 #include "qtcsv/stringdata.h"
 #include "qtcsv/reader.h"
@@ -491,6 +490,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     connect(wsClient, &WSClient::fwVersionChanged, this, &MainWindow::updateSerialInfos);
     connect(wsClient, &WSClient::hwSerialChanged, this, &MainWindow::updateSerialInfos);
     connect(wsClient, &WSClient::hwMemoryChanged, this, &MainWindow::updateSerialInfos);
+    connect(wsClient, &WSClient::platformSerialChanged, this, &MainWindow::updateSerialInfos);
     connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::displayBundleVersion);
     connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::sendRequestNotes);
     connect(wsClient, &WSClient::bundleVersionChanged, this, &MainWindow::onBundleVersionChanged);
@@ -975,7 +975,6 @@ void MainWindow::updateSerialInfos() {
         ui->labelAboutFwVersValue->setVisible(!wsClient->isMPBLE());
         ui->label_UserManual->setText(MANUAL_STRING.arg(wsClient->isMPBLE() ? BLE_MANUAL_URL : MINI_MANUAL_URL));
         ui->label_UserManual->show();
-        qCritical() << "Platform serial: " << wsClient->get_platformSerial();
         if (wsClient->isMPBLE() && serialNum > STARTING_NOT_FLASHED_SERIAL &&
                 wsClient->get_hwSerial() != wsClient->get_platformSerial())
         {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include "SettingsGuiHelper.h"
 #include "DeviceDetector.h"
 #include "SystemNotifications/SystemNotification.h"
+#include <limits>
 
 #include "qtcsv/stringdata.h"
 #include "qtcsv/reader.h"
@@ -132,6 +133,8 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     ui->widgetNotFlashedWarning->hide();
     ui->labelNotFlashedWarningIcon->setPixmap(AppGui::qtAwesome()->icon(fa::warning).pixmap(QSize(20, 20)));
+    ui->labelSerialNumberIncorrect->setStyleSheet("QLabel {color: blue;}");
+    connect(ui->labelSerialNumberIncorrect, &ClickableLabel::clicked, this, &MainWindow::onIncorrectSerialNumberClicked);
 
     ui->pbBleBattery->setStyleSheet("border: 1px solid black");
     ui->pbBleBattery->hide();
@@ -2416,4 +2419,17 @@ void MainWindow::onBleNameChanged(const QString &name)
     m_bleNameOriginal = name;
     ui->lineEditBleName->setText(name);
     checkSettingsChanged();
+}
+
+void MainWindow::onIncorrectSerialNumberClicked()
+{
+    bool ok = false;
+    int serialNum = QInputDialog::getInt(this, tr("Incorrect Serial Number"),
+                             tr("It looks like your device serial number doesn't match the one present on your device's case.\n") +
+                             tr("Please reach out to support@themooltipass.com for the right code to enter below"),
+                             0, 0, std::numeric_limits<int>::max(), 1, &ok);
+    if (ok)
+    {
+        qCritical() << "Serial num: " << serialNum;
+    }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2455,7 +2455,7 @@ void MainWindow::onSerialNumberChanged(bool success, int serialNumber)
     if (success)
     {
         wsClient->set_hwSerial(serialNumber);
-        if (wsClient->get_hwSerial() != wsClient->get_platformSerial())
+        if (wsClient->get_hwSerial() == wsClient->get_platformSerial())
         {
             QMessageBox::information(this, title, tr("Set serial number successfully."));
             ui->widgetNotFlashedWarning->hide();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -130,6 +130,9 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->labelAboutAuxMCU->setText(tr("Aux MCU version:"));
     ui->labelAboutMainMCU->setText(tr("Main MCU version:"));
 
+    ui->widgetNotFlashedWarning->hide();
+    ui->labelNotFlashedWarningIcon->setPixmap(AppGui::qtAwesome()->icon(fa::warning).pixmap(QSize(20, 20)));
+
     ui->pbBleBattery->setStyleSheet("border: 1px solid black");
     ui->pbBleBattery->hide();
 
@@ -957,7 +960,8 @@ void MainWindow::updateSerialInfos() {
     if(connected)
     {
         ui->labelAboutFwVersValue->setText(wsClient->get_fwVersion());
-        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : NONE_STRING);
+        auto serialNum = QString::number(wsClient->get_hwSerial());
+        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? serialNum : NONE_STRING);
         ui->labelAbouHwMemoryValue->setText(wsClient->get_hwMemory() > 0 ? tr("%1Mb").arg(wsClient->get_hwMemory()): NONE_STRING);
         displayMCUVersion(wsClient->isMPBLE());
         //When ble is detected not displaying fw version
@@ -965,6 +969,14 @@ void MainWindow::updateSerialInfos() {
         ui->labelAboutFwVersValue->setVisible(!wsClient->isMPBLE());
         ui->label_UserManual->setText(MANUAL_STRING.arg(wsClient->isMPBLE() ? BLE_MANUAL_URL : MINI_MANUAL_URL));
         ui->label_UserManual->show();
+        if (wsClient->isMPBLE() && serialNum > STARTING_NOT_FLASHED_SERIAL)
+        {
+            ui->widgetNotFlashedWarning->show();
+        }
+        else
+        {
+            ui->widgetNotFlashedWarning->hide();
+        }
     }
     else
     {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -213,7 +213,7 @@ private slots:
 
     void onIncorrectSerialNumberClicked();
 
-    void onSerialNumberChanged(bool success);
+    void onSerialNumberChanged(bool success, int serialNumber);
 
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -260,6 +260,8 @@ private:
 
     void fillInitialCurrentCategories();
 
+    bool validateSerialString(const QString& serialStr, uint& serialNum);
+
     Ui::MainWindow *ui = nullptr;
     QtAwesome* awesome;
 
@@ -323,6 +325,8 @@ private:
     static const QString BLE_MANUAL_URL;
     static const QString MINI_MANUAL_URL;
     static const QString BUNDLE_OUTDATED_TEXT;
+    static const QString SERIAL_STR_START;
+    static constexpr int SERIAL_NUM_LENGTH = 4;
 #ifdef Q_OS_MAC
     static constexpr int MAC_DEFAULT_HEIGHT = 500;
 #endif

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -211,6 +211,8 @@ private slots:
 
     void onBleNameChanged(const QString& name);
 
+    void onIncorrectSerialNumberClicked();
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -213,6 +213,8 @@ private slots:
 
     void onIncorrectSerialNumberClicked();
 
+    void onSerialNumberChanged(bool success);
+
 protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void keyReleaseEvent(QKeyEvent *event) override;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -322,6 +322,7 @@ private:
 #ifdef Q_OS_MAC
     static constexpr int MAC_DEFAULT_HEIGHT = 500;
 #endif
+    static constexpr int STARTING_NOT_FLASHED_SERIAL = 2000;
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3917,8 +3917,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>487</width>
-               <height>590</height>
+               <width>646</width>
+               <height>874</height>
               </rect>
              </property>
              <property name="autoFillBackground">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3345,10 +3345,12 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelSerialNumberIncorrect">
+                 <widget class="ClickableLabel" name="labelSerialNumberIncorrect">
                   <property name="font">
                    <font>
                     <pointsize>10</pointsize>
+                    <italic>false</italic>
+                    <underline>true</underline>
                    </font>
                   </property>
                   <property name="text">
@@ -5237,6 +5239,12 @@ Hint: keep your mouse positioned over an option to get more details.</string>
    <class>NotesManagement</class>
    <extends>QWidget</extends>
    <header>NotesManagement.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ClickableLabel</class>
+   <extends>QLabel</extends>
+   <header>ClickableLabel.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3249,7 +3249,10 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_15">
+            <layout class="QHBoxLayout" name="horizontalLayout_72">
+             <property name="spacing">
+              <number>6</number>
+             </property>
              <item>
               <widget class="QLabel" name="labelAbouHwSerial">
                <property name="sizePolicy">
@@ -3270,6 +3273,24 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </item>
              <item>
               <widget class="QLabel" name="labelAbouHwSerialValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
+                </size>
+               </property>
                <property name="font">
                 <font>
                  <pointsize>10</pointsize>
@@ -3279,6 +3300,77 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                 <string/>
                </property>
               </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="widgetNotFlashedWarning" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_73">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="labelNotFlashedWarningIcon">
+                  <property name="maximumSize">
+                   <size>
+                    <width>25</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelSerialNumberIncorrect">
+                  <property name="font">
+                   <font>
+                    <pointsize>10</pointsize>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>Incorrect serial number</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_62">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </item>
@@ -3573,6 +3665,16 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               </widget>
              </item>
              <item>
+              <widget class="QFrame" name="frame">
+               <property name="frameShape">
+                <enum>QFrame::StyledPanel</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QLabel" name="UIDRequestResultLabel">
                <property name="enabled">
                 <bool>true</bool>
@@ -3813,8 +3915,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>646</width>
-               <height>874</height>
+               <width>487</width>
+               <height>590</height>
               </rect>
              </property>
              <property name="autoFillBackground">

--- a/src/MessageProtocol/MessageProtocolBLE.cpp
+++ b/src/MessageProtocol/MessageProtocolBLE.cpp
@@ -377,6 +377,7 @@ void MessageProtocolBLE::fillCommandMapping()
         {MPCmd::WAKE_UP_DEVICE        , 0x003F},
         {MPCmd::SET_BLE_NAME          , 0x0040},
         {MPCmd::GET_BLE_NAME          , 0x0042},
+        {MPCmd::SET_SERIAL_NUMBER     , 0x003A},
         {MPCmd::CMD_DBG_OPEN_DISP_BUFFER    , 0x8001},
         {MPCmd::CMD_DBG_SEND_TO_DISP_BUFFER , 0x8002},
         {MPCmd::CMD_DBG_CLOSE_DISP_BUFFER   , 0x8003},

--- a/src/MooltipassCmds.h
+++ b/src/MooltipassCmds.h
@@ -173,6 +173,7 @@ public:
             WAKE_UP_DEVICE      ,
             SET_BLE_NAME        ,
             GET_BLE_NAME        ,
+            SET_SERIAL_NUMBER   ,
             CMD_DBG_MESSAGE     ,
             CMD_DBG_OPEN_DISP_BUFFER    ,
             CMD_DBG_SEND_TO_DISP_BUFFER ,

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -206,6 +206,10 @@ void WSClient::onTextMessageReceived(const QString &message)
             set_auxMCUVersion(o["aux_mcu_version"].toString());
             set_mainMCUVersion(o["main_mcu_version"].toString());
             set_bundleVersion(o["bundle_version"].toInt());
+            if (o.contains("platform_serial_number"))
+            {
+                set_platformSerial(o["platform_serial_number"].toInt());
+            }
         }
         else
         {
@@ -607,7 +611,7 @@ void WSClient::onTextMessageReceived(const QString &message)
     else if (rootobj["msg"] == "set_serial_number")
     {
         QJsonObject o = rootobj["data"].toObject();
-        emit serialNumberChanged(o.value("success").toBool());
+        emit serialNumberChanged(o.value("success").toBool(), o["serial_number"].toInt());
     }
 }
 

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -601,8 +601,13 @@ void WSClient::onTextMessageReceived(const QString &message)
     }
     else if (rootobj["msg"] == "get_ble_name" || rootobj["msg"] == "set_ble_name")
     {
-         QJsonObject o = rootobj["data"].toObject();
-         emit bleNameChanged(o.value("name").toString());
+        QJsonObject o = rootobj["data"].toObject();
+        emit bleNameChanged(o.value("name").toString());
+    }
+    else if (rootobj["msg"] == "set_serial_number")
+    {
+        QJsonObject o = rootobj["data"].toObject();
+        emit serialNumberChanged(o.value("success").toBool());
     }
 }
 
@@ -920,6 +925,13 @@ void WSClient::sendSetBleName(QString name)
 {
     sendJsonData({{ "msg", "set_ble_name" },
                   { "data", QJsonObject{ {"name", name } } }
+                 });
+}
+
+void WSClient::sendSetSerialNumber(uint serialNum)
+{
+    sendJsonData({{ "msg", "set_serial_number" },
+                  { "data", QJsonObject{ {"serial_number", static_cast<double>(serialNum) } } }
                  });
 }
 

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -123,6 +123,7 @@ public:
     void sendNiMHReconditioning();
     void sendSecurityChallenge(QString str);
     void sendSetBleName(QString name);
+    void sendSetSerialNumber(uint serialNum);
 
     void sendChangedParam(const QString& paramName, int value);
 
@@ -187,6 +188,8 @@ signals:
     void fileDeleted(bool success, const QString& file);
 
     void bleNameChanged(const QString& name);
+
+    void serialNumberChanged(bool success);
 
 public slots:
     void sendJsonData(const QJsonObject &data);

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -51,6 +51,8 @@ class WSClient: public QObject
     QT_WRITABLE_PROPERTY(int, bundleVersion, 0)
     QT_WRITABLE_PROPERTY(bool, advancedMenu, false)
 
+    QT_WRITABLE_PROPERTY(quint32, platformSerial, 0)
+
 public:
     explicit WSClient(QObject *parent = nullptr);
     ~WSClient();
@@ -189,7 +191,7 @@ signals:
 
     void bleNameChanged(const QString& name);
 
-    void serialNumberChanged(bool success);
+    void serialNumberChanged(bool success, int serialNumber);
 
 public slots:
     void sendJsonData(const QJsonObject &data);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -635,6 +635,7 @@ void WSServerCon::resetDevice(MPDevice *dev)
         connect(mpBle, &MPDeviceBleImpl::chargingStatusChanged, this, &WSServerCon::sendChargingStatus);
         connect(mpBle, &MPDeviceBleImpl::nimhReconditionFinished, this, &WSServerCon::sendNimhReconditionFinished);
         connect(mpBle, &MPDeviceBleImpl::changeBleName, this, &WSServerCon::sendBleName);
+        connect(mpBle, &MPDeviceBleImpl::platformSerialNumberChanged, this, &WSServerCon::sendVersion);
         connect(mpdevice, &MPDevice::displayMiniImportWarning, this, &WSServerCon::sendMiniImportWarning);
     }
 }

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1578,6 +1578,23 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
             sendJsonMessage(oroot);
         });
     }
+    else if (root["msg"] == "set_serial_number")
+    {
+        QJsonObject o = root["data"].toObject();
+        auto serialNum = o["serial_number"].toDouble();
+        bleImpl->setSerialNumber(serialNum,
+                [this, root](bool success)
+        {
+            if (!WSServer::Instance()->checkClientExists(this))
+                return;
+
+            QJsonObject ores;
+            QJsonObject oroot = root;
+            ores["success"] = success;
+            oroot["data"] = ores;
+            sendJsonMessage(oroot);
+        });
+    }
     else
     {
         qDebug() << root["msg"] << " message have not implemented yet for BLE";

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -751,6 +751,7 @@ void WSServerCon::sendVersion()
             data["aux_mcu_version"] = bleImpl->get_auxMCUVersion();
             data["main_mcu_version"] = bleImpl->get_mainMCUVersion();
             data["bundle_version"] = bleImpl->get_bundleVersion();
+            data["platform_serial_number"] = static_cast<qint64>(bleImpl->get_platformSerialNumber());
         }
     }
     sendJsonMessage({{ "msg", "version_changed" }, { "data", data }});

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1583,7 +1583,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
         QJsonObject o = root["data"].toObject();
         auto serialNum = o["serial_number"].toDouble();
         bleImpl->setSerialNumber(serialNum,
-                [this, root](bool success)
+                [this, root, serialNum](bool success)
         {
             if (!WSServer::Instance()->checkClientExists(this))
                 return;
@@ -1591,6 +1591,7 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
             QJsonObject ores;
             QJsonObject oroot = root;
             ores["success"] = success;
+            ores["serial_number"] = serialNum;
             oroot["data"] = ores;
             sendJsonMessage(oroot);
         });


### PR DESCRIPTION
For devices with above 2000 serial number compare serial number with platform serial, if they are not equal display error message and option to set the correct serial number.
![setSerialDemo](https://user-images.githubusercontent.com/11043249/195673084-8c759afa-b545-479e-8a52-06139d65b900.gif)
