### PR TITLE
src/MPDeviceBleImpl.cpp: Fix compilation on GCC 14

### DIFF
--- a/src/MPDeviceBleImpl.cpp
+++ b/src/MPDeviceBleImpl.cpp
@@ -769,7 +769,7 @@ bool MPDeviceBleImpl::processReceivedData(const QByteArray &data, QByteArray &da
 {
     if (data.size() < 2)
     {
-        return {0};
+        return {QByteArray::number(0)};
     }
     QVector<QByteArray> res;
     for (int i = 0; i < data.size() - 1; i += 2)


### PR DESCRIPTION
GCC begins to get stricter regarding types in 14, meaning it will no longer allow casting a type `int` to `const char*`. This was fixed by simply casting the 0 to a `char*` with `QByteArray::number(0)`. Is this the best way to go about it?

Gentoo bug: https://bugs.gentoo.org/916994

Error output:
```
src/MPDeviceBleImpl.cpp: In member function ‘QVector<QByteArray> MPDeviceBleImpl::processReceivedStartNodes(const QByteArray&) const’: src/MPDeviceBleImpl.cpp:738:18: error: invalid conversion from ‘int’ to ‘const char*’ [-fpermissive]
  738 |         return {0};
      |                  ^
      |                  |
      |                  int
In file included from /usr/include/qt5/QtCore/qstring.h:50,
                 from /usr/include/qt5/QtCore/qobject.h:47,
                 from /usr/include/qt5/QtCore/QObject:1,
                 from src/MPDevice.h:22,
                 from src/MPDeviceBleImpl.h:4,
                 from src/MPDeviceBleImpl.cpp:1:
/usr/include/qt5/QtCore/qbytearray.h:181:16: note:   initializing argument 1 of ‘QByteArray::QByteArray(const char*, int)’
  181 |     QByteArray(const char *, int size = -1);
      |                ^~~~~~~~~~~~
```