### PR TITLE
Add option to use shared or bundled QZXing

### DIFF
--- a/gui.pro
+++ b/gui.pro
@@ -20,7 +20,12 @@ linux {
 
 include(src/QtAwesome/QtAwesome/QtAwesome.pri)
 include(src/QSimpleUpdater/QSimpleUpdater.pri)
-include(src/QZXing/src/QZXing.pri)
+
+CONFIG(use_system_qzxing) {
+    LIBS += -lQZXing
+} else {
+    include(src/QZXing/src/QZXing.pri)
+}
 
 greaterThan(QT_MAJOR_VERSION, 5) {
     include (src/qtcsv6/qtcsv.pri)


### PR DESCRIPTION
Add the `use_system_qzxing` option to conditionally use the system-provided QZXing instead of the bundled version. The bundled version will be used by default.