### PR TITLE
Run tests on `make check`

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -11,7 +11,7 @@ QT       -= gui
 CONFIG += c++11
 
 TARGET = tests
-CONFIG   += console
+CONFIG   += testcase no_testcase_installs
 CONFIG   -= app_bundle
 
 TEMPLATE = app


### PR DESCRIPTION
`make check` currently only builds the tests. Marking the app as a `testcase` ensures that the tests are actually run with `make check`.

`no_testcase_installs` prevents the test from being installed.

Docs: https://doc.qt.io/qt-5/qtest-overview.html#building-with-qmake

Sidenote: some tests, such as FilesCacheTests, are not enabled. Is this intended?