### PR TITLE
add disable TLD check option

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1412,7 +1412,7 @@ void CredentialsManagement::checkLinkingOnLoginSelected(const QModelIndex &srcIn
     }
 }
 
-QString CredentialsManagement::processMultipleDomainsInput(const QString& service, const QString &domains)
+QString CredentialsManagement::processMultipleDomainsInput(const QString& service, const QString &domains, const bool disable_tld_check)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     auto splitBehavior = QString::SkipEmptyParts;
@@ -1435,7 +1435,7 @@ QString CredentialsManagement::processMultipleDomainsInput(const QString& servic
             domain.prepend('.');
         }
         ParseDomain dom(serviceDomain + domain);
-        if (domain == dom.tld())
+        if (disable_tld_check || domain == dom.tld())
         {
             validDomains.append(domain);
         }
@@ -1677,13 +1677,15 @@ void CredentialsManagement::onTreeViewContextMenuRequested(const QPoint& pos)
                                 serviceNameChanged = true;
                             }
                         }
+                        QSettings s;
                         bool ok = false;
+                        bool disable_tld_check = s.value("settings/disable_tld_check", false).toBool();
                         QString text = QInputDialog::getText(this, tr("Multiple Domains for %1").arg(pServiceItem->name()),
                                                                  tr("Enter comma separated domain extensions:"), QLineEdit::Normal,
                                                                  defaultDomains, &ok);
                         if (ok)
                         {
-                            text = processMultipleDomainsInput(serviceName, text);
+                            text = processMultipleDomainsInput(serviceName, text, disable_tld_check);
                             if (!text.isEmpty())
                             {
                                 pServiceItem->setMultipleDomains(text);

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -142,7 +142,7 @@ private:
 
     void checkLinkingOnLoginSelected(const QModelIndex &srcIndex);
 
-    QString processMultipleDomainsInput(const QString& service, const QString &domains);
+    QString processMultipleDomainsInput(const QString& service, const QString &domains, const bool disable_tld_check);
 
     bool isUICategoryClean() const;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -656,6 +656,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
 
     //Check is ssh agent opt has to be checked
     ui->checkBoxSSHAgent->setChecked(s.value("settings/auto_start_ssh").toBool());
+    ui->checkBoxTLDCheck->setChecked(s.value("settings/disable_tld_check").toBool());
     ui->lineEditSshArgs->setText(s.value("settings/ssh_args").toString());
 
     ui->scrollArea->setStyleSheet("QScrollArea { background-color:transparent; }");
@@ -1453,6 +1454,12 @@ void MainWindow::on_checkBoxSSHAgent_stateChanged(int)
 {
     QSettings s;
     s.setValue("settings/auto_start_ssh", ui->checkBoxSSHAgent->isChecked());
+}
+
+void MainWindow::on_checkBoxTLDCheck_stateChanged(int)
+{
+    QSettings s;
+    s.setValue("settings/disable_tld_check", ui->checkBoxTLDCheck->isChecked()); 
 }
 
 void MainWindow::on_pushButtonExportFile_clicked()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -128,6 +128,7 @@ private slots:
     void on_pushButtonAutoStart_clicked();
 
     void on_checkBoxSSHAgent_stateChanged(int arg1);
+    void on_checkBoxTLDCheck_stateChanged(int arg1);
 
     void on_pushButtonExportFile_clicked();
     void on_pushButtonImportFile_clicked();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>1120</height>
+    <height>632</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1014</width>
-             <height>1721</height>
+             <width>770</width>
+             <height>882</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3901,7 +3901,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <x>0</x>
                <y>0</y>
                <width>646</width>
-               <height>941</height>
+               <height>874</height>
               </rect>
              </property>
              <property name="autoFillBackground">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>1120</height>
+    <height>632</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1014</width>
-             <height>1721</height>
+             <width>770</width>
+             <height>882</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3930,7 +3930,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <x>0</x>
                <y>0</y>
                <width>646</width>
-               <height>941</height>
+               <height>874</height>
               </rect>
              </property>
              <property name="autoFillBackground">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3879,6 +3879,35 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <number>120</number>
           </property>
           <item>
+            <widget class="QLabel" name="label_31">
+             <property name="font">
+              <font>
+               <pointsize>12</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Moolticute Settings</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_17">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          <item>
            <widget class="QScrollArea" name="scrollAreaMCSettings">
             <property name="styleSheet">
              <string notr="true">QScrollArea { background-color:red }</string>
@@ -4583,35 +4612,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </layout>
             </widget>
            </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_31">
-            <property name="font">
-             <font>
-              <pointsize>12</pointsize>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Moolticute Settings</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_17">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>10</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3879,34 +3879,34 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <number>120</number>
           </property>
           <item>
-            <widget class="QLabel" name="label_31">
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Moolticute Settings</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_17">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>10</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
+           <widget class="QLabel" name="label_31">
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Moolticute Settings</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_17">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item>
            <widget class="QScrollArea" name="scrollAreaMCSettings">
             <property name="styleSheet">
@@ -3982,6 +3982,19 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_17">
                 <item>
+                 <widget class="QLabel" name="label_32">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>View Daemon Logs</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <spacer name="horizontalSpacer_21">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
@@ -4021,19 +4034,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                   </property>
                   <property name="text">
                    <string>Start Moolticute with the computer: Enabled</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_32">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>View Daemon Logs</string>
                   </property>
                  </widget>
                 </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>632</height>
+    <height>1120</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>770</width>
-             <height>882</height>
+             <width>1014</width>
+             <height>1721</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3930,7 +3930,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <x>0</x>
                <y>0</y>
                <width>646</width>
-               <height>874</height>
+               <height>941</height>
               </rect>
              </property>
              <property name="autoFillBackground">
@@ -3982,7 +3982,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_17">
                 <item>
-                 <widget class="QLabel" name="label_32">
+                 <widget class="QLabel" name="labelAutoStart">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
                     <horstretch>0</horstretch>
@@ -3990,7 +3990,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string>View Daemon Logs</string>
+                   <string>Start Moolticute with the computer: Enabled</string>
                   </property>
                  </widget>
                 </item>
@@ -4025,7 +4025,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_16">
                 <item>
-                 <widget class="QLabel" name="labelAutoStart">
+                 <widget class="QLabel" name="label_32">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
                     <horstretch>0</horstretch>
@@ -4033,7 +4033,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                    </sizepolicy>
                   </property>
                   <property name="text">
-                   <string>Start Moolticute with the computer: Enabled</string>
+                   <string>View Daemon Logs</string>
                   </property>
                  </widget>
                 </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>632</height>
+    <height>1120</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>770</width>
-             <height>882</height>
+             <width>1014</width>
+             <height>1721</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3879,35 +3879,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <number>120</number>
           </property>
           <item>
-           <widget class="QLabel" name="label_31">
-            <property name="font">
-             <font>
-              <pointsize>12</pointsize>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Moolticute Settings</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_17">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>10</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
            <widget class="QScrollArea" name="scrollAreaMCSettings">
             <property name="styleSheet">
              <string notr="true">QScrollArea { background-color:red }</string>
@@ -3930,7 +3901,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <x>0</x>
                <y>0</y>
                <width>646</width>
-               <height>874</height>
+               <height>941</height>
               </rect>
              </property>
              <property name="autoFillBackground">
@@ -3982,19 +3953,6 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_17">
                 <item>
-                 <widget class="QLabel" name="labelAutoStart">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>Start Moolticute with the computer: Enabled</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
                  <spacer name="horizontalSpacer_21">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
@@ -4024,6 +3982,19 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_16">
+                <item>
+                 <widget class="QLabel" name="labelAutoStart">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Start Moolticute with the computer: Enabled</string>
+                  </property>
+                 </widget>
+                </item>
                 <item>
                  <widget class="QLabel" name="label_32">
                   <property name="sizePolicy">
@@ -4060,6 +4031,37 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                   </property>
                   <property name="text">
                    <string>View</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_15">
+                <item>
+                 <widget class="QLabel" name="label_27">
+                  <property name="text">
+                   <string>Allow to use invalid or private TLDs</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_63">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="checkBoxTLDCheck">
+                  <property name="text">
+                   <string>Disable TLD check</string>
                   </property>
                  </widget>
                 </item>
@@ -4581,6 +4583,35 @@ Hint: keep your mouse positioned over an option to get more details.</string>
              </layout>
             </widget>
            </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_31">
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Moolticute Settings</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_17">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>10</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
fix #1100 

It adds a new config option checkbox and skips TLD validation when setting is enabled.