### PR TITLE
Fix not set change number during import

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -4016,6 +4016,12 @@ void MPDevice::processStatusChange(const QByteArray &data)
             }
         }
 
+        if (s == Common::UnknownSmartcard)
+        {
+            credentialsDbChangeNumberClone = 0;
+            dataDbChangeNumberClone = 0;
+        }
+
         if (s == Common::Unlocked)
         {
             if (isBLE())


### PR DESCRIPTION
Reset changeNumbers for UnknownSmartCard.
Original issue is import dialog popped up after a successful import.

ChangeNumbers were not reset and due to that the change number from import file was not saved to device during import.