### PR TITLE
[BLE] Fetch notes on user change

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -290,7 +290,7 @@ void MPDeviceBleImpl::deleteFile(QString file, bool isNote, std::function<void (
 
 void MPDeviceBleImpl::fetchNotes()
 {
-    if (mpDev->get_status() != Common::Unlocked)
+    if (mpDev->get_status() != Common::Unlocked && mpDev->get_status() != Common::MMMMode)
     {
         if (AppDaemon::isDebugDev())
         {
@@ -336,6 +336,11 @@ void MPDeviceBleImpl::fetchNotes(AsyncJobs *jobs, QByteArray addr)
                             return true;
                         }
     ));
+}
+
+void MPDeviceBleImpl::fetchNotesLater()
+{
+    createAndAddCustomJob("Fetch notes", [this](){fetchNotes();});
 }
 
 void MPDeviceBleImpl::getNoteNode(QString note, std::function<void (bool, QString, QString, QByteArray)> cb)

--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -70,6 +70,7 @@ public:
 
     void fetchNotes();
     void fetchNotes(AsyncJobs *jobs, QByteArray addr);
+    void fetchNotesLater();
     QList<QString> getNotes() const { return m_notes; }
     void getNoteNode(QString note, std::function<void(bool, QString, QString, QByteArray)> cb);
 


### PR DESCRIPTION
Fetching notes when change numbers set.

**Other issue fixed**: When deleting note from Files Management we need to fetch notes after exiting.
I am fetching notes after MC exited from MMM, but the new status message have not received at this point, so I needed to enable fetchNotes for MMMMode status too.