### PR TITLE
[BLE] Fix sending save password for empty password

### DIFF
--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -7934,9 +7934,12 @@ void MPDevice::setMMCredentials(const QJsonArray &creds, bool noDelete,
                 }
                 else
                 {
-                    QStringList changeList;
-                    changeList << servicePwd << login << password;
-                    mmmPasswordChangeArray.append(changeList);
+                    if (!password.isEmpty())
+                    {
+                        QStringList changeList;
+                        changeList << servicePwd << login << password;
+                        mmmPasswordChangeArray.append(changeList);
+                    }
                 }
                 qDebug() << "Queing password change as well";
             }


### PR DESCRIPTION
Earlier we added the credential to `mmmPasswordChangeArray` even if password was empty and later password save message was sent to device.
Prevent this with a condition for empty password.