### PR TITLE
[BLE] Send response to inform_(un)lock, lock_device, fix #1075

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -8606,17 +8606,17 @@ void MPDevice::lockDevice(const MessageHandlerCb &cb)
     const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
     jobs->append(new MPCommandJob(this, MPCmd::LOCK_DEVICE, afterFn));
 
+    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &)
+    {
+        qInfo() << "Lock device was successful.";
+        cb(true, "");
+    });
+
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
     {
         Q_UNUSED(failedJob);
         qCritical() << "Failed to lock device!";
         cb(false, {});
-    });
-
-    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &)
-    {
-        qInfo() << "Lock device was successful.";
-        cb(true, "");
     });
 
     jobsQueue.enqueue(jobs);

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -8613,6 +8613,12 @@ void MPDevice::lockDevice(const MessageHandlerCb &cb)
         cb(false, {});
     });
 
+    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &)
+    {
+        qInfo() << "Lock device was successful.";
+        cb(true, "");
+    });
+
     jobsQueue.enqueue(jobs);
     runAndDequeueJobs();
 }
@@ -8628,6 +8634,12 @@ void MPDevice::informLocked(const MessageHandlerCb &cb)
     {
         exitMemMgmtMode();
     }
+
+    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &)
+    {
+        qInfo() << "Inform locked was successful.";
+        cb(true, "");
+    });
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
     {
@@ -8646,6 +8658,13 @@ void MPDevice::informUnlocked(const MessageHandlerCb &cb)
 
     const auto afterFn = [](const QByteArray &, bool &) -> bool { return true; };
     jobs->append(new MPCommandJob(this, MPCmd::INFORM_UNLOCKED, afterFn));
+
+    connect(jobs, &AsyncJobs::finished, [cb](const QByteArray &)
+    {
+        qInfo() << "Inform unlock was successful.";
+        cb(true, "");
+    });
+
 
     connect(jobs, &AsyncJobs::failed, [cb](AsyncJob *failedJob)
     {


### PR DESCRIPTION
Sending json response after the following commands sent to device:
-inform_lock
-inform_unlock
-lock_device