### PR TITLE
Generate Exec in moolticute.desktop during build

### DIFF
--- a/data/moolticute.desktop
+++ b/data/moolticute.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Moolticute
 Comment=Start Moolticute daemon and App
-Exec=/usr/bin/moolticute
+Exec=PREFIX/bin/moolticute
 Icon=moolticute
 Terminal=false
 Categories=Utility;

--- a/gui.pro
+++ b/gui.pro
@@ -211,8 +211,9 @@ unix {
     INSTALLS += target
 
     # install the desktop files
+
     xdgdesktop.path = $$PREFIX/share/applications
-    xdgdesktop.files += $$PWD/data/moolticute.desktop
+    xdgdesktop.extra = "sed 's|PREFIX|$${PREFIX}|' $$PWD/data/moolticute.desktop > $(INSTALL_ROOT)$$xdgdesktop.path/moolticute.desktop"
     INSTALLS += xdgdesktop
 
     # install icons


### PR DESCRIPTION
To be merged after #1130, otherwise builds for the debian package will be broken (`PREFIX` will not be replaced).

Depending on how moolticute is installed or which distribution one uses, the moolticute executable might not be located in `/usr/bin`. For example, the nix package manager installes packages under `/nix/store`. This would also fix manual installs in `/usr/local`.