### PR TITLE
[BLE] Display when entered multiple domain is invalid

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -31,6 +31,9 @@
 #include "SettingsGuiBLE.h"
 #include "ParseDomain.h"
 
+const QString CredentialsManagement::INVALID_DOMAIN_TEXT =
+        tr("The following domains are invalid or private: <b><ul><li>%1</li></ul></b>They are not saved.");
+
 CredentialsManagement::CredentialsManagement(QWidget *parent) :
     QWidget(parent), ui(new Ui::CredentialsManagement), m_pAddedLoginItem(nullptr)
 {
@@ -1421,6 +1424,7 @@ QString CredentialsManagement::processMultipleDomainsInput(const QString& servic
 #endif
     auto domainList = domains.split(MULT_DOMAIN_SEPARATOR, splitBehavior);
     QStringList validDomains;
+    QStringList invalidDomains;
     QString result = "";
     auto serviceDomain = service;
     if (serviceDomain.contains('.'))
@@ -1442,7 +1446,13 @@ QString CredentialsManagement::processMultipleDomainsInput(const QString& servic
         else
         {
             qWarning() << "The following domain is not valid: " << domain;
+            invalidDomains.append(domain);
         }
+    }
+    if (!invalidDomains.isEmpty())
+    {
+        QMessageBox::information(this, tr("Invalid domain"),
+                                INVALID_DOMAIN_TEXT.arg(invalidDomains.join("</li><li>")));
     }
     return validDomains.join(MULT_DOMAIN_SEPARATOR);
 }

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -178,6 +178,7 @@ private:
     static constexpr int MINI_PASSWORD_LENGTH = 31;
     static constexpr int BLE_PASSWORD_LENGTH = 64;
     static constexpr char MULT_DOMAIN_SEPARATOR = ',';
+    static const QString INVALID_DOMAIN_TEXT;
 
 signals:
     void wantEnterMemMode();


### PR DESCRIPTION
Issue was mentioned here: https://github.com/mooltipass/moolticute/issues/1100#issuecomment-1381945658
When a private or invalid domain was entered for multiple domains during save these were discarded without any notification.
With this fix I display a dialog, where showing these not saved domains:
![kép](https://user-images.githubusercontent.com/11043249/213874062-c7d95dfa-e8cd-4d21-98e3-f3413c3b234e.png)
