### PR TITLE
Use SnoreToast from installed folder, fix #1238

### DIFF
--- a/src/SystemNotifications/SystemNotificationWindows.h
+++ b/src/SystemNotifications/SystemNotificationWindows.h
@@ -30,6 +30,9 @@ public:
     virtual bool displayLoginRequestNotification(const QString& service, QString &loginName, QString message) override;
     virtual bool displayDomainSelectionNotification(const QString& domain, const QString& subdomain, QString &serviceName, QString message) override;
 
+    static QString findSnoreToast(QString path);
+
+    const static QString SNORETOAST_EXE;
     const static QString SNORETOAST;
     const static QString SNORETOAST_INSTALL;
     const static QString NOTIFICATIONS_SETTING_REGENTRY;


### PR DESCRIPTION
Instead of installing SnoreToast to Start Menu/Programs use it from installation folder.