### PR TITLE
[BLE] Multiple domain improvements

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -535,3 +535,12 @@ bool Common::isEmail(const QString &service)
     return mailREX.match(service).hasMatch();
 #endif
 }
+
+QString Common::getFirstDomain(const QString &domains)
+{
+    if (!domains.isEmpty())
+    {
+        return domains.split(MULT_DOMAIN_SEPARATOR).at(0);
+    }
+    return "";
+}

--- a/src/Common.h
+++ b/src/Common.h
@@ -268,6 +268,8 @@ public:
 
     static bool isEmail(const QString &service);
 
+    static QString getFirstDomain(const QString& domains);
+
     typedef enum
     {
         MP_Classic = 0,
@@ -360,6 +362,7 @@ public:
     static const int BLE_BUNDLE_WITH_MIRRORING = 11;
     static const int BLE_BUNDLE_WITH_MULT_DOMAINS = 11;
     static const char ZERO_BYTE = static_cast<char>(0x00);
+    static const char MULT_DOMAIN_SEPARATOR = ',';
     static const int ALPHABET_SIZE = 26;
     static QByteArray NOT_SET_ADDR;
 };

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -578,11 +578,18 @@ QJsonArray CredentialModel::getJsonChanges()
 void CredentialModel::addCredential(QString sServiceName, const QString &sLoginName, const QString &sPassword, const QString &sDescription, const QByteArray& pointedTo)
 {
     //Force all service names to lowercase
-    sServiceName = ParseDomain(sServiceName).getManuallyEnteredDomainName(sServiceName);
+    ParseDomain parsedDomain{sServiceName};
+    sServiceName = parsedDomain.getManuallyEnteredDomainName(sServiceName);
 
     // Retrieve target service
     ServiceItem *pTargetService = m_pRootItem->findServiceByName(sServiceName);
     LoginItem *pAddedLoginItem = nullptr;
+
+    if (nullptr == pTargetService)
+    {
+        pTargetService = m_pRootItem->findServiceByName(parsedDomain.domain());
+        // TODO check for multiple domain
+    }
 
     // Check if a service/login pair already exists
     if (pTargetService != nullptr)

--- a/src/CredentialModel.cpp
+++ b/src/CredentialModel.cpp
@@ -588,7 +588,22 @@ void CredentialModel::addCredential(QString sServiceName, const QString &sLoginN
     if (nullptr == pTargetService)
     {
         pTargetService = m_pRootItem->findServiceByName(parsedDomain.domain());
-        // TODO check for multiple domain
+        if (pTargetService)
+        {
+            if (!pTargetService->isMultipleDomainSet())
+            {
+                // Found service without domain, but it is not a multiple domain
+                pTargetService = nullptr;
+            }
+            else
+            {
+                if (!pTargetService->multipleDomains().contains(parsedDomain.tld()))
+                {
+                    // Add new tld to multiple domain
+                    pTargetService->setMultipleDomains(pTargetService->multipleDomains() + Common::MULT_DOMAIN_SEPARATOR + parsedDomain.tld());
+                }
+            }
+        }
     }
 
     // Check if a service/login pair already exists

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1497,7 +1497,7 @@ QString CredentialsManagement::processMultipleDomainsInput(const QString& servic
 #else
     auto splitBehavior = Qt::SkipEmptyParts;
 #endif
-    auto domainList = domains.split(MULT_DOMAIN_SEPARATOR, splitBehavior);
+    auto domainList = domains.split(Common::MULT_DOMAIN_SEPARATOR, splitBehavior);
     QStringList validDomains;
     QStringList invalidDomains;
     QString result = "";
@@ -1529,7 +1529,7 @@ QString CredentialsManagement::processMultipleDomainsInput(const QString& servic
         QMessageBox::information(this, tr("Invalid domain"),
                                 INVALID_DOMAIN_TEXT.arg(invalidDomains.join("</li><li>")));
     }
-    return validDomains.join(MULT_DOMAIN_SEPARATOR);
+    return validDomains.join(Common::MULT_DOMAIN_SEPARATOR);
 }
 
 bool CredentialsManagement::isUICategoryClean() const
@@ -1782,7 +1782,7 @@ void CredentialsManagement::onTreeViewContextMenuRequested(const QPoint& pos)
                             {
                                 ParseDomain parsedService{serviceDomain};
                                 serviceDomain = parsedService.domain();
-                                defaultDomains = parsedService.tld() + MULT_DOMAIN_SEPARATOR;
+                                defaultDomains = parsedService.tld() + Common::MULT_DOMAIN_SEPARATOR;
                                 serviceNameChanged = true;
                             }
                         }
@@ -1815,7 +1815,7 @@ void CredentialsManagement::onTreeViewContextMenuRequested(const QPoint& pos)
             auto* actionRemove = m_enableMultipleDomainMenu.addAction(tr("Remove multiple domains"));
             connect(actionRemove, &QAction::triggered, [pServiceItem, this](){
                 QString multipleDomains = pServiceItem->multipleDomains();
-                QString domain = multipleDomains.split(MULT_DOMAIN_SEPARATOR).first();
+                QString domain = multipleDomains.split(Common::MULT_DOMAIN_SEPARATOR).first();
                 pServiceItem->setName(pServiceItem->name() + domain);
                 pServiceItem->setMultipleDomains("");
                 credentialDataChanged();

--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -1549,11 +1549,7 @@ QString CredentialsManagement::getFirstDomain(TreeItem *pItem) const
 
     ServiceItem* serviceItem = dynamic_cast<ServiceItem*>(pItem);
     QString multDomains = (serviceItem != nullptr) ? serviceItem->multipleDomains() : "";
-    if (!multDomains.isEmpty())
-    {
-        return multDomains.split(',').at(0);
-    }
-    return "";
+    return Common::getFirstDomain(multDomains);
 }
 
 void CredentialsManagement::on_toolButtonFavFilter_clicked()

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -195,7 +195,6 @@ private:
     static constexpr int BLE_PASSWORD_LENGTH = 64;
     static constexpr int BLE_LOGIN_LENGTH = 63;
     static constexpr int MINI_LOGIN_LENGTH = 62;
-    static constexpr char MULT_DOMAIN_SEPARATOR = ',';
     static const QString INVALID_DOMAIN_TEXT;
     static const QString INVALID_INPUT_STYLE;
 

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7847,7 +7847,6 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
             // For multiple domain we need the add the first domain to service name for password save
             if (!multipleDomains.isEmpty())
             {
-                //TODO Only add if it does not contain
                 servicePwd += Common::getFirstDomain(multipleDomains);
             }
             for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(addrArray[j].toInt()); }

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7843,6 +7843,13 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
 
                 multipleDomains = qjobject["multiple_domains"].toString();
             }
