### PR TITLE
Allow silent install without application launch

### DIFF
--- a/win/installer.iss
+++ b/win/installer.iss
@@ -53,7 +53,7 @@ Name: "Full"; Description: "Full installation"
 Name: "moolticute"; Description: "Moolticute"; Types: Full
 
 [Run]
-Filename: "{app}\moolticute.exe"; WorkingDir: "{app}"; Description: "Start Moolticute"; Flags: postinstall nowait runascurrentuser
+Filename: "{app}\moolticute.exe"; WorkingDir: "{app}"; Description: "Start Moolticute"; Flags: postinstall nowait runascurrentuser skipifsilent
 
 [Registry]
 Root: "HKCU"; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "Moolticute"; ValueData: "{app}\moolticute.exe --autolaunched"; Flags: uninsdeletevalue


### PR DESCRIPTION
Some users may want to install moolticute in an unattended silent way, e.g. the following installs in silent mode skipping the creation of a desktop icon:

    setupfile.exe /VERYSILENT /TASKS="!desktopicon"

However this will still run programs in the `RUN` section which executes moolticute. This is undesired in an unattended setup, so we skip this [on silent installs][1].

NOTE: My change is based on the innosetup documentation but I did not run a build myself off this commit since I have no prior experience with innosetup.

[1]: https://documentation.help/Inno-Setup/topic_runsection.htm#skipifsilent