### PR TITLE
Fix Login and Password length limit on Credentials tab, fix #1030

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1228,26 +1228,9 @@ void CredentialsManagement::onItemCollapsed(const QModelIndex &proxyIndex)
 void CredentialsManagement::onLoginEdited(const QString &loginName)
 {
     static auto defaultStyle = ui->addCredLoginInput->styleSheet();
-    const auto loginNameSize = loginName.size();
-    const auto maxLoginLength = wsClient->isMPBLE() ? BLE_LOGIN_LENGTH : MINI_LOGIN_LENGTH;
-    if (loginNameSize > maxLoginLength)
-    {
-        if (!m_invalidLoginName)
-        {
-            ui->addCredLoginInput->setStyleSheet(INVALID_INPUT_STYLE);
-            ui->addCredLoginInput->setToolTip(tr("Service name is too long, maximum length is %1").arg(maxLoginLength));
-            m_invalidLoginName = true;
-        }
-    }
-    else
-    {
-        if (m_invalidLoginName)
-        {
-            ui->addCredLoginInput->setStyleSheet(defaultStyle);
-            ui->addCredLoginInput->setToolTip("");
-            m_invalidLoginName = false;
-        }
-    }
+    const int loginNameSize = loginName.size();
+    const int maxLoginLength = wsClient->isMPBLE() ? BLE_LOGIN_LENGTH : MINI_LOGIN_LENGTH;
+    checkInputLength(ui->addCredLoginInput, m_invalidLoginName, defaultStyle, loginNameSize, maxLoginLength);
 }
 
 void CredentialsManagement::onPasswordEdited(const QString &password)
@@ -1255,22 +1238,27 @@ void CredentialsManagement::onPasswordEdited(const QString &password)
     static auto defaultStyle = ui->addCredPasswordInput->styleSheet();
     const auto passwordSize = password.size();
     const auto maxPasswordLength = wsClient->isMPBLE() ? BLE_PASSWORD_LENGTH : BLE_PASSWORD_LENGTH;
-    if (passwordSize > maxPasswordLength)
+    checkInputLength(ui->addCredPasswordInput, m_invalidPassword, defaultStyle, passwordSize, maxPasswordLength);
+}
+
+void CredentialsManagement::checkInputLength(SimpleLineEdit *input, bool &isInvalid, const QString& defaultStyle, int nameSize, int maxLength)
+{
+    if (nameSize > maxLength)
     {
-        if (!m_invalidPassword)
+        if (!isInvalid)
         {
-            ui->addCredPasswordInput->setStyleSheet("border: 2px solid red");
-            ui->addCredPasswordInput->setToolTip(tr("Service name is too long, maximum length is %1").arg(maxPasswordLength));
-            m_invalidPassword = true;
+            input->setStyleSheet(INVALID_INPUT_STYLE);
+            input->setToolTip(tr("Text is too long, maximum length is %1").arg(maxLength));
+            isInvalid = true;
         }
     }
     else
     {
-        if (m_invalidPassword)
+        if (isInvalid)
         {
-            ui->addCredPasswordInput->setStyleSheet(defaultStyle);
-            ui->addCredPasswordInput->setToolTip("");
-            m_invalidPassword = false;
+            input->setStyleSheet(defaultStyle);
+            input->setToolTip("");
+            isInvalid = false;
         }
     }
 }

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -33,6 +33,8 @@
 
 const QString CredentialsManagement::INVALID_DOMAIN_TEXT =
         tr("The following domains are invalid or private: <b><ul><li>%1</li></ul></b>They are not saved.");
+const QString CredentialsManagement::INVALID_INPUT_STYLE =
+        "border: 2px solid red";
 
 CredentialsManagement::CredentialsManagement(QWidget *parent) :
     QWidget(parent), ui(new Ui::CredentialsManagement), m_pAddedLoginItem(nullptr)
