### PR TITLE
[WIP] recondition: Allow to specify custom rated capacity for recondition logic

### DIFF
--- a/src/MPDeviceBleImpl.h
+++ b/src/MPDeviceBleImpl.h
@@ -123,7 +123,7 @@ public:
     void readBatteryPercent(const QByteArray& statusData);
     void getBattery();
 
-    void nihmReconditioning(bool enableRestart);
+    void nihmReconditioning(bool enableRestart, int ratedCapacity);
     void getSecurityChallenge(const QString& key, const MessageHandlerCb &cb);
 
     void processDebugMsg(const QByteArray& data, bool& isDebugMsg);
@@ -252,6 +252,7 @@ private:
 
     bool m_enforceLayout = false;
     quint32 m_nimhResultSec = 0;
+    quint32 m_nimhRestartUnderSec = RECONDITION_RESTART_UNDER_SECS_STOCK;
 
     int m_miniFilePartCounter = 0;
 
@@ -290,8 +291,9 @@ private:
     static constexpr int SET_BLE_NAME_BUNDLE_VERSION = 9;
     static constexpr int WAKEUP_DEVICE_BUNDLE_VERSION = 10;
     static constexpr int POINTED_TO_ADDR_SIZE = 2;
-    static constexpr int PLATFORM_SERIAL_NUM_FIRST_BYTE = 16;
-    static constexpr int RECONDITION_RESTART_UNDER_SECS = 2500;
+    static constexpr int PLATFORM_SERIAL_NUM_FIRST_BYTE = 16;    
+    static constexpr int STOCK_BATTERY_CAPACITY_MAH = 300;
+    static constexpr int RECONDITION_RESTART_UNDER_SECS_STOCK = 2500;
     const QByteArray DEFAULT_BUNDLE_PASSWORD = "\x63\x44\x31\x91\x3a\xfd\x23\xff\xb3\xac\x93\x69\x22\x5b\xf3\xc0";
     const QString DEFAULT_BLE_NAME = "Mooltipass Mini BLE";
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2030,7 +2030,9 @@ bool MainWindow::validateSerialString(const QString &serialStr, uint &serialNum)
 
 void MainWindow::displayReconditionWaitScreen(double lastElapsedTime)
 {
-    QString lastElapsedText = lastElapsedTime > 0 ? QString("<p>Recondition restarted. Last elapsed time: %1 seconds</p>").arg(lastElapsedTime) : "";
+    QString lastElapsedText = lastElapsedTime > 0 ?
+        QString("<p>Recondition restarted. Last elapsed time: %1 seconds (~ %2 mAh)</p><br><p>Need at least %3 seconds for rated %4 mAh capacity</p>")
+                .arg(lastElapsedTime).arg(0) : "";
     ui->labelWait->show();
     ui->labelWait->setText(tr("<html><!--nimh_recondition--><head/><body><p><span style=\"font-size:12pt; font-weight:600;\">NiMH Recondition is in progress.</span></p>%1<p>Please wait.</p></body></html>").arg(lastElapsedText));
     ui->stackedWidget->setCurrentWidget(ui->pageWaiting);
@@ -2356,7 +2358,7 @@ void MainWindow::on_pushButtonNiMHRecondition_clicked()
 
     if (btn == QMessageBox::Ok)
     {
-        wsClient->sendNiMHReconditioning(ui->checkBoxContinueRecondition->isChecked());
+        wsClient->sendNiMHReconditioning(ui->checkBoxContinueRecondition->isChecked(), ui->exp_capacity->value());
         displayReconditionWaitScreen();
     }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2030,9 +2030,14 @@ bool MainWindow::validateSerialString(const QString &serialStr, uint &serialNum)
 
 void MainWindow::displayReconditionWaitScreen(double lastElapsedTime)
 {
+    /* FixMe: This should come from MPDeviceBLEImpl.cpp */
+    //RECONDITION_RESTART_UNDER_SECS_STOCK * 300 / ratedCapacity
+    auto ratedCapacityTime = 2500 * 300 / ui->exp_capacity->value();
+    auto currentCapacity = 2500 * lastElapsedTime / 300;
+
     QString lastElapsedText = lastElapsedTime > 0 ?
         QString("<p>Recondition restarted. Last elapsed time: %1 seconds (~ %2 mAh)</p><br><p>Need at least %3 seconds for rated %4 mAh capacity</p>")
-                .arg(lastElapsedTime).arg(0) : "";
+                .arg(lastElapsedTime).arg(currentCapacity).arg(ratedCapacityTime).arg(ui->exp_capacity->value()) : "";
     ui->labelWait->show();
     ui->labelWait->setText(tr("<html><!--nimh_recondition--><head/><body><p><span style=\"font-size:12pt; font-weight:600;\">NiMH Recondition is in progress.</span></p>%1<p>Please wait.</p></body></html>").arg(lastElapsedText));
     ui->stackedWidget->setCurrentWidget(ui->pageWaiting);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>632</height>
+    <height>1081</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -328,7 +328,7 @@ QWidget {background-color: #EFEFEF;}</string>
        <enum>Qt::LeftToRight</enum>
       </property>
       <property name="currentIndex">
-       <number>9</number>
+       <number>15</number>
       </property>
       <widget class="QWidget" name="pageNoDaemon">
        <layout class="QHBoxLayout" name="horizontalLayout_noDaemon1">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>770</width>
-             <height>882</height>
+             <width>932</width>
+             <height>1832</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3940,7 +3940,7 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                <x>0</x>
                <y>0</y>
                <width>646</width>
-               <height>874</height>
+               <height>897</height>
               </rect>
              </property>
              <property name="autoFillBackground">
@@ -5243,6 +5243,23 @@ Hint: keep your mouse positioned over an option to get more details.</string>
                 </size>
                </property>
               </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_47">
+               <property name="text">
+                <string>Battery rated capacity, mAh</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="exp_capacity">
+               <property name="maximum">
+                <number>1000</number>
+               </property>
+               <property name="value">
+                <number>300</number>
+               </property>
+              </widget>
              </item>
              <item>
               <widget class="QCheckBox" name="checkBoxContinueRecondition">

--- a/src/WSClient.cpp
+++ b/src/WSClient.cpp
@@ -928,10 +928,11 @@ void WSClient::sendCurrentCategory(int category)
                   {"data", o}});
 }
 
