### PR TITLE
[BLE] Fix multiple low battery notification

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -302,6 +302,15 @@ private:
 
     bool m_notesFetched = false;
 
+    enum class BatteryNotiStatus
+    {
+        NO_STATUS,
+        VALID_BATTERY_RECIEVED,
+        LOW_BATTERY_DISPLAYED
+    };
+
+    BatteryNotiStatus m_firstBatteryPctReceived = BatteryNotiStatus::NO_STATUS;
+
     bool m_computerUnlocked = true;
     struct LockUnlockItem
     {


### PR DESCRIPTION
Only send low battery notification if a valid battery % was received earlier.
I assume BT reconnections caused #1034, this logic would prevent the multiple notifications.