### PR TITLE
Remove CTRL from shortcut displayed on Advanced tab

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1396,7 +1396,7 @@ void MainWindow::setKeysTabVisibleOnDemand(bool bValue)
     QSettings s;
     s.setValue("settings/SSHKeysTabsVisibleOnDemand", bValue);
 
-    // SSH keys tab will show up only after activating the CTRL+SHIFT+F1 shortcut
+    // SSH keys tab will show up only after activating the SHIFT+F1 shortcut
     if (bSSHKeysTabVisibleOnDemand) {
         bSSHKeyTabVisible = false;
         connect(m_FilesAndSSHKeysTabsShortcut, &QShortcut::activated, this, &MainWindow::onFilesAndSSHTabsShortcutActivated);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -4969,7 +4969,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
            <item>
             <widget class="QRadioButton" name="radioButtonSSHTabOnDemand">
              <property name="text">
-              <string>Visible ON DE&amp;MAND  (use CTRL+SHIFT+F1 keyboard shortcut)</string>
+              <string>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</string>
              </property>
              <property name="checked">
               <bool>true</bool>


### PR DESCRIPTION
Issue mentioned in #1142
![image](https://user-images.githubusercontent.com/11043249/227314923-c1fbf0d6-85c9-4284-bd23-0340b3d742a3.png)