@@ -107,6 +109,9 @@ CredentialsManagement::CredentialsManagement(QWidget *parent) :
     connect(ui->lineEditCategory2, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
     connect(ui->lineEditCategory3, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
     connect(ui->lineEditCategory4, &QLineEdit::textEdited, this, &CredentialsManagement::onCategoryEdited);
+
+    connect(ui->addCredLoginInput, &QLineEdit::textEdited, this, &CredentialsManagement::onLoginEdited);
+    connect(ui->addCredPasswordInput, &QLineEdit::textEdited, this, &CredentialsManagement::onPasswordEdited);
 
     ui->pushButtonFavorite->setMenu(&m_favMenu);
 
@@ -321,7 +326,8 @@ void CredentialsManagement::enableCredentialsManagement(bool enable)
 void CredentialsManagement::updateQuickAddCredentialsButtonState()
 {
     bool isValidPasswordInput = (ui->addCredPasswordInput->hasAcceptableInput() && ui->addCredPasswordInput->text().length() > 0) || m_altKeyPressed;
-    ui->addCredentialButton->setEnabled(ui->addCredServiceInput->hasAcceptableInput() && ui->addCredServiceInput->text().length() > 0 && isValidPasswordInput);
+    ui->addCredentialButton->setEnabled(ui->addCredServiceInput->hasAcceptableInput() && ui->addCredServiceInput->text().length() > 0 &&
+                                        isValidPasswordInput && !m_invalidLoginName && !m_invalidPassword);
 }
 
 void CredentialsManagement::onPasswordInputReturnPressed()
@@ -1219,6 +1225,56 @@ void CredentialsManagement::onItemCollapsed(const QModelIndex &proxyIndex)
         pServiceItem->setExpanded(false);
 }
 
+void CredentialsManagement::onLoginEdited(const QString &loginName)
+{
+    static auto defaultStyle = ui->addCredLoginInput->styleSheet();
+    const auto loginNameSize = loginName.size();
+    const auto maxLoginLength = wsClient->isMPBLE() ? BLE_LOGIN_LENGTH : MINI_LOGIN_LENGTH;
+    if (loginNameSize > maxLoginLength)
+    {
+        if (!m_invalidLoginName)
+        {
+            ui->addCredLoginInput->setStyleSheet(INVALID_INPUT_STYLE);
+            ui->addCredLoginInput->setToolTip(tr("Service name is too long, maximum length is %1").arg(maxLoginLength));
+            m_invalidLoginName = true;
+        }
+    }
+    else
+    {
+        if (m_invalidLoginName)
+        {
+            ui->addCredLoginInput->setStyleSheet(defaultStyle);
+            ui->addCredLoginInput->setToolTip("");
+            m_invalidLoginName = false;
+        }
+    }
+}
+
+void CredentialsManagement::onPasswordEdited(const QString &password)
+{
+    static auto defaultStyle = ui->addCredPasswordInput->styleSheet();
+    const auto passwordSize = password.size();
+    const auto maxPasswordLength = wsClient->isMPBLE() ? BLE_PASSWORD_LENGTH : BLE_PASSWORD_LENGTH;
+    if (passwordSize > maxPasswordLength)
+    {
+        if (!m_invalidPassword)
+        {
+            ui->addCredPasswordInput->setStyleSheet("border: 2px solid red");
+            ui->addCredPasswordInput->setToolTip(tr("Service name is too long, maximum length is %1").arg(maxPasswordLength));
+            m_invalidPassword = true;
+        }
+    }
+    else
+    {
+        if (m_invalidPassword)
+        {
+            ui->addCredPasswordInput->setStyleSheet(defaultStyle);
+            ui->addCredPasswordInput->setToolTip("");
+            m_invalidPassword = false;
+        }
+    }
+}
+
 void CredentialsManagement::onExpandedStateChanged(bool bIsExpanded)
 {
     ui->pushButtonExpandAll->setText(bIsExpanded ? tr("Collapse All") : tr("Expand All"));
@@ -1361,8 +1417,6 @@ void CredentialsManagement::updateDeviceType(Common::MPHwVersion newDev)
             ui->credDisplayKeyAfterPwdInput->show();
             ui->credDisplayKeyAfterPwdLabel->show();
         }
-        ui->addCredPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
-        ui->credDisplayPasswordInput->setMaxPasswordLength(BLE_PASSWORD_LENGTH);
         ui->pushButtonTOTP->show();
         ui->pushButtonDeleteTOTP->hide();
     }

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -33,6 +33,7 @@ class CredentialModel;
 class CredentialModelFilter;
 class LoginItem;
 class PasswordProfilesModel;
+class SimpleLineEdit;
 
 class CredentialsManagement : public QWidget
 {
@@ -86,6 +87,7 @@ private slots:
     void onItemCollapsed(const QModelIndex &proxyIndex);
     void onLoginEdited(const QString &loginName);
     void onPasswordEdited(const QString &password);
+    void checkInputLength(SimpleLineEdit *input, bool &isInvalid, const QString& defaultStyle, int nameSize, int maxLength);
     void onExpandedStateChanged(bool bIsExpanded);
     void onModelLoaded(bool bClearLoginDescription);
     void onSelectLoginItem(LoginItem *pLoginItem);

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -84,6 +84,8 @@ private slots:
     void onServiceSelected(const QModelIndex &srcIndex);
     void onItemExpanded(const QModelIndex &proxyIndex);
     void onItemCollapsed(const QModelIndex &proxyIndex);
+    void onLoginEdited(const QString &loginName);
+    void onPasswordEdited(const QString &password);
     void onExpandedStateChanged(bool bIsExpanded);
     void onModelLoaded(bool bClearLoginDescription);
     void onSelectLoginItem(LoginItem *pLoginItem);
@@ -161,6 +163,8 @@ private:
     bool m_isClean = true;
     bool m_isSetCategoryClean = true;
     bool m_altKeyPressed = false;
+    bool m_invalidLoginName = false;
+    bool m_invalidPassword = false;
 
     LinkingMode m_linkingMode = LinkingMode::OFF;
     QByteArray m_credentialLinkedAddr;
@@ -177,8 +181,11 @@ private:
     static constexpr int BLE_FAVORITE_NUM = 50;
     static constexpr int MINI_PASSWORD_LENGTH = 31;
     static constexpr int BLE_PASSWORD_LENGTH = 64;
+    static constexpr int BLE_LOGIN_LENGTH = 63;
+    static constexpr int MINI_LOGIN_LENGTH = 62;
     static constexpr char MULT_DOMAIN_SEPARATOR = ',';
     static const QString INVALID_DOMAIN_TEXT;
+    static const QString INVALID_INPUT_STYLE;
 
 signals:
     void wantEnterMemMode();

--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -55,9 +55,6 @@ border-right: none;
         </item>
         <item row="1" column="1">
          <widget class="SimpleLineEdit" name="addCredLoginInput">
-          <property name="maxLength">
-           <number>62</number>
-          </property>
          </widget>
         </item>
         <item row="1" column="0">
@@ -69,9 +66,6 @@ border-right: none;
         </item>
         <item row="1" column="2">
          <widget class="LockedPasswordLineEdit" name="addCredPasswordInput">
-          <property name="maxLength">
-           <number>31</number>
-          </property>
          </widget>
         </item>
         <item row="0" column="0">


### PR DESCRIPTION
Login input size was incorrect fixing #1030 with it.
In case of long login or password pasted or typed display a warning red border instead of truncating the text, fix #1068:
![kép](https://user-images.githubusercontent.com/11043249/226021143-2b63c5cf-0875-4dee-b55c-ef26a5ed6233.png)