+            QString servicePwd = service;
+            // For multiple domain we need the add the first domain to service name for password save
+            if (!multipleDomains.isEmpty())
+            {
+                //TODO Only add if it does not contain
+                servicePwd += Common::getFirstDomain(multipleDomains);
+            }
             for (qint32 j = 0; j < addrArray.size(); j++) { nodeAddr.append(addrArray[j].toInt()); }
             qDebug() << "MMM Save: tackling " << login << " for service " << service << " at address " << nodeAddr.toHex();
 
@@ -7922,7 +7929,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 else
                 {
                     QStringList changeList;
-                    changeList << service << login << password;
+                    changeList << servicePwd << login << password;
                     mmmPasswordChangeArray.append(changeList);
                 }
                 qDebug() << "Queing password change as well";
@@ -7977,7 +7984,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                     }
                     {
                         QStringList changeList;
-                        changeList << service << login << password;
+                        changeList << servicePwd << login << password;
                         mmmPasswordChangeArray.append(changeList);
                     }
                 }
@@ -8089,7 +8096,7 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                     else
                     {
                         QStringList changeList;
-                        changeList << service << login << password;
+                        changeList << servicePwd << login << password;
                         mmmPasswordChangeArray.append(changeList);
                     }
                     packet_send_needed = true;


### PR DESCRIPTION
- Changing password for multiple domain failed, fix with storing service with first tld from multiple domain list
- We have a multiple domain service e.g.: gmail [.com,.de], if I add a new credential in MMM for service 'gmail.hu' instead of adding new gmail.hu service add '.hu' to "gmail [.com,.de]".