-void WSClient::sendNiMHReconditioning(bool enableRestart)
+void WSClient::sendNiMHReconditioning(bool enableRestart, int ratedCapacity)
 {
     QJsonObject o;
     o["enable_restart"] = enableRestart;
+    o["rated_capacity"] = ratedCapacity;
     sendJsonData({{ "msg", "nimh_reconditioning" },
                   {"data", o}});
 }

--- a/src/WSClient.h
+++ b/src/WSClient.h
@@ -122,7 +122,7 @@ public:
     void sendBatteryRequest();
     void sendBleNameRequest();
     void sendCurrentCategory(int category);
-    void sendNiMHReconditioning(bool enableRestart);
+    void sendNiMHReconditioning(bool enableRestart, int ratedCapacity);
     void sendSecurityChallenge(QString str);
     void sendSetBleName(QString name);
     void sendSetSerialNumber(uint serialNum);

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -1400,7 +1400,8 @@ void WSServerCon::processMessageBLE(QJsonObject root, const MPDeviceProgressCb &
     {
         QJsonObject o = root["data"].toObject();
         auto enableRestart = o.value("enable_restart").toBool();
-        bleImpl->nihmReconditioning(enableRestart);
+        auto ratedCapacity= o.value("rated_capacity").toInt();
+        bleImpl->nihmReconditioning(enableRestart, ratedCapacity);
     }
     else if (root["msg"] == "request_security_challenge")
     {


### PR DESCRIPTION
Hi! This patchset improves battery reconditioning in a few ways.  It's still WiP. 

It allows to specify custom battery capacity for the 'recondition until rated capacity is reached'. I've added the dumb logic (from the calculation that 300mAh == 2500 sec), so that for devices with modded batteries and DIY variants can recondition properly (Mine has a 600mAh battery).

I've also tried to send the calculations to reconditioning GUI (So that the user knows sees, that say 2500 seconds is ~300mAh), but I'm not sure how would be best to patch it to GUI without breaking too many things or introduce hacks (I've last done things in C++/Qt ~7 years ago, so bear with me ;) ). For now I've hardcoded some things and set it up for a test run. 

I also plan on implementing a timer, so that reconditioning to max capacity will not go beyond, say, 10 hours. Just for safety. 