### PR TITLE
Remove window size workaround on Unix

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -839,13 +839,6 @@ void AppGui::createMainWindow()
 
     win = new MainWindow(wsClient, dbMasterController);
 
-#ifdef Q_OS_UNIX
-    // Force resize and reset maximumWidth
-    // This fixes a crash on some Gnome+Wayland platforms
-    win->resize(0,0);
-    win->setMaximumWidth(win->width());
-#endif
-
     connect(win, &MainWindow::destroyed, [this](QObject *)
     {
         win = nullptr;


### PR DESCRIPTION
The Qt6 versions of Moolticute on KDE fails to launch due to the workaround in #972. I tried to reproduce the issue this workaround should fix on multiple builds and systems, but failed to so.

This PR removes that workaround.