### PR TITLE
[BLE] Improve notes label name display

### DIFF
--- a/src/NotesManagement.cpp
+++ b/src/NotesManagement.cpp
@@ -96,7 +96,7 @@ void NotesManagement::addNewIcon(const QString &name)
     vertIconNameLayout->addWidget(labelIcon);
 
     auto* labelName = new QLabel();
-    labelName->setAlignment(Qt::AlignCenter);
+    labelName->setAlignment(name.length() < NOTE_LEFT_ALIGN_SIZE ? Qt::AlignCenter : Qt::AlignLeft);
     labelName->setText(name);
     QFont font = labelName->font();
     font.setPointSize(NOTE_FONT_SIZE);

--- a/src/NotesManagement.h
+++ b/src/NotesManagement.h
@@ -69,7 +69,8 @@ private:
 
     static constexpr int NOTE_ICON_WIDTH = 120;
     static constexpr int NOTE_ICON_HEIGHT = 160;
-    static constexpr int NOTE_FONT_SIZE = 16;
+    static constexpr int NOTE_FONT_SIZE = 14;
+    static constexpr int NOTE_LEFT_ALIGN_SIZE = 15;
     static const QString EXIT_TEXT;
     static const QString DISCARD_TEXT;
 };


### PR DESCRIPTION
If note name is too long, align left.
Decrease note name size.
![image](https://github.com/mooltipass/moolticute/assets/11043249/e3fd7e98-fcd1-4a10-9ccd-16bc8ad4675a)
