### PR TITLE
[BLE] Fix saving credential without password Qt6

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -639,6 +639,7 @@ void CredentialsManagement::saveChanges()
 
 void CredentialsManagement::keyPressEvent(QKeyEvent *event)
 {
+    QWidget::keyPressEvent(event);
     if (wsClient->get_memMgmtMode() || !wsClient->isMPBLE())
     {
         return;
@@ -652,6 +653,7 @@ void CredentialsManagement::keyPressEvent(QKeyEvent *event)
 
 void CredentialsManagement::keyReleaseEvent(QKeyEvent *event)
 {
+    QWidget::keyReleaseEvent(event);
     if (wsClient->get_memMgmtMode() || !wsClient->isMPBLE())
     {
         return;

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -54,8 +54,10 @@ public:
 public slots:
     bool confirmDiscardUneditedCredentialChanges(const QModelIndex &proxyIndex = {});
     void saveChanges();
-    void keyPressEvent(QKeyEvent* event);
-    void keyReleaseEvent(QKeyEvent* event);
+
+protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
 
 private slots:
     void enableCredentialsManagement(bool);

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -54,14 +54,14 @@ border-right: none;
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="addCredLoginInput">
+         <widget class="SimpleLineEdit" name="addCredLoginInput">
           <property name="maxLength">
            <number>62</number>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLineEdit" name="addCredServiceInput">
+         <widget class="SimpleLineEdit" name="addCredServiceInput">
           <property name="maxLength">
            <number>57</number>
           </property>
@@ -1020,6 +1020,11 @@ border-right: none;
   </customwidget>
   <customwidget>
    <class>LockedPasswordLineEdit</class>
+   <extends>SimpleLineEdit</extends>
+   <header>PasswordLineEdit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>SimpleLineEdit</class>
    <extends>QLineEdit</extends>
    <header>PasswordLineEdit.h</header>
   </customwidget>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2391,6 +2391,7 @@ void MainWindow::displayNotePage()
 
 void MainWindow::keyPressEvent(QKeyEvent *event)
 {
+    QMainWindow::keyPressEvent(event);
     if (event->key() == Qt::Key_Control)
     {
         DeviceDetector::instance().shiftPressed();
@@ -2403,6 +2404,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 
 void MainWindow::keyReleaseEvent(QKeyEvent *event)
 {
+    QMainWindow::keyReleaseEvent(event);
     if (event->key() == Qt::Key_Control)
     {
         DeviceDetector::instance().shiftReleased();

--- a/src/PasswordLineEdit.cpp
+++ b/src/PasswordLineEdit.cpp
@@ -48,7 +48,7 @@
     "}"
 
 PasswordLineEdit::PasswordLineEdit(QWidget* parent):
-    QLineEdit(parent),
+    SimpleLineEdit(parent),
     m_passwordProfilesModel(nullptr),
     m_passwordOptionsPopup(nullptr)
 
@@ -514,4 +514,18 @@ void LockedPasswordLineEdit::modifyLinkAction(bool isLink /*= true*/, bool remov
     {
         addAction(pwdAction, QLineEdit::TrailingPosition);
     }
+}
+
+SimpleLineEdit::SimpleLineEdit(QWidget *parent)
+    : QLineEdit{parent}
+{
+
+}
+
+void SimpleLineEdit::keyReleaseEvent(QKeyEvent *event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QLineEdit::keyReleaseEvent(event);
+#endif
+    QWidget::keyReleaseEvent(event);
 }

--- a/src/PasswordLineEdit.h
+++ b/src/PasswordLineEdit.h
@@ -70,7 +70,24 @@ private:
 
 
 class PasswordOptionsPopup;
-class PasswordLineEdit : public QLineEdit
+
+/**
+ * @brief The SimpleLineEdit class
+ * keyReleaseEvent is overwritten for QLineEdit in Qt6, but overwritten
+ * parent function is not called, so event is not delegated from QLineEdit,
+ * to fix this we call keyReleaseEvent for parent (QWidget) here.
+ */
+class SimpleLineEdit : public QLineEdit
+{
+    Q_OBJECT
+public:
+    SimpleLineEdit(QWidget* parent = nullptr);
+
+protected:
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
+};
+
+class PasswordLineEdit : public SimpleLineEdit
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
### Issue:
When I wanted to save a credential without password and one of the QLineEdit widget is in the focus then the Save button is enabled even after Alt key is released.
In Qt6 the keyReleaseEvent is not received in CredentialsWidget.
### Fix:
[QLineEdit keyReleaseEvent](https://doc.qt.io/qt-6/qlineedit.html#keyReleaseEvent) was overwritten in Qt6. In Qt5 and before this was handled in event function.
The problem in Qt6 they are not calling keyReleaseEvent's parent function, so the event is not delegated to the parent classes, therefor in CredentialsWidget we are not getting this event.
I created a new subclass (SimpleLineEdit) where I am calling the parent's (QWidget) keyReleaseEvent function from the overwritten one.
I am using this SimpleLineEdit for the adding credentials UIs.