### PR TITLE
[BLE] Fix adding new credential after linking

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -185,7 +185,7 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     connect(ui->credentialTreeView, &CredentialView::collapsed, this, &CredentialsManagement::onItemCollapsed);
     connect(ui->pushButtonExpandAll, &QPushButton::clicked, ui->credentialTreeView, &CredentialView::onChangeExpandedState);
     connect(ui->credentialTreeView, &CredentialView::expandedStateChanged, this, &CredentialsManagement::onExpandedStateChanged);
-    connect(m_pCredModel, &CredentialModel::selectLoginItem, this, &CredentialsManagement::onSelectLoginItem, Qt::QueuedConnection);
+    connect(m_pCredModel, &CredentialModel::selectLoginItem, this, &CredentialsManagement::onSelectLoginItem);
 
     m_tSelectLoginTimer.setInterval(50);
     m_tSelectLoginTimer.setSingleShot(true);
@@ -533,6 +533,11 @@ void CredentialsManagement::saveSelectedCredential()
 
     if (currentSelectionIndex.isValid())
         saveCredential(currentSelectionIndex);
+
+    if (!m_credentialLinkedAddr.isEmpty())
+    {
+        m_credentialLinkedAddr.clear();
+    }
 }
 
 void CredentialsManagement::saveSelectedTOTP()


### PR DESCRIPTION
There was an isseu when we linked a credential and wanted to add a new one in MMM instead the typed password it used the previous link. This issue is fixed with clearing the linkedAddress after confirming the linking.

Also fixing QueuedConnection issue on Qt6.