### PR TITLE
[Mini] Fix files upload for Qt6

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4917,7 +4917,7 @@ void MPDevice::setDataNode(QString service, const QByteArray &nodeData,
     if (!isBLE())
     {
         currentDataNode.resize(MP_DATA_HEADER_SIZE);
-        qToBigEndian(nodeData.size(), (quint8 *)currentDataNode.data());
+        qToBigEndian<quint32>(nodeData.size(), (quint8 *)currentDataNode.data());
     }
     currentDataNode.append(nodeData);
 


### PR DESCRIPTION
In Qt6 without telling quint32 explicitly, the size is {0x00,0x00,0x00,0x00} every time and the uploaded data is incorrect.