### PR TITLE
Fix SnoreToast notifications for Win10

### DIFF
--- a/src/AppGui.cpp
+++ b/src/AppGui.cpp
@@ -26,6 +26,7 @@
 
 #ifdef Q_OS_WIN
 #include "SystemNotifications/SystemNotificationWindows.h"
+#include "windows.h"
 #endif
 
 #ifdef Q_OS_MAC

--- a/src/SystemNotifications/SystemNotificationWindows.h
+++ b/src/SystemNotifications/SystemNotificationWindows.h
@@ -30,14 +30,15 @@ public:
     virtual bool displayLoginRequestNotification(const QString& service, QString &loginName, QString message) override;
     virtual bool displayDomainSelectionNotification(const QString& domain, const QString& subdomain, QString &serviceName, QString message) override;
 
-    const static QString SNORETOAST_FORMAT;
+    const static QString SNORETOAST;
     const static QString SNORETOAST_INSTALL;
-    const static QString WINDOWS10_VERSION;
     const static QString NOTIFICATIONS_SETTING_REGENTRY;
     const static QString DND_ENABLED_REGENTRY;
     const static QString TOAST_ENABLED_SETTING_REGPATH;
     const static QString TOAST_ENABLED_REGENTRY;
-    const static bool IS_WIN10;
+    const static QString ICON;
+    const static int WINDOWS10_VERSION = 10;
+    const static bool IS_WIN10_OR_ABOVE;
 
 signals:
     void notifySystray(QString title, QString text);


### PR DESCRIPTION
For Win10 notifications were not working, because the usage for QProcess start got deprecated, so switched to https://doc.qt.io/qt-6/qprocess.html#start.
Fixed focus assist and win10/11 detection too.

Tested on Win10 and Win11.