### PR TITLE
Add 'Community creation' warning

### DIFF
--- a/lang/mc_br.ts
+++ b/lang/mc_br.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,67 +203,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1184,8 +1184,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1571,43 +1571,48 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1842,126 +1847,126 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2147,162 +2152,162 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2322,22 +2327,22 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2357,79 +2362,79 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2479,488 +2484,493 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lang/mc_de.ts
+++ b/lang/mc_de.ts
@@ -2171,7 +2171,7 @@ Tipp: Halten Sie die Maus über eine Option, um weitere Details zu erhalten.</tr
     <message>
         <location filename="../src/MainWindow.ui" line="3386"/>
         <source>Community Creation</source>
-        <translation type="unfinished"></translation>
+        <translation>Community-Erstellung</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="5272"/>
@@ -3140,7 +3140,8 @@ You will be prompted for import or export operations if any changes to your Mool
     <message>
         <location filename="../src/MainWindow.cpp" line="1695"/>
         <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Diese Gerät (Seriennummer %1) ist ein von der Community erstelltes Gerät und in keiner weise mit dem ursprünglichen Mooltipass-Team verbunden!&lt;ol&gt;&lt;li&gt;Mooltipass ist Open Source und Open Hardware, sodass jeder mit den nötigen Fähigkeiten eines erstellen kann;&lt;/li&gt;&lt;li&gt;Wir können auf keinen Fall einen Sicherheitstest für Ihr Gerät durchführen, da wir es nicht erstellt haben und nicht über die erforderlichen Daten verfügen;&lt;/li&gt;&lt;li&gt;Dieses Menü ist deaktiviert, um Frustration und fehlerhafte E-Mails zu vermeiden;&lt;/li&gt;&lt;/ol&gt;</translatorcomment>
+        <translation>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="2370"/>

--- a/lang/mc_de.ts
+++ b/lang/mc_de.ts
@@ -233,7 +233,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,67 +243,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation>Firmware auswählen</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation>Ungültiger Dateipfad</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation>Die ausgewählte Firmware ist ungültig.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation>Firmware wird geschrieben.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation>Firmware Status</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation>Firmware wurde geschrieben.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation>Firmware konnte nicht geschrieben werden.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation>Datei auswählen</translation>
     </message>
@@ -1267,8 +1267,8 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation>Moolticute</translation>
     </message>
@@ -1663,13 +1663,13 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
         <translation type="vanished">Klopferkennung inaktiv</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1693,17 +1693,17 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
         <translation>Moolticute (c) das Mooltipass Team</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation>Aux MCU Version:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation>Main MCU Version:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation>Firmware Version:</translation>
     </message>
@@ -1716,109 +1716,109 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verhalten von ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>Systray Symbol</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Auswahl der Subdomain: aktiv</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation>Integration von Have I Been Pwned: aktiv</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation>Aktiviere Entwicklerlog</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation>Aktiviere Debug Log</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation>Standard Kennwortlänge</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Karte zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Lösche die eingelegte Karte</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Karte zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>CSV Datei importieren/exportieren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Importiere unverschlüsselte Kennwörter</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>Importiere CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Exportiere unverschlüsselte Kennwörter</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>Exportiere CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation>Lesen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation>Verfügbare Anwender:</translation>
     </message>
@@ -1881,88 +1881,88 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Anwendungssprache</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Daemon-Protokolle anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Moolticute SSH-Agent automatisch starten</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Neustart benötigt)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticute SSH-Argumente</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Daemon neu starten mit Debug Web Server (auf Port 8484</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Daemon Web Server aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Kennwort-Profile Verwalten</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>Kennwort-Profile...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Verzögerte Abbrechen-Schaltflächen, um Fehler zu verhindern</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Lang-Drücken Abbrechen-Tasten aktivieren</translation>
     </message>
@@ -1978,7 +1978,7 @@ Die maximal zulässige Größe beträgt %2 Byte.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Integritätsprüfung</translation>
     </message>
@@ -2169,7 +2169,12 @@ Tipp: Halten Sie die Maus über eine Option, um weitere Details zu erhalten.</tr
         <translation>Mooltipass Bildschirmhelligkeit</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2348,24 +2353,24 @@ Tipp: Halten Sie die Maus über eine Option, um weitere Details zu erhalten.</tr
         <translation>Gerätseriennummer:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Gerätespeicher:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID-Anfrage</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Kennwort</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Validieren</translation>
     </message>
@@ -2374,70 +2379,70 @@ Tipp: Halten Sie die Maus über eine Option, um weitere Details zu erhalten.</tr
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Moolitcute mit dem Computer starten: Aktiviert</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Ändere</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Autostart SSH-Agent</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>Die Integrität Ihrer gespeicherten Anmeldeinformationen wird getestet. Das kann eine Weile dauern. Bitte trennen Sie Ihren Mooltipass nicht während des Checks.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSH-Schlüssel Tab</translation>
     </message>
@@ -2446,22 +2451,22 @@ Tipp: Halten Sie die Maus über eine Option, um weitere Details zu erhalten.</tr
         <translation type="vanished">Sichtbar bei &amp;Bedarf (Tastenkombination STRG + UMSCHALT + F1 verwenden)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>Immer &amp;sichtbar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Niedrig</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Mittel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Hoch</translation>
     </message>
@@ -2528,32 +2533,32 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Fenster ausblenden</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Deaktiviert</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Allein Kennwort</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Anmeldename + Kennwort</translation>
     </message>
@@ -2579,60 +2584,60 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Strg + Alt + Entf / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Schwarz</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Weiss</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation>_weiss</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>UID vom Gerät holen. Das kann ein paar Sekunden dauern ...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>Entweder wurde das Gerät manipuliert oder der EingabeSchlüssel- ist ungültig.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>Die Geräte-UID ist %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Anmeldedaten wurden geändert.
 Möchten Sie die Änderungen speichern?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Entfernen Sie die Karte vom Gerät, um diese Einstellung zu ändern.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation>Deaktiviere die Have I Been Pwned Prüfung?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation>Aktiviere die Have I Been Pwned Prüfung?</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
@@ -2655,12 +2660,12 @@ You will be prompted for import or export operations if any changes to your Mool
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation>Keine Inaktivität</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
@@ -2689,192 +2694,192 @@ You will be prompted for import or export operations if any changes to your Mool
         <translation type="vanished">6 Stunden</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1 Mb</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Auf die Geräts-Bestätigung warten&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bestätigen Sie die Anfrage auf dem Gerät.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Änderungen am Gerät speichern&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte warten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Bestätigen Sie die Anfrage auf dem Gerät.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Bestätigen Sie die Anfrage auf dem Gerät.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Änderungen im Gerätespeicher speichern&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte warten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Die Datenbank wird vom Gerät exportiert&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte warten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Datei auf Gerät importieren und zusammenführen&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte warten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Auswahl Subdomain: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation>Integration mit &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation>Wähle Datenbankexport...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation>Die Datenbank wurde erfolgreich von Ihrem Gerät eportiert.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Speicherprüfung erfolgreich abgeschlossen!
 %1 von %2 verfügbaren Speicherplätzen belegt.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>Um sicher zu stellen, dass das Gerät nicht manipuliert wurde, können Sie ein Kennwort anfordern um die Geräte UID zu prüfen.&lt;ol&gt;&lt;li&gt;Sende die Seriennummer des Geräts, die sich auf der Rückseite befindet.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Sende eine Mail&lt;/a&gt; mit der Seriennummer und der Bestellnummer, um das Gerätekennwort anzufordern.&lt;/li&gt;&lt;li&gt;Geben Sie das Kennwort, das Sie von uns erhalten ein.&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Speicherabbilder (*.bin)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>Zurücksetzen der Karte fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>Zurücksetzen der Karte erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>CSV-Datei für den Import auswählen...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Keine Daten von %1 gelesen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>%1 kann nicht gelesen werden: jede Zeile darf nur genau 3 Einträge haben. Einige Zeilen sind fehlerhaft (Zeilen: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>%1 kann nicht gelesen werden: jede Zeile darf nur genau 3 Einträge haben (mehr als 10 Fehler)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>%1 kann nicht gelesen werden: jede Zeile darf nur genau 3 Einträge haben und durch Komma getrennt sein</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Deaktiviere Subdomänen?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Aktiviere Subdomänen?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Fehler</translation>
     </message>
@@ -2893,61 +2898,61 @@ You will be prompted for import or export operations if any changes to your Mool
         <translation type="vanished">Die MooltiApp-Sicherungsdatei verfügt nicht über verschlüsselte Anmeldungen.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Die Anmeldedaten konnten nicht gespeichert werden. Bitte kontaktieren Sie das Support-Team mit dem Moolticute-Protokoll</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Autostart beim Booten deaktivieren?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Autostart beim Booten aktivieren?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>Starte Moolticute mit dem Computer: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Aktiviert</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Datenbankexport speichern...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
@@ -2967,213 +2972,218 @@ You will be prompted for import or export operations if any changes to your Mool
         <translation>Exportiere nicht verschlüsselte Kennwörter in eine CSV-Datei.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Sehr nieder</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished">30 Minuten {5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished">30 Minuten {10 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished">30 Minuten {15 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">1 Sekunde {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 Sekunde</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Kann Datei %1 nicht lesen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Kann nicht in Datei %1 schreiben</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>Die Datenbank wurde erfolgreich in das Gerät importiert und zusammengeführt.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Möchten Sie die Integritätsprüfung Ihres Geräts starten?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Auf die Geräts-Bestätigung warten&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bestätigen Sie die Anfrage auf dem Gerät.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>Speicherintegritätsprüfung fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3190,7 +3200,7 @@ You will be prompted for import or export operations if any changes to your Mool
         <translation type="vanished">Speicherverwaltungsfehler</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3199,7 +3209,7 @@ You will be prompted for import or export operations if any changes to your Mool
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>System standard Sprache</translation>
     </message>

--- a/lang/mc_fr.ts
+++ b/lang/mc_fr.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,67 +203,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1242,8 +1242,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation></translation>
     </message>
@@ -1678,13 +1678,13 @@ Maximum allowed size is %2 bytes.</source>
         <translation type="vanished">Détection du &quot;toc-toc&quot; inactive</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation>Recyclage NiMH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation>Démarrer le recyclage NiMH</translation>
     </message>
@@ -1708,17 +1708,17 @@ Maximum allowed size is %2 bytes.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation></translation>
     </message>
@@ -1731,59 +1731,59 @@ Maximum allowed size is %2 bytes.</source>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Comportement de ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>Icone de la zone de notification</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Sélection de sous-domaine: activée</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation>Intégration avec Have I Been Pwned : activée</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation>Activer les journeaux développeur</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation>Activer jouneaux de débogage</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation>Longueur par défaut des mots de passe</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Réinitialiser la carte</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Effacer la carte insérée dans l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Réinitialiser la carte</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>Import/Export de fichier CSV</translation>
     </message>
@@ -1798,18 +1798,18 @@ Maximum allowed size is %2 bytes.</source>
         <translation>Annuler les modifications</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation>Si actif, Moolticute selectionnera la catégorie choisie lors de la connexion à l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation>A la connexion, forcer la catégorie :</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation>Bannière de notification de sauvegarde</translation>
     </message>
@@ -1859,77 +1859,77 @@ Maximum allowed size is %2 bytes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation>Activer notification de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation>Afficher le tutoriel de Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation>Afficher tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Importer des mots de passe non chiffrés</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>Importer un fichier CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Exporter les mots de passe sans les chiffrer</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>Exporter un fichier CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation>Récupérer</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation>Nombre d&apos;utilisateurs disponibles :</translation>
     </message>
@@ -1983,78 +1983,78 @@ Maximum allowed size is %2 bytes.</source>
         <translation>Version du firmware de l&apos;appareil :</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation>Manuel utilisateur</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation>Challenge de sécurité</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Paramètres de Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Langue de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Afficher les logs du démon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Démarrer l&apos;agent SSH Moolticute automatiquement</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Redémarrage nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Paramètres SSH de Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Redémarrer le démon avec le serveur web de débug (sur le port 8484)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Activer le serveur web du démon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Gérer vos profils de most de passe</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>Profils de mots de passe...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Boutons d&apos;annulation temporisés afin de minimiser le risque d&apos;erreurs</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Activer l&apos;appui long sur les boutons d&apos;annulations</translation>
     </message>
@@ -2078,7 +2078,7 @@ Maximum allowed size is %2 bytes.</source>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Contrôle d&apos;intégrité</translation>
     </message>
@@ -2267,7 +2267,12 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation>Luminosité de l&apos;écran du Mooltipass</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2400,24 +2405,24 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation>Numéro de série de l&apos;appareil :</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Mémoire de l&apos;appareil :</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>Requête d&apos;UID</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Valider</translation>
     </message>
@@ -2430,14 +2435,14 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation type="vanished">Langue de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Démarrer Moolticute avec l&apos;ordinateur: Activé</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Changer</translation>
     </message>
@@ -2446,7 +2451,7 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation type="vanished">Voir les logs du démon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
@@ -2459,7 +2464,7 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation type="vanished">(Redémarrage nécessaire)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Démarrage de l&apos;agent SSH</translation>
     </message>
@@ -2480,17 +2485,17 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation type="vanished">Profils...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>En cours de vérification de l&apos;intégrité de vos identifiants. Cela peut prendre un certain temps. Ne débrancher pas votre Mooltipass pendant la procédure.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>Onglet SSH</translation>
     </message>
@@ -2499,7 +2504,7 @@ Astuce: laisser votre souris sur une option pour avoir plus d&apos;informations.
         <translation type="vanished">Visible sur demande (utilisez CTRL+SHIFT+F1)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>Toujours Visible</translation>
     </message>
@@ -2527,17 +2532,17 @@ You will be prompted for import or export operations if any changes to your Mool
  Si un changement est détecté dans la base de données de votre Mooltipass ou le fichier de sauvegarde sous surveillance, vous serez averti et vous pourrez choisir d&apos;importer ou d&apos;exporter ces changements.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Basse</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Moyenne</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Haute</translation>
     </message>
@@ -2613,32 +2618,32 @@ Réfléchissez-y à deux fois avant d&apos;effacer une carte.</translation>
         <translation type="vanished">Cacher la fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Mot de passe seulement</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Identifiant + Mot de passe</translation>
     </message>
@@ -2663,60 +2668,60 @@ Réfléchissez-y à deux fois avant d&apos;effacer une carte.</translation>
         <translation type="vanished">Ctrl + Alt +Supprl / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Noir</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Blanc</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation>_blanc</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>Récupération de l&apos;UID depuis l&apos;appareil. Cela peut prendre quelques secondes...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>Soit l&apos;appareil a été compromis, soit la clé entrée n&apos;est pas valide.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>L&apos;UID de votre appareil est %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Les identifiants ont été modifiés.
 Voulez-vous sauvegarder vos modifications?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Retirer la carte de votre appareil pour changer ce paramètre.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation>Désactiver la vérification Have I Been Pwned ?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation>Activer la vérification Have I Been Pwned ?</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
@@ -2726,199 +2731,204 @@ Voulez-vous sauvegarder vos modifications?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation>Pas d&apos;inactivité</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation>30 minutes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1Mo</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;En attente de confirmation sur l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirmez la requête sur l&apos;appareil.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Sauvegarde des modifications sur l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Merci d&apos;approuver la requête sur l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Merci d&apos;approuver la requête sur l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Sauvegarde des modifications dans la mémoire de l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporter la base de données depuis l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importer et fusionner le fichier dans l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Sous-domaine sélectionné: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation>Intégration avec &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt; : %2</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translatorcomment>not 100% sure</translatorcomment>
         <translation>Selectionner la base de données</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation>La base de données de votre appareil a bien été exportée.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Le contrôle de l&apos;intégrité de la mémoire est réussi!
 %1 emplacements utilisés  sur %2 possible.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translatorcomment>I made the translation guessing it was &quot;tampered&quot; instead of tempered</translatorcomment>
         <translation>Pour être sûr que personne n&apos;a altéré votre appareil, vous pouvez demander un mot de passe qui vousd permettra de récupérer l&apos;UID de votre appareil.&lt;ol&gt;&lt;li&gt;Récupérer le mot de passe au dos de votre appareil&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: METTER VOTRE NUMERO DE COMMANDE ICI&quot;&gt;Envoyez nous un emaill&lt;/a&gt; avec votre numéro de série et votre numéro de commande en demandant votre mot de passe.&lt;/li&gt;&lt;li&gt;Entrez le mot de passe que nous vous avons envoyé&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>Pour être sûr que personne n&apos;a altéré votre appareil, vous pouvez demander une clé de challenge et l&apos;entrer ci-dessous.&lt;ol&gt;&lt;li&gt;Récupérez le numéro de série au dos de votre appareil&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: A REMPLACER PAR VOTRE NUMERO DE COMMANDE&quot;&gt;Envoyez nous un emaill&lt;/a&gt; avec votre numéro de série et votre numéro de commande en demandant votre clé de challenge.&lt;/li&gt;&lt;li&gt;Entrez la clé que nous vous aurons renvoyé&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation>Alerte d&apos;importation</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation>Les fichiers n&apos;ont pas été importés de la sauvegarde du Mini</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Fichiers d&apos;exports (*.bin)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>La réinitialisation de la carte a échoué!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>La carte a été correctement réinitialisée</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>Sélectionner le fichier CSV à importer...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Rien à lire dans %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>Impossible d&apos;importer %1: chaque ligne doit contenir exactement 3 éléments. Certaines lignes sont incorrectes (lignes numéro: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>Impossible d&apos;importer %1: chaque ligne doit contenir exactement 3 éléments.(Plus de 10  lignes sont incorrectes)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>Impossible d&apos;importer %1: chaque ligne doit contenir exactement 3 éléments séparés par une virgule</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Désactiver la sélection du sous-domaine ?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Activer la sélection de sous-domaine?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2931,12 +2941,12 @@ Voulez-vous sauvegarder vos modifications?</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;En cours d&apos;enregistrement sur l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Echec</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>L&apos;enregistrement a échoué, veuillez contacter l&apos;équipe de support avec les logs de Moolticute</translation>
     </message>
@@ -2953,56 +2963,56 @@ Voulez-vous sauvegarder vos modifications?</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;En cours d&apos;enregistrement dans la mémoire de l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Désactiver le lancement automatique?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Activer le lancement automatique?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>Démarrer Moolticute avec l&apos;ordinateur: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Activé</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Exporter la base de donnée...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
@@ -3029,132 +3039,132 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation>Exporter des mots de passe non-chiffrés vers un fichier CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation>Batterie faible</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation>Le niveau de batterie est inférieur à %1%, veuillez recharger votre Mooltipass.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Très bas</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation>5 minutes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation>10 minutes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation>15 minutes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation>0.5 seconde</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 seconde</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation>2 secondes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation>3 secondes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation>4 secondes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation>5 secondes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation>Laisser Moolticute décider</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation>Forcer l&apos;usage du sous-domaine</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation>Forcer l&apos;omission du sous-domaine</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation>Echec du challenge de sécurité</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation>[Entrée] + Mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation>[Ctrl+Alt+Suppr] + Mot de passe</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation>Mot de passe / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation>Identifiant + Mot de passe / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation>[Entrée] + Mot de passe / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation>[Ctrl+Alt+Suppr] + Mot de passe / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation>Nom du périphérique Bluetooth changé</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation>Veuillez désactiver et réactiver le Bluetooth pour que vos modifications soient prises en compte</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation>Changement de tous les mots de passe impossible, veuillez approuver les demandes sur l&apos;appareil</translation>
     </message>
@@ -3163,23 +3173,23 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation type="vanished">Service en doublon détecté,veuillez contacter le support technique</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Sauvegarde des modifications dans la mémoire de l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Impossible de lire le fichier %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Impossible d&apos;écrire dans le fichier %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>L&apos;import et la fusion de la base de donnée a été réalisée avec succès.</translation>
     </message>
@@ -3188,22 +3198,22 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation type="vanished">Service en doublon détecté durant l&apos;import, veuillez contacter le support technique</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Souhaitez vous démarrer la vérification d&apos;intégrité de votre appareil?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;En attente de la confirmation de l&apos;appareil&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez confirmer la demande sur le Mooltipass.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>La vérification d&apos;intégrité a échoué!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation>Cette procédure prendra environ 5 heures, veuillez confirmer</translation>
     </message>
@@ -3212,42 +3222,42 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation type="vanished">&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Recyclage NiMH en cours.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez patienter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation>En attente du résultat du challenge de sécurité...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation>Recyclage NiMH terminé</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation>Recyclage terminé dans %1 seconds</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation>Erreur du recyclage NiMH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation>Recyclage terminé avec erreur</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation>Confirmez la réinitialisation des paramètres aux valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation>Voulez-vous réinitialiser tous les paramètres aux valeurs par défaut ?</translation>
     </message>
@@ -3260,7 +3270,7 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation type="vanished">Afin d&apos;être sûr que personne n&apos;a altéré votre appareil, vous pouvez demander un mot de passe qui vous permettra de récupérer l&apos;UID de votre appareil.&lt;ol&gt;&lt;li&gt;Obtenez le numéro de série à l&apos;arrière de votre appareil.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1&quot;&gt;Envoyez nous un email&lt;/a&gt; avec le numéro de série, en demandant le mot de passe.&lt;/li&gt;&lt;li&gt;Entrez le mot de passe que vous avez recu&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Langage par défaut du système</translation>
     </message>
@@ -3273,7 +3283,7 @@ Réfléchissez-y à 2 fois avant de réinitialiser une carte.</translation>
         <translation type="vanished">Erreur de gestion de la mémoire</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>

--- a/lang/mc_hu.ts
+++ b/lang/mc_hu.ts
@@ -194,7 +194,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -204,67 +204,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1233,8 +1233,8 @@ A maximum megengedett fájl méret %2 bájt.</translation>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translatorcomment>Multiaranyos :P</translatorcomment>
         <translation>Moolticute</translation>
@@ -1773,7 +1773,7 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1841,17 +1841,17 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1860,134 +1860,134 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/mooltipass/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/mooltipass/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Kártya visszaállítása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Behelyezett kártya törlése</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Kártya Visszaállítása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>CSV fájl importálása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Titkosítatlan jelszavak importálása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>CSV Importálása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Titkosítatlan jelszavak exportálása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>CSV Explortálása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Integritás vizsgálat</translation>
     </message>
@@ -2201,38 +2201,43 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2261,24 +2266,24 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation>Eszköz széria száma:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Eszköz memória:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID Lekérdezése</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Jelszó</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Megerősít</translation>
     </message>
@@ -2287,87 +2292,87 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Megjelenítési Nyelv</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>A Moolticute elindítása a számítógéppel: Bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Módosítás</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Daemon Naplózás Megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Megnéz</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Moolticute SSH Agent-et automatikus elindítása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Szükséges az Újraindítás)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>SSH Agent automatikus indítása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticute SSH Argumentum</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Daemon újraindítása hibakereső web szerverrel (a 8484-es porton)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Daemon Web Szerver Elindítása</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Menedzselje a Jelszó Profiljait</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>Jelszó Profilok...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Elhalasztott Mégsem Gomb a hibák megelőzése érdekében</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Hosszan Tartott Mégsem Gomb Bekapcsolása</translation>
     </message>
@@ -2376,27 +2381,27 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A viselkedése ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>Rendszertálca ikon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Subdomain kijelölése: Bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>Most az ön hitelesítő adatainak az integritás ellenőrzése megy. Ez altarthat egy darabig.  Kérem ne húzza ki a kábelt és ne kapcsolja le a Mooltipassot a gépről.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation>Szövegcímke</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSH kulcs fül</translation>
     </message>
@@ -2406,7 +2411,7 @@ Tipp: tartsa az egeret az opció fölött, hogy több információt kapjon arró
         <translation type="vanished">Látható KÉ&amp;RÉSRE  (hasznája a CTRL+SHIFT+F1 billenyű parancsot)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translatorcomment>wtf is this? &quot;ALWA&amp;YS visible&quot; lol?</translatorcomment>
         <translation>MIN&amp;DIG látszódik</translation>
@@ -2461,22 +2466,22 @@ Gondolja át újra mielőtt egy ismeretlen kártyát letöröl.</translation>
         <translation>Exportálja a kódolatlan formátumban a jelszavakat csak vesszővel szeparált érékeként text fáljba.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Nagyon Alacsony</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Alacsony</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Közepes</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Magas</translation>
     </message>
@@ -2505,32 +2510,32 @@ Gondolja át újra mielőtt egy ismeretlen kártyát letöröl.</translation>
         <translation type="vanished">Ablak elrejtése</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>&amp;Fálj</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>&amp;Kilépés</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Kikapcsolás</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Csak Jelszó</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Login és Jelszó</translation>
     </message>
@@ -2555,51 +2560,51 @@ Gondolja át újra mielőtt egy ismeretlen kártyát letöröl.</translation>
         <translation type="vanished">Ctrl + Alt + Del / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Fekete</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Fehér</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation>_fehér</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>UID azonosító lekérdezése folyamatban van. Ez eltarthat néhány másodpercig...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translatorcomment>I had to reverse sentence order to make sense of it.</translatorcomment>
         <translation>A megadott kulcs érvénytelen vagy az eszközt illetéktelenek módosították.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>Az eszköze UID-je : %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Belépési azonosító változott.
 Elszerené menteni a változtatásokat?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Vegye ki a kártyát az eszközből ahhoz, hogy ezen beállítást módisíthassa.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Semmi</translation>
     </message>
@@ -2649,473 +2654,478 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1Mb</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Eszköz megerősítésre vár&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Erősítse meg a kérést az eszközén.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Folyamatban van a változtatások mentése az eszközre&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kérem várjon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Nem lehetett elmenteni a hitelesítő adatokat, kérem lépjek kapcsolatba a fejlesztő csapattal a moolticute logját csatolva</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">1 másodperc {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 másodperc</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Kérem hitelesítse a kérést az eszközén&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Kérem hitelesítse a kérést az eszközén&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Változtatások mentése az eszköz memóriájába&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kérem várjon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Adatbázis exportálása az eszközről&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kérem várjon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Fájl importálása és egyesítése az eszközön&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kérem várjon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Kikapcsolja az automatikus indítást bekapcsoláskor?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Bekapcsolja az automatikus indítást bekapcsoláskor?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>A Moolticute indítása rendszerindításakor: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Kikapcsol</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Bekapcsol</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Subdomain kijelölés: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translatorcomment>Selecting a database or something within a database to export?</translatorcomment>
         <translation>Jelölje ki az adatbázist exportálásra...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Nem lehet olvasni a %1 fájlt</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Exportált adatbázis elmentése...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Nem lehet a %1 nevű fájlra írni</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>Az adatbázi importálása és eggyesítése az eszközön sikeresen megtörtént.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Szeretné elindítani az eszköz integritás vizsgálatát?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Eszköz megerősítésre vár&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kérem erősítse meg a kérelmet az eszközön.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>Memória integritás vizsgálata meghiúsult!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Memória integritás vizsgálat skieresen befejeződött!
 %1 a %2 jelszó tárhelyből már foglalt.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>Hogy megyőződjünk arról, hogy senki sem babrált az eszközével szállitás közben, ön kérhet a készitőtől egy egyedi eszökz azonositó jelszavat amelyel előhivhatja az eszköze UID-ját.&lt;ol&gt;&lt;li&gt;Készitse elő az eszköze széria számát a hátoldaláról.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Küldjön nekünk egy e-mail-t.&lt;/a&gt; az ön széria számával a jelszóért cserébe.&lt;/li&gt;&lt;li&gt;A kapott jelszavat irja be.&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>Kártya visszaállítás sikertelen!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>Kártya vissza állítás sikeres volt</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>Jelölje ki a CSV fájlt importálásra...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Semmi nem lett beolvasva a %1 -tól</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>Nem lehetséges importálni a %1: Minden sornak pontosan 3 elemet kell tartalmaznia. Néhány sor nem (ezen sorokban: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>Nem lehetséges importálni a %1: Minden sornak pontosan 3 elemet kell tartalmaznia. (több mint 10 sornak nincs ilyen)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>Nem lehetséges importálni a %1: Minden sornak pontosan 3 elemet kell tartalmaznia és vesszőt kell használni a delimitálóként.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Kikapcsolja a subdomain funkciót?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Bekapcsolja a subdomain funkciót?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3133,7 +3143,7 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Memória Menedzsment Hiba</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3142,12 +3152,12 @@ Think twice before resetting a card.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Rendszer alapértelmezett nyelve</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translatorcomment>I&apos;m not srue if I&apos;m supposed to rename technical terms here.</translatorcomment>
         <translation>Memória export (*.bin)</translation>

--- a/lang/mc_ja.ts
+++ b/lang/mc_ja.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,67 +203,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1211,8 +1211,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation>Moolticute</translation>
     </message>
@@ -1743,7 +1743,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1772,74 +1772,74 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1849,50 +1849,50 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1932,7 +1932,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>整合性チェック</translation>
     </message>
@@ -2145,38 +2145,43 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2205,24 +2210,24 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>デバイスシリアル：</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>デバイスメモリ：</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID要求</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>パスワード</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>検証する</translation>
     </message>
@@ -2231,133 +2236,133 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute設定</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>アプリケーション言語</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>コンピュータでMoolticuteを起動する：有効</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>変更する</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>デーモンログを表示する</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Moolticute SSHエージェントを自動的に起動する</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>（再起動が必要）</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>SSHエージェントを自動スタートする</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticute SSH引数</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>デバッグWebサーバーでデーモンを再起動する（ポート8484）</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>デーモンWebサーバーを有効にする</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>パスワードプロファイルの管理</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>パスワードプロファイル...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>間違いを防ぐための遅延キャンセルボタン</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>長押しボタンを有効にする</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>保存された資格情報の整合性をチェックします。 これは時間がかかる場合があります。 確認の間、Mooltipassのプラグを抜かないでください。</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation>TextLabel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSHキータブ</translation>
     </message>
@@ -2366,7 +2371,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="vanished">表示&amp;オンデマンド（CTRL + SHIFT + F1キーボードショートカットを使用）</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>常に&amp;目に見える</translation>
     </message>
@@ -2398,17 +2403,17 @@ Mooltipassデータベースまたは監視対象ファイルへの変更が検�
         <translation type="vanished">MooltiAppバックアップファイルには暗号化されたログインがありません。</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>低い</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>中くらい</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>高い</translation>
     </message>
@@ -2428,32 +2433,32 @@ Mooltipassデータベースまたは監視対象ファイルへの変更が検�
         <translation>Space</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation type="unfinished">&amp;終了</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>無効</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>パスワードだけ</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>ログイン&#x3000;＋&#x3000;パスワード</translation>
     </message>
@@ -2474,49 +2479,49 @@ Mooltipassデータベースまたは監視対象ファイルへの変更が検�
         <translation type="vanished">Enter&#x3000;+&#x3000;パスワードやWin&#x3000;+&#x3000;L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>デバイスからUIDを取得しています。 これには数秒かかることがあります...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>デバイスが改ざんされているか、入力キーが無効です。</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>あなたのデバイスのUIDは「%1」</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>この設定を変更するには、デバイスからカードを取り外します。</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
@@ -2566,440 +2571,445 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1Mb</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイスの確認を待つ&lt;/span&gt;&lt;/p&gt;&lt;p&gt;デバイス上の要求を確認します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイスへの変更の保存&lt;/span&gt;&lt;/p&gt;&lt;p&gt;お待ちください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>失敗</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>資格情報を保存できませんでした.Moolticuteのログでサポートチームにお問い合わせください</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">１秒 {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">１秒</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイス上でリクエストを承認してください&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイス上でリクエストを承認してください&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイスのメモリに変更を保存する&lt;/span&gt;&lt;/p&gt;&lt;p&gt;お待ちください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイスからのデータベースのエクスポート&lt;/span&gt;&lt;/p&gt;&lt;p&gt;お待ちください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイスへのファイルのインポートとマージ&lt;/span&gt;&lt;/p&gt;&lt;p&gt;お待ちください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>起動時に自動起動を無効にしますか？</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>起動時に自動起動を有効にしますか？</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>コンピュータでMoolticuteを起動する： %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>無効する</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>無効する</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>データベースのエクスポートを保存...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -3014,38 +3024,38 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>ファイル「%1」を読み取れません</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>ファイル「%1」に書き込めません</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>データベースをインポートし、デバイスにマージしました。</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>あなたのデバイスの整合性チェックを開始しますか？</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;デバイス確認待ち&lt;/span&gt;&lt;/p&gt;&lt;p&gt;デバイス上の要求を確認します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>メモリの整合性チェックに失敗しました！</translation>
     </message>
@@ -3062,7 +3072,7 @@ Think twice before resetting a card.</source>
         <translation type="vanished">メモリ管理エラー</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3071,12 +3081,12 @@ Think twice before resetting a card.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>システムのデフォルト言語</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>メモリのエクスポート (*.bin)</translation>
     </message>

--- a/lang/mc_ko.ts
+++ b/lang/mc_ko.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation>잘못된 번들 파일이 선택되었습니다.</translation>
     </message>
@@ -203,67 +203,67 @@
         <translation>지정된 번들 파일 이름이 올바르지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation>번들 파일 이름에 장치 일련 번호가 올바르지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation>번들 파일 이름에 번들 버전이 올바르지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation>배터리가 너무 부족하여 번들을 업로드할 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation>장치를 USB로 연결하고 완전히 충전한 상태여야 합니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation>번들 파일 선택</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation>잘못된 경로</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation>번들에 대해 선택한 경로가 파일이 아닙니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation>지정된 번들 파일이 올바르지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation>번들 파일 업로드 시작.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation>번들 결과 업로드</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation>번들 업로드가 성공적으로 완료되었습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation>번들 업로드가 오류와 함께 완료되었습니다.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation>데이터를 가져올 파일 선택</translation>
     </message>
@@ -1200,8 +1200,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation></translation>
     </message>
@@ -1890,7 +1890,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>무결성 검사</translation>
     </message>
@@ -2005,327 +2005,332 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>잘못된 일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>장치 메모리:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation>보조 MCU 버전:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation>메인 MCU 버전:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation>번들 버전:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation>사용자 설명서</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID 요청</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>비밀번호</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>유효성 검사</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation>보안 과제</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute 설정</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>애플리케이션 언어</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>컴퓨터로 Moolticute를 시작합니다: 활성화됨</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>데몬 로그 보기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>보기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation>전체 개발자 로그 사용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(재시작 필요)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation>디버그 로그 활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation>유효하지 않거나 비공개 TLD 사용 허용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation>TLD 확인 비활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Moolticute SSH 에이전트 자동 시작</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>SSH 에이전트 자동 시작</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticute SSH 인자</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>디버그 웹 서버로 데몬 재시작(포트 8484에서)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>데몬 웹 서버 사용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation>Have I Been Pwned와 통합: 활성화됨</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>하위 도메인 선택: 활성화됨</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>비밀번호 프로필 관리</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>비밀번호 프로필...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation>기본 비밀번호 길이</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation>화면이 잠겨 있을 때 기기 잠금</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation>장치 잠금 사용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>실수를 방지하는 지연 취소 버튼</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>길게 누르기 취소 버튼 활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation>백업 알림 배너</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation>백업 알림 사용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation>Moolticute 튜토리얼 표시</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation>튜토리얼 표시</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation>선택시 디바이스 연결 시 특정 카테고리를 설정하도록 moolticute를 설정할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation>연결되면 카테고리를 강제 적용합니다:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>시스템트레이 아이콘</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>이제 저장된 자격 증명의 무결성을 확인합니다. 시간이 걸릴 수 있습니다. 확인하는 동안 Mooltipass의 연결을 제거하지 마세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>CSV 파일 가져오기/내보내기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>암호화되지 않은 비밀번호 가져오기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>CSV 가져오기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>암호화되지 않은 비밀번호 내보내기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>CSV 내보내기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSH 키 탭</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation>주문형 표시(&amp;M)(단축키 SHIFT+F1 사용)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>항상 표시(&amp;Y)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>카드 재설정</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>삽입된 카드 지우기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>카드 재설정</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation>가져오기</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation>사용 가능한 사용자 수:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation>NiMH 리컨디셔닝</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation>NiMH 리컨디셔닝 시작</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation>공칭 용량에 도달할 때까지 계속 진행</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
@@ -2410,412 +2415,417 @@ Think twice before resetting a card.</source>
         <translation>메인 MCU 버전:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation>배터리 부족</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation>배터리가 %1% 미만입니다. Mooltipass를 충전하세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>매우 낮음</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>낮음</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>보통</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>높음</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation>비활성 상태 없음</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation>10 분</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation>15 분</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation>30 분</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation>0.5 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation>1 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation>2 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation>3 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation>4 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation>5 초</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation>Moolticute가 결정합니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation>하위 도메인 강제 지원</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation>하위 도메인 강제 무시</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>파일(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>종료(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>검정</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>흰색</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>장치에서 UID를 가져옵니다. 몇 초 정도 걸릴 수 있습니다...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>장치가 템퍼링되었거나 입력 키가 유효하지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>장치의 UID는 %1입니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation>보안 챌린지 실패</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>비밀번호 전용</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>로그인 + 비밀번호</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation>[Enter] + 비밀번호</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation>[Ctrl+Alt+Del] + 패스</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation>비밀번호 / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation>로그인 + 패스 / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation>[Enter] + 패스 / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation>[Ctrl+Alt+Del] + 패스 / [Win+L]</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>자격 증명이 수정되었습니다.
 변경 사항을 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation>블루투스 이름 변경</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation>변경 사항을 적용하려면 블루투스를 비활성화했다가 다시 활성화하세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>이 설정을 변경하려면 장치에서 카드를 제거합니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;장치 확인 대기 중&lt;/span&gt;&lt;/p&gt;&lt;p&gt;기기에서 요청을 확인합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;장치에 변경 사항 저장&lt;/span&gt;&lt;/p&gt;&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation>모든 비밀번호를 변경할 수 없습니다. 기기에서 메시지가 표시되면 승인해 주세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>자격 증명을 저장할 수 없습니다. moolticute의 로그와 함께 지원팀에 문의하세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>실패</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;기기에서 요청을 승인해 주세요&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;기기에서 요청을 승인해 주세요&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;디바이스의 메모리에 변경 사항 저장&lt;/span&gt;&lt;/p&gt;&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;디바이스의 메모리에 변경 사항 저장&lt;/span&gt;&lt;/p&gt;&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;장치에서 데이터베이스 내보내기&lt;/span&gt;&lt;/p&gt;&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;장치로 파일 가져오기 및 병합&lt;/span&gt;&lt;/p&gt;&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>부팅 시 자동 시작을 비활성화하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>부팅 시 자동 시작을 사용하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>컴퓨터에서 Moolticute 시작: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>활성화됨</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>활성화</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>하위 도메인 선택: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation>&lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;와 통합: %2</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation>데이터베이스 내보내기 선택...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>에러</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>%1파일을 읽을 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>데이터베이스 내보내기 저장...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>%1파일에 쓸 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation>장치에서 데이터베이스를 성공적으로 내보냈습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>데이터베이스를 장치로 성공적으로 가져와 병합했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>디바이스의 무결성 검사를 시작하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;장치 확인 대기 중&lt;/span&gt;&lt;/p&gt;&lt;p&gt;기기에서 요청을 확인합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>메모리 무결성 검사에 실패했습니다!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>메모리 무결성 검사가 성공적으로 완료되었습니다!
 자격 증명 슬롯 %2개 중 %1개를 사용했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>장치에 템퍼링한 사람이 없는지 확인하기 위해 장치의 UID를 가져올 수 있는 비밀번호를 요청할 수 있습니다.&lt;ol&gt;&lt;li&gt;장치 뒷면에서 일련번호를 가져옵니다.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;일련 번호와 주문 번호가 포함된 이메일&lt;/a&gt;로 비밀번호를 요청하세요.&lt;/li&gt;&lt;li&gt;받은 비밀번호를 입력하세요&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>다른 사람이 장치를 조작하지 않았는지 확인하기 위해 챌린지 문자열을 요청하고 아래에 입력할 수 있습니다.&lt;ol&gt;&lt;li&gt;장치 뒷면에서 일련 번호를 가져옵니다.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;일련 번호와 주문 번호가 포함된 이메일&lt;/a&gt;로 챌린지 문자열을 요청하세요.&lt;/li&gt;&lt;li&gt;당사에서 받은 문자열을 입력하세요&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -2824,170 +2834,170 @@ Do you want to save your changes?</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>시스템 기본 언어</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation>가져오기 경고</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation>미니 백업에서 파일을 가져오지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH 리컨디셔닝이 진행 중입니다.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;잠시만 기다려주세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>메모리 내보내기(*.bin)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>카드 재설정에 실패했습니다!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>카드 재설정이 성공적으로 완료되었습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>가져올 CSV 파일 선택...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>%1에서 읽은 내용이 없습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>%1을(를) 가져올 수 없습니다: 각 행에 정확히 3개의 항목이 포함되어야 합니다. 일부 행이 그렇지 않습니다(행 번호: %2).</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>%1을(를) 가져올 수 없습니다: 각 행에 정확히 3개의 항목이 포함되어야 합니다(10줄 이상은 안 됨).</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>%1을(를) 가져올 수 없습니다: 각 행은 쉼표를 구분 기호로 사용하여 정확히 3개의 항목을 포함해야 합니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>하위 도메인 선택을 비활성화하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>하위 도메인 선택을 사용하시나요?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation>Have I Been Pwned 확인을 비활성화하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation>Have I Been Pwned 확인을 설정하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation>이 절차는 약 5시간 정도 소요되며, 다음 사항을 확인하시기 바랍니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation>이 토큰은 디버깅 목적으로만 사용됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation>보안 챌린지 결과를 기다리는 중...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation>NiMH 리컨디셔닝 완료</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation>1초 후에 재조정 완료</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation>NiMH 리컨디셔닝 오류</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation>오류로 재조정 완료</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation>기본값으로 설정 재설정 확인</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation>모든 설정 값을 디바이스 기본값으로 초기화하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation>잘못된 일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation>장치 일련 번호가 장치 케이스에 표시된 번호와 일치하지 않는 것 같습니다.
 </translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation>아래에서 올바른 코드를 입력하려면 support@themooltipass.com 으로 문의하세요.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation>입력한 일련번호가 올바르지 않습니다!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation>일련 번호 변경</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation>일련 번호를 성공적으로 설정했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation>일련 번호가 여전히 플랫폼 일련 번호와 일치하지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation>일련 번호 설정에 실패했습니다.</translation>
     </message>

--- a/lang/mc_nl.ts
+++ b/lang/mc_nl.ts
@@ -195,7 +195,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -205,67 +205,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1231,8 +1231,8 @@ Maximaal toegestane grootte is %2 bytes.</translation>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation>Moolticute</translation>
     </message>
@@ -1769,7 +1769,7 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1798,17 +1798,17 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1821,60 +1821,60 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gedrag van ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translatorcomment>Systray is a technical term, the question is whether it warrants translation</translatorcomment>
         <translation>Systray icoon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Subdomeinselectie: Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Kaart herinitialiseren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Ingegeven kaart wissen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Kaart Herinitialiseren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>CSV-bestand importeren/exporteren</translation>
     </message>
@@ -1884,50 +1884,50 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Importeer versleutelde wachtwoorden</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>CSV importeren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Exporteer onversleutelde wachtwoorden</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>CSV exporteren</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1967,7 +1967,7 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Controleer integriteit</translation>
     </message>
@@ -2180,38 +2180,43 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2240,24 +2245,24 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation>Apparaat serienummer:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Apparaat geheugen:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID aanvraag</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Valideer</translation>
     </message>
@@ -2266,133 +2271,133 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Taal van de applicatie</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Start Moolticute met je computer: Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Bekijk het achtergrondproceslogboek</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Start Moolticute SSH Agent automatisch</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Herstart noodzakelijk)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Autostart SSH Agent</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticute SSH argumenten</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Herstart het achtergrondproces met Debug Web Server (op poort 8484)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Schakel de achtergrondproces wen server in</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Beheer je wachtwoordprofielen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>wachtwoordprofielen...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Vertraag afbraakknoppen om vergissingen te voorkomen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Schakel langdurig induwen van afbreekknoppen in</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>De integriteit van de opgeslagen logingegevens wordt nu gecontroleerd. Dit kan even duren. Gelieve je Mooltipass aangesloten te laten tijdens het controleren.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSH Sleutel Tabblad</translation>
     </message>
@@ -2402,7 +2407,7 @@ Hint: zweef met je muis boven een bepaalde optie om meer details weer te geven.<
         <translation type="vanished">Zichtbaar op aanvraag  (gebruik CTRL+SHIFT+F1 sneltoets)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translatorcomment>No Y in this translation, what should I do?</translatorcomment>
         <translation>Altijd zichtbaar</translation>
@@ -2435,17 +2440,17 @@ Je zal meldingen krijgen voor import- of exportoperaties indien er wijzigingen a
         <translation type="vanished">Het MooltiApp backupbestand bevat geen geëncrypteerde logingegevens.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Laag</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Gemiddeld</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
@@ -2473,34 +2478,34 @@ Je zal meldingen krijgen voor import- of exportoperaties indien er wijzigingen a
         <translation type="vanished">Venster Verbergen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translatorcomment>No F in this translation, what should I do?</translatorcomment>
         <translation>Bestand</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translatorcomment>No Q in this translation, what should I do?</translatorcomment>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Enkel het wachtwoord</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Gebruikersnaam + Wachtwoord</translation>
     </message>
@@ -2525,51 +2530,51 @@ Je zal meldingen krijgen voor import- of exportoperaties indien er wijzigingen a
         <translation type="vanished">Ctrl + Alt + Del / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Zwart</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Wit</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation>_wit</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>UID van het apparaat aan het ophalen. Dit kan enkele seconden duren...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translatorcomment>Key as in keyboard key or key as in private key public key? Cause that&apos;s a different word. Invoersleutel is for a private key, use &quot;invoertoets&quot; is it&apos;s a keyboard key</translatorcomment>
         <translation>Ofwel is er geknoeid met het apparaat, ofwel is de invoersleutel ongeldig.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>Je apparaat&apos;s UID is %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Logingegevens zijn aangepast.
 Wilt je je wijzigingen opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Verwijder de kaart uit je apparaat om deze instelling te kunnen wijzigen.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
@@ -2619,442 +2624,447 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1Mb</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Aan het wachten op apparaatsbevestiging&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Gelieve de aanvraag op het apparaat te bevestigen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Wijzigingen op het apparaat aan het opslaan&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Gelieve te wachten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Fout bij het opslaan</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Kon de logingegevens niet opslaan, gelieve het ondersteuningsteam te contacteren met je moolticute logboek</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">1 seconde {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 seconde</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Gelieve de aanvraag te bevestigen op het apparaat&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Gelieve de aanvraag te bevestigen op het apparaat&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Wijzigingen in het geheugen van je apparaat aan het opslaan&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Gelieve te wachten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Database aan het exporteren vanaf je apparaat&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Gelieve te wachten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Bestand aan het importeren en samenvoegen op je apparaat&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Gelieve te wachten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Autostart uitschakelen bij systeemstart?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Autostart inschakelen bij systeemstart?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translatorcomment>with seems weird in English here</translatorcomment>
         <translation>Start Moolticute met computer: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Inschakelen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Subdomeinselectie: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation>Geëxporteerde database selecteren...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Database export opslaan...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Geheugenintegriteitscontrole succesvol afgerond!
 %1 van de %2 logingegevenssloten in gebruik.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>Om zeker te zijn dat er niet is geknoeid met je toestel kan je een wachtwoord opvragen dat het mogelijk maakt de UID van je apparaat te achterhalen.&lt;ol&gt;&lt;li&gt;Vind het serienummer op de achterkant van je apparaat.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1&quot;&gt;Stuur ons een mail (in het Engels)&lt;/a&gt; met het serienummer en de vraag voor het wachtwoord.&lt;/li&gt;&lt;li&gt;Geef vervolgens het ontvangen wachtwoord in.&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>Herinitialiseren van de kaart is msilukt!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>Herinitialiseren van de kaart was succesvol</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>Selecteer het CSV-bestand om te importeren...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Er is niets om te lezen in %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>Kon niets importeren uit %1: Elke rij moet precies 3 delen bevatten. Bij sommige lijnen is dat niet zo (lijnnummers: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>Kon niets importeren uit %1: Elke rij moet precies 3 delen bevatten. Bij sommige lijnen is dat niet zo (meer dan 10 lijnen)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>Kon niets importeren uit %1: Elke rij moet precies 3 delen bevatten gescheiden door komma&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Subdomeinselectie uitschakelen?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Subdomeinselectie inschakelen?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
@@ -3081,38 +3091,38 @@ Denk dus goed na voordat je de kaart herinitialiseert.</translation>
         <translation>Exporteer versleutelde wachtwoorden naar een CSV-tekstbestand (komma gescheiden waarden).</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Heel Leeg</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Kon niet lezen uit bestand %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Kon niet schrijven naar bestand %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>Database succesvol geimporteerd en in je apparaat gevoegd.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Wil je een integriteitscontrole van je apparaat starten?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Aan het wachten op apparaatbevestiging&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bevestig de aanvraag op je apparaat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>Geheugenintegriteitscontrole is gefaald!</translation>
     </message>
@@ -3130,7 +3140,7 @@ Denk dus goed na voordat je de kaart herinitialiseert.</translation>
         <translation type="vanished">Geheugenbeheersfout</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3139,12 +3149,12 @@ Denk dus goed na voordat je de kaart herinitialiseert.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Standaard systeemstaal</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Geheugenexports (*.bin)</translation>
     </message>

--- a/lang/mc_pt.ts
+++ b/lang/mc_pt.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,67 +203,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1205,8 +1205,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation>Moolticute</translation>
     </message>
@@ -1737,7 +1737,7 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1766,74 +1766,74 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1843,50 +1843,50 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1926,7 +1926,7 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Verificar integridade</translation>
     </message>
@@ -2139,38 +2139,43 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2199,24 +2204,24 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation>Número de Série do Dispositivo:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Memória do Dispositivo:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>Pedido de UID</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Validar</translation>
     </message>
@@ -2225,133 +2230,133 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Definições do Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Idioma da Aplicação</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Iniciar o Moolticute com o computador: ativado</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Alterar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Ver lgos do serviço</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Iniciar o agente SSH do Moolticute Automáticamente</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Necessário reiniciar)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Iniciar automáticamente o agente SSH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Argumentos SSH do Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Reiniciar o serviço em mdo debug com o servidor web (porta 8484)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Gerir os seus perfis de password</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Botões de Cancelar atrasados para evitar erros</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Habilitar o pressionar logo, nos botões de Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>Verificando a integridade de suas credenciais armazenadas. Isso pode demorar um pouco. Por favor, não desligue o seu Mooltipass durante o check-in.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation>Etiqueta de Texto</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>Guia Chave SSH</translation>
     </message>
@@ -2360,7 +2365,7 @@ Dica: mantenha seu rato posicionado sobre uma opção para obter mais detalhes.<
         <translation type="vanished">Visivel a Pe&amp;dido (utilize o atalho de teclado CRTL+SHIFT+F1 )</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>Sem&amp;pre Visivel</translation>
     </message>
@@ -2388,17 +2393,17 @@ You will be prompted for import or export operations if any changes to your Mool
 Ser-lhe-á solicitada a importação ou exportação  se qualquer alteração na sua base de dados Mooltipass ou arquivo monitorizado for detectada.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Baixo</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Médio</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Elevado</translation>
     </message>
@@ -2418,32 +2423,32 @@ Ser-lhe-á solicitada a importação ou exportação  se qualquer alteração na
         <translation>Espaço</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation type="unfinished">&amp;Sair</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Desabilitado</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Apenas Password</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Login + Password</translation>
     </message>
@@ -2464,49 +2469,49 @@ Ser-lhe-á solicitada a importação ou exportação  se qualquer alteração na
         <translation type="vanished">Enter + Pass / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>Obtendo o UID do dispositivo. Isso pode demorar alguns segundos...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>O dispositivo foi adulterado ou a chave de entrada é inválida.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>O UID do seu dispositivo é %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Remova o cartão do dispositivo para alterar esta configuração.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
@@ -2556,440 +2561,445 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1Mb</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Aguardando confirmação do dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirme pedido no seu dispositivo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Gravar alterações no dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Por favor aguarde.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Falha</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Não foi possível gravar as credenciais, entre em contato com a equipe de suporte com o log do moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">1 segundo {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 segundo</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Por favor Aprove o Pedido no Dispositivo &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Por favor aprove o pedido no Dispositivo&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Gravando alterações na memória do dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Por favor aguarde.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exportar base de dados do Dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Por favor aguarde.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importando e unindo arquivos para o dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Por favor, aguarde.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Desabilitar arranque automático na inicialização?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Activar arranque automático na iticialização?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>Iniciar Moolticute com o computador:%1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Habilitar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Desabilitar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Salvar exportação da base de dados...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
@@ -3004,38 +3014,38 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Impossivel ler o ficheiro %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Não é possível gravar no arquivo%1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>Importada e unida a base de dados para o dispositivo.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Deseja iniciar a verificação de integridade do seu dispositivo?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Esperando a confirmação do dispositivo&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirme o pedido no seu dispositivo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>A verificação da integridade da memória falhou!</translation>
     </message>
@@ -3052,7 +3062,7 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Erro de gestãoo de memória</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3061,12 +3071,12 @@ Think twice before resetting a card.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Idioma padrão do sistema</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Exportações de memória (* .bin)</translation>
     </message>

--- a/lang/mc_ru.ts
+++ b/lang/mc_ru.ts
@@ -2074,7 +2074,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
     <message>
         <location filename="../src/MainWindow.ui" line="3386"/>
         <source>Community Creation</source>
-        <translation type="unfinished"></translation>
+        <translation>Устройство собрано сообществом</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="4154"/>
@@ -2715,7 +2715,7 @@ Think twice before resetting a card.</source>
     <message>
         <location filename="../src/MainWindow.cpp" line="1695"/>
         <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Ваше устройство (серийный номер %1) создано кем-то из сообщества mooltipass и авторы никак не связаны с основной командой Mooltipass!&lt;ol&gt;&lt;li&gt; Mooltipass это проект с открытым исходным кодом и конструкторской документацией, потому его может собрать любой человек обладающий навыком;&lt;/li&gt;&lt;li&gt;Мы никак не можем провести проверку безопасности такого устройства, так как не мы его делали и у нас нет соответствующих данных;&lt;/li&gt;&lt;li&gt;Это меню отключено, чтобы никто по ошибке не отправил нам письма и не было недопонимания;&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="2557"/>

--- a/lang/mc_ru.ts
+++ b/lang/mc_ru.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation>Выбран некоррентный файл пакета</translation>
     </message>
@@ -203,67 +203,67 @@
         <translation>Введенное имя файла пакета содержит ошибку.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation>Серийный номер устройства не совпадает с серийным номеров в пакете обновления.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation>Версия пакета не является корректной в выбранном файле.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation>Батарея слишком сильно разряжена, загрузка пакета невозможна</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation>Пожалуйста, подключите устройство по USB и полностью зарядите</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation>Выбор файла пакета</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation>Некорректный путь</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation>Выбранный путь пакета не является файлом.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation>Выбранный файл пакета не является корректным.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation>Начало загрузки пакета.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation>Результат загрузки пакета</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation>Загрузка пакета успешно завершена.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation>Загрузка пакета завершена с ошибкой.</translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation>Выберите файл, куда сохранить данные</translation>
     </message>
@@ -1198,8 +1198,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation></translation>
     </message>
@@ -1585,193 +1585,193 @@ Maximum allowed size is %2 bytes.</source>
         <translation>Версия прошивка устройства:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation>Версия прошивки AUX MCU:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation>Версия прошивки Main MCU:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation>Версия пакета:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Настройки Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Язык приложения</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Посмотреть логи сервиса</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Запускать Moolticute SSH Agent автоматически</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Требуется перезапуск)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Аргументы командной строки для Moolticute SSH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Перезапустить службу с включенным отладочным веб-сервером (на порту 8484)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Включить веб-сервер службы Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Управление профилями паролей</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>Профили паролей...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Задержка для кнопок отмены чтобы избежать ошибок</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Включить долгое нажатие на кнопки отмены</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation>когда выбрано, moolticute будет устанавливать определенную категорию при подключении устройства</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation>При подключении, выбирать категорию:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation>Интеграция с сервисом &apos;Have I Been Pwned&apos;: Включена</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation>Включить полный лог (для разработчиков)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation>Включить отладочный лог</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation>Длина пароля по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation>Уведомление о резервном копировании</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation>Включить уведомление о резервном копировании</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation>Отображать обучение при старте</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation>Отображать обучение</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Сброс карты</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Сбросить карту в устройстве</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Сброс карты</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>Импорт/экспорт CSV файла</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Импортирование незашифрованных паролей</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>Импорт CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Экспорт незашифрованных паролей</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>Экспорт CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation>Запросить</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation>Число доступных пользователей:</translation>
     </message>
@@ -1787,7 +1787,7 @@ Maximum allowed size is %2 bytes.</source>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Проверка целостности</translation>
     </message>
@@ -2072,43 +2072,48 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>Неправильный серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation>Разрешить использование неправильных или частных доменных имен</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation>Отключение проверки TLD</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation>Блокировать устройство при блокировке экрана ПК</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation>Включить блокировку устройства</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation>Видима по &amp;требованию (При нажатии SHIFT+F1)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation>Восстановление емкости NiMH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation>Начать процедуру</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation>До достижения номинальной емкости</translation>
     </message>
@@ -2278,84 +2283,84 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>Серийный номер устройства:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Память устройства:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation>Руководство по эксплуатации (EN)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>Запрос UID устройства</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Проверить</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Запуск Moolticute вместе с компьютером: Включено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Изменить</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Просмотр</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Автоматически запускать SSH агент</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>Значок в системном трее</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Выбор поддомена: Включено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>Проверяем целостность сохраненных учетных данных на устройстве. Пожалуйста, не выдергивайте Ваш Mooltipass из компьютера во время проверки.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>Вкладка с ключами для SSH</translation>
     </message>
@@ -2364,7 +2369,7 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="vanished">Видима по &amp;требованию (Используйте CTRL+SHIFT+F1)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>Всегда &amp;видима</translation>
     </message>
@@ -2384,22 +2389,22 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>Экспортировать незашифрованные пароли в CSV фаайл.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Очень низкая</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Низкая</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Средняя</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Высокая</translation>
     </message>
@@ -2419,79 +2424,79 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation>Пробел</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Только пароль</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Логин + Пароль</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Темный</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Светлый</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>Запрашиваю UID у устройства, это займет несколько секунд...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>Либо кто-то вмешивался в устройство, либо введенный ключ не является корректным.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>UID Вашего устройства: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Учетные данные изменены. Сохранить?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Удалите карту из устройства для изменения этой настройки.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Отсутствует</translation>
     </message>
@@ -2543,38 +2548,38 @@ Think twice before resetting a card.</source>
         <translation>Версия прошивки MAIN MCU:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation>Нет активности</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation>30 минут</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Ожидаю подтверждения на устройстве&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Подтвердите запрос на устройстве.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Сохраняем настройки в устройство&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Не удалось сохранить учетные данные. Пожалуйста, отправте лог moolticute разработчикам</translation>
     </message>
@@ -2583,170 +2588,175 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Вышел новый пакет обновления ПО. Скачать можно &lt;a href=&quot;https://www.themooltipass.com/updates/index.php?sn=%1&amp;bundlev=%2&quot;&gt;тут.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation>Низкий заряд батареи</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation>Заряд батареи ниже %1%, пожалуйста зарядите Mooltipass.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation>5 минут</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation>10 минут</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation>15 минут</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation>0.5 секунды</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation>1 секунда</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation>2 секунды</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation>3 секунды</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation>4 секунды</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation>5 секунд</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation>НянКотэ</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation>Пусть выбирает Moolticute</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation>Принудительно включить поддержку поддоменов</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation>Принудительно игнорировать поддомены</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation>Security Challenge завершен с ошибкой</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation>Имя bluetooth устройства изменено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation>Пожалуйста, выключите и снова включитет bluetooth для того, чтобы изменения вступили в силу</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation>Не удалось изменить все паролт, пожалуйста согласитесь на запросы на устройстве</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation>Неправильный Серийный Номер</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation>Похоже, что серийный номер на корпусе устройствав не совпадает с тем, что есть в памяти.
 </translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation>Обратитесь в службу поддержки по адресу support@themooltipass.com за правильным кодом и введите его ниже</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation>Серийный номер введен неправильно!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation>Изменение Серийного Номера</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation>Серийный номер установлен успешно.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation>Серийный номер все еще не совпадает с серийным номером платформы.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation>Не удалось выставить серийный номер.</translation>
     </message>
@@ -2755,93 +2765,93 @@ Think twice before resetting a card.</source>
         <translation type="vanished">Обнаружены дублирующиеся сервисы, пожалуйста обратитесь в поддержку</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Пожалуйста, подтвердите запрос на устройстве&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Подтвердите запрос на устройстве&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Сохраняю изменения в память устройства&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Сохраняю изменения в память устройства&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Экспортируется база данных с устройства&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Импортирование и слияния файла с базой в устройстве&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Отключить автозапуск при старте системы?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Включить автозапуск при старте системы?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>Запускать Moolticute при загрузке ПК: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>Включено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Выбор поддомена: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation>Интеграция с сервисом &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation>Выбрать файл экспорта базы данных...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Сохранить файл экспорта базы данных...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation>База данных успешно экспортирована из устройства.</translation>
     </message>
@@ -2850,95 +2860,95 @@ Think twice before resetting a card.</source>
         <translation type="vanished">При импорте службы найдет дубликат, свяжитесь с поддержкой</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Проверка целостности устройства успешно завершена. Используется %1 из %2 слотов для учетных данных.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translatorcomment>Yet another easter egg</translatorcomment>
         <translation>Чтобы убедиться, что ничьи &quot;шаловливые ручки&quot; не влезали в прошивку устройства, Вы можете запросить пароль для получения UID устройства.&lt;ol&gt;&lt;li&gt;Запишите серийный номер с задней крышки устройства.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Напишите нам письмо&lt;/a&gt;  с серийным номером устройства и запросите пароль.&lt;/li&gt;&lt;li&gt;Введите пароль, который получили от нас&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translatorcomment>Yet another easter egg</translatorcomment>
         <translation>Чтобы убедиться, что ничьи &quot;шаловливые ручки&quot; не влезали в прошивку устройства, Вы можете запросить пароль от нас и ввести ниже.&lt;ol&gt;&lt;li&gt;Запишите серийный номер с задней крышки устройства.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Напишите нам письмо&lt;/a&gt; с серийным номером устройства и запросите пароль.&lt;/li&gt;&lt;li&gt;Введите пароль, который получили от нас&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation>Предупреждение импорта</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation>Файлы не были импортированы из резервной копии mini.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Идёт восстановление емкости NiMH.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>Не удалось сбросить карту!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>Сброс карты выполнен успешно</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>Выберите CSV файл для импорта...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Ничего не прочитано из %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>Не могу импортировать %1: Каждая строка должна содержать 3 элемента. Для некоторых строк это не так (номера строк: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>Не могу импортировать %1: Каждая строка должна содержать 3 элемента. Для некоторых строк это не так (Таких строк более 10)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>Не могу импортировать %1: Каждая строка должна содержать 3 элемента. Запятая должна быть разделительным элементом</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Выключить выбор поддомена?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Включить выбор поддомена?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation>Отключить проверку &apos;Have I Been Pwned&apos;?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation>Включить проверку &apos;Have I Been Pwned&apos;?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation>Процедура потребует около 5 часов, пожалуйста подтвердите</translation>
     </message>
@@ -2947,91 +2957,91 @@ Think twice before resetting a card.</source>
         <translation type="vanished">&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Идет восстановление NiMH&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Пожалуйста, подождите&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation>Этот токен используется только для целей отладки</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation>Ожидается результат Security Challenge...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation>Восстановление емкости NiMH завершено</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation>Восстановление емкости завершено за %1 секунд</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation>Ошибка восстановления емкости NiMH</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation>Восстановление батареи завершено с ошибкой</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation>Подтвердите сброс настроек на заводские</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation>Хотите сбросить все настройки устройства на заводские?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Невозможно прочитать файл %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Невозможно записать файл %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>База данных успешно импортирована и совмещена с базой данных на устройстве.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Хотите начать проверку целостности устройства?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Ожидаю подтверждения на устройстве&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Подтвердите запрос на устройстве.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>Проверка целостности устройства завершилась с ошибкой!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3040,12 +3050,12 @@ Think twice before resetting a card.</source>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Язык системы по умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Файл экспорта памяти устройства (*.bin)</translation>
     </message>

--- a/lang/mc_sv.ts
+++ b/lang/mc_sv.ts
@@ -194,7 +194,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -204,67 +204,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1223,8 +1223,8 @@ Max tillåten storlek är %2 bytes.</translation>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation>Moolticute</translation>
     </message>
@@ -1760,7 +1760,7 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1789,17 +1789,17 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1812,59 +1812,59 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beteende för ⌘+Q&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation>Systray-ikon</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation>Val av underdomäner: På</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation>Nollställ kort</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation>Radera istoppat kort</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation>Nollställ kort</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation>Importera/exportera CSV-fil</translation>
     </message>
@@ -1874,50 +1874,50 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation>Importera okrypterade lösenord</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation>Importera CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation>Exportera lösenorden okrypterade</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation>Exportera CSV</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1957,7 +1957,7 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation>Integritetskontroll</translation>
     </message>
@@ -2170,38 +2170,43 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2230,24 +2235,24 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation>Enhetens serienummer:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation>Enhetens minne:</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation>UID-förfrågan</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation>Lösenord</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation>Validera</translation>
     </message>
@@ -2256,133 +2261,133 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/raoulh/moolticute&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/raoulh/moolticute&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation>Moolticute-inställningar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation>Applikationsspråk</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation>Starta Moolticute vid datorns uppstart: På</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation>Ändra</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation>Läs daemonloggar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation>Läs</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation>Starta Moolticutes SSH-agent automatiskt</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation>(Omstart krävs)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation>Autostarta SSH-agent</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation>Moolticutes SSH-argument</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation>Starta om daemonen med debug-webbserver (på port 8484)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation>Slå på daemonens webbserver</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation>Hantera dina lösenordsprofiler</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation>Lösenordsprofiler...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation>Fördröjda avbryt-knappar för att undvika misstag</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation>Slå på långtryck för avbrytknappar</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation>Kontrollerar integriteten hos dina sparade identifikationer. Detta kan ta en stund. koppla inte ur din Mooltipass medan kontrollen pågår.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation>SSH-nyckelfliken</translation>
     </message>
@@ -2391,7 +2396,7 @@ Tips: Håll muspekaren över en inställning för mer information.</translation>
         <translation type="vanished">Synlig PÅ &amp;BEGÄRAN (använd Ctrl+Shift+F1-snabbtangenten)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation>&amp;ALLTID synlig</translation>
     </message>
@@ -2423,17 +2428,17 @@ Du kommer bli tillfrågad om export eller import om ändringar i din Mooltipass 
         <translation type="vanished">MooltiAppens säkerhetskopior har inte krypterade användarnamn.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation>Låg</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation>Medel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation>Hög</translation>
     </message>
@@ -2461,32 +2466,32 @@ Du kommer bli tillfrågad om export eller import om ändringar i din Mooltipass 
         <translation type="vanished">Göm fönstret</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation>&amp;Avsluta</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation>Avslagen</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation>Endast lösenord</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation>Användarnamn + lösen</translation>
     </message>
@@ -2511,50 +2516,50 @@ Du kommer bli tillfrågad om export eller import om ändringar i din Mooltipass 
         <translation type="vanished">Ctrl + Alt + Del / Win + L</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation>Svart</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation>Vit</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation>_vit</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation>Hämtar UID från enheten. Kan ta några sekunder...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation>Antingen har enheten mixtrats med eller så är den inmatade nyckeln felaktig.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation>Din enhets UID är %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation>Identifikationer har ändrats.
 Vill du spara dina ändringar?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation>Ta ut kortet ur enheten för att ändra den här inställningen.</translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation>Inget</translation>
     </message>
@@ -2604,441 +2609,446 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Väntar på bekräftelse från enhet&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bekräfta på din enhet.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Sparar ändringar till enheten&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Vänta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation>Misslyckades</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation>Kunde inte spara identifikationer, kontakta support-teamet och ge dem Moolticutes log</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished">1 sekund {0.5 ?}</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished">1 sekund</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Godkänn på enheten&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Godkänn på enheten&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Sparar ändringar till enhetens minne&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Vänta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporterar databas från enhet&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Vänta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importerar och slår ihop fil till enhet&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Vänta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation>Slå av autostart vid uppstart?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation>Slå på autostart vid uppstart?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation>Starta Moolticute vid datorns uppstart: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation>På</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation>Slå av</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation>Slå på</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation>Val av underdomäner: %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation>Välj säkerhetskopia av databas...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation>Spara säkerhetskopia av databas...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation>Minnesintegritetskontroll lyckades!
 %1 identifikationer av %2 möjliga används.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation>För att säkerställa att ingen mixtrat med din enhet kan du be om ett lösenord för tillåtelse att hämta UID från din enhet.&lt;ol&gt;&lt;li&gt;Kolla serienumret på baksidan av din enhet.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Skicka oss ett mail&lt;/a&gt; med serienumret och ditt ordernummer där du ber att få lösenordet.&lt;/li&gt;&lt;li&gt;Skriv in lösenordet vi gav dig&lt;/li&gt;&lt;/ol&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation>Nollställning av kort misslyckades!</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation>Kortet nollställt</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation>Välj CSV-fil att importera...</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation>Inget läst från %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation>Kunde inte importera %1: Varje rad måste innehålla exakt 3 fält. Några rader gör inte det (felaktiga rader: %2)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation>Kunde inte importera %1: Varje rad måste innehålla exakt 3 fält (fler än 10 rader gör inte det)</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation>Kunde inte importera %1: Varje rad måste innehålla exakt 3 fält separerade med kommatecken</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation>Slå av val av underdomäner?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation>Slå på val av underdomäner?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
@@ -3065,38 +3075,38 @@ Tänk efter innan du nollställer ett kort.</translation>
         <translation>Exportera okrypterade lösenord till textfil med kommaseparerade värden.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation>Väldigt låg</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation>Kunde inte läsa fil %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation>Kunde inte skriva till fil %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation>Lyckades importera och slå ihop databasen till enheten.</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation>Vill du starta integritetskontroll av din enhet?</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Väntar på bekräftelse från enhet&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bekräfta på din enhet.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation>Minnesintegritetskontroll misslyckades!</translation>
     </message>
@@ -3113,7 +3123,7 @@ Tänk efter innan du nollställer ett kort.</translation>
         <translation type="vanished">Minneshanteringsfel</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
@@ -3122,12 +3132,12 @@ Tänk efter innan du nollställer ett kort.</translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation>Systemets förinställda språk</translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation>Minnesexportfiler (*.bin)</translation>
     </message>

--- a/lang/mc_tr.ts
+++ b/lang/mc_tr.ts
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../src/BleDev.cpp" line="151"/>
-        <location filename="../src/BleDev.cpp" line="221"/>
+        <location filename="../src/BleDev.cpp" line="222"/>
         <source>Invalid bundle file is selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,67 +203,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="163"/>
+        <location filename="../src/BleDev.cpp" line="164"/>
         <source>The device serial number is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="170"/>
+        <location filename="../src/BleDev.cpp" line="171"/>
         <source>The bundle version is not correct in bundle filename.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="184"/>
+        <location filename="../src/BleDev.cpp" line="185"/>
         <source>Battery too low for bundle upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="185"/>
+        <location filename="../src/BleDev.cpp" line="186"/>
         <source>Please have your device connected through USB and fully charged</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="193"/>
+        <location filename="../src/BleDev.cpp" line="194"/>
         <source>Select bundle file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="213"/>
+        <location filename="../src/BleDev.cpp" line="214"/>
         <source>Invalid path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="214"/>
+        <location filename="../src/BleDev.cpp" line="215"/>
         <source>The choosen path for bundle is not a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="222"/>
+        <location filename="../src/BleDev.cpp" line="223"/>
         <source>The given bundle file is not correct.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="238"/>
+        <location filename="../src/BleDev.cpp" line="239"/>
         <source>Starting upload bundle file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="250"/>
+        <location filename="../src/BleDev.cpp" line="251"/>
         <source>Upload Bundle Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="255"/>
+        <location filename="../src/BleDev.cpp" line="256"/>
         <source>Upload bundle finished successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="260"/>
+        <location filename="../src/BleDev.cpp" line="261"/>
         <source>Upload bundle finished with error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BleDev.cpp" line="277"/>
+        <location filename="../src/BleDev.cpp" line="278"/>
         <source>Select file to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1184,8 +1184,8 @@ Maximum allowed size is %2 bytes.</source>
     <name>MainWindow</name>
     <message>
         <location filename="../src/MainWindow.ui" line="26"/>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Moolticute</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1571,43 +1571,48 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4138"/>
+        <location filename="../src/MainWindow.ui" line="3386"/>
+        <source>Community Creation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.ui" line="4154"/>
         <source>Allow to use invalid or private TLDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4158"/>
+        <location filename="../src/MainWindow.ui" line="4174"/>
         <source>Disable TLD check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4442"/>
+        <location filename="../src/MainWindow.ui" line="4458"/>
         <source>Lock device when screen is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4462"/>
+        <location filename="../src/MainWindow.ui" line="4478"/>
         <source>Enable Device Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5019"/>
+        <location filename="../src/MainWindow.ui" line="5035"/>
         <source>Visible ON DE&amp;MAND  (use SHIFT+F1 keyboard shortcut)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5206"/>
-        <location filename="../src/MainWindow.cpp" line="2352"/>
+        <location filename="../src/MainWindow.ui" line="5222"/>
+        <location filename="../src/MainWindow.cpp" line="2369"/>
         <source>NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5223"/>
+        <location filename="../src/MainWindow.ui" line="5239"/>
         <source>Start NiMH Reconditioning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5256"/>
+        <location filename="../src/MainWindow.ui" line="5272"/>
         <source>Continues until nominal capacity reached</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1842,126 +1847,126 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3439"/>
+        <location filename="../src/MainWindow.ui" line="3455"/>
         <source>Aux MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3473"/>
+        <location filename="../src/MainWindow.ui" line="3489"/>
         <source>Main MCU Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4288"/>
+        <location filename="../src/MainWindow.ui" line="4304"/>
         <source>Integration with Have I Been Pwned: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4095"/>
+        <location filename="../src/MainWindow.ui" line="4111"/>
         <source>Enable full developer log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4127"/>
+        <location filename="../src/MainWindow.ui" line="4143"/>
         <source>Enable Debug Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5039"/>
+        <location filename="../src/MainWindow.ui" line="5055"/>
         <source>Reset card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5073"/>
+        <location filename="../src/MainWindow.ui" line="5089"/>
         <source>Erase Inserted Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4955"/>
-        <location filename="../src/MainWindow.ui" line="4980"/>
-        <location filename="../src/MainWindow.ui" line="5083"/>
+        <location filename="../src/MainWindow.ui" line="4971"/>
+        <location filename="../src/MainWindow.ui" line="4996"/>
+        <location filename="../src/MainWindow.ui" line="5099"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5092"/>
+        <location filename="../src/MainWindow.ui" line="5108"/>
         <source>Reset Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4926"/>
+        <location filename="../src/MainWindow.ui" line="4942"/>
         <source>CSV file import/export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4584"/>
-        <location filename="../src/MainWindow.ui" line="4613"/>
+        <location filename="../src/MainWindow.ui" line="4600"/>
+        <location filename="../src/MainWindow.ui" line="4629"/>
         <source>when selected, you can set moolticute to set a given category upon device connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4587"/>
+        <location filename="../src/MainWindow.ui" line="4603"/>
         <source>Upon connection, force category:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4510"/>
+        <location filename="../src/MainWindow.ui" line="4526"/>
         <source>Backup Notification Banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4530"/>
+        <location filename="../src/MainWindow.ui" line="4546"/>
         <source>Enable Backup Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4541"/>
+        <location filename="../src/MainWindow.ui" line="4557"/>
         <source>Display Moolticute Tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4573"/>
+        <location filename="../src/MainWindow.ui" line="4589"/>
         <source>Display tutorial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4948"/>
+        <location filename="../src/MainWindow.ui" line="4964"/>
         <source>Import unencrypted passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4964"/>
+        <location filename="../src/MainWindow.ui" line="4980"/>
         <source>Import CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4973"/>
+        <location filename="../src/MainWindow.ui" line="4989"/>
         <source>Export passwords unencrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4989"/>
+        <location filename="../src/MainWindow.ui" line="5005"/>
         <source>Export CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5104"/>
+        <location filename="../src/MainWindow.ui" line="5120"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5127"/>
+        <location filename="../src/MainWindow.ui" line="5143"/>
         <source>Get</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5148"/>
+        <location filename="../src/MainWindow.ui" line="5164"/>
         <source>Number of available users:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/MainWindow.ui" line="2429"/>
-        <location filename="../src/MainWindow.ui" line="4728"/>
+        <location filename="../src/MainWindow.ui" line="4744"/>
         <source>Integrity Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2147,162 +2152,162 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3405"/>
+        <location filename="../src/MainWindow.ui" line="3421"/>
         <source>Device Memory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3507"/>
+        <location filename="../src/MainWindow.ui" line="3523"/>
         <source>Bundle Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3585"/>
+        <location filename="../src/MainWindow.ui" line="3601"/>
         <location filename="../src/MainWindow.cpp" line="39"/>
         <source>User Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3608"/>
+        <location filename="../src/MainWindow.ui" line="3624"/>
         <source>UID Request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3644"/>
-        <location filename="../src/MainWindow.ui" line="3761"/>
+        <location filename="../src/MainWindow.ui" line="3660"/>
+        <location filename="../src/MainWindow.ui" line="3777"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3651"/>
-        <location filename="../src/MainWindow.ui" line="3768"/>
+        <location filename="../src/MainWindow.ui" line="3667"/>
+        <location filename="../src/MainWindow.ui" line="3784"/>
         <source>Validate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3731"/>
-        <location filename="../src/MainWindow.cpp" line="635"/>
-        <location filename="../src/MainWindow.cpp" line="2370"/>
+        <location filename="../src/MainWindow.ui" line="3747"/>
+        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="2387"/>
         <source>Security Challenge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3900"/>
+        <location filename="../src/MainWindow.ui" line="3916"/>
         <source>Moolticute Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="3970"/>
+        <location filename="../src/MainWindow.ui" line="3986"/>
         <source>Application Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4003"/>
+        <location filename="../src/MainWindow.ui" line="4019"/>
         <source>Start Moolticute with the computer: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4029"/>
-        <location filename="../src/MainWindow.ui" line="4314"/>
-        <location filename="../src/MainWindow.ui" line="4357"/>
+        <location filename="../src/MainWindow.ui" line="4045"/>
+        <location filename="../src/MainWindow.ui" line="4330"/>
+        <location filename="../src/MainWindow.ui" line="4373"/>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4046"/>
+        <location filename="../src/MainWindow.ui" line="4062"/>
         <source>View Daemon Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4072"/>
+        <location filename="../src/MainWindow.ui" line="4088"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4169"/>
+        <location filename="../src/MainWindow.ui" line="4185"/>
         <source>Start Moolticute SSH Agent Automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4107"/>
-        <location filename="../src/MainWindow.ui" line="4181"/>
-        <location filename="../src/MainWindow.ui" line="4224"/>
-        <location filename="../src/MainWindow.ui" line="4553"/>
+        <location filename="../src/MainWindow.ui" line="4123"/>
+        <location filename="../src/MainWindow.ui" line="4197"/>
+        <location filename="../src/MainWindow.ui" line="4240"/>
+        <location filename="../src/MainWindow.ui" line="4569"/>
         <source>(Restart Needed)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4201"/>
+        <location filename="../src/MainWindow.ui" line="4217"/>
         <source>Autostart SSH Agent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4212"/>
+        <location filename="../src/MainWindow.ui" line="4228"/>
         <source>Moolticute SSH Arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4257"/>
+        <location filename="../src/MainWindow.ui" line="4273"/>
         <source>Restart Daemon with Debug Web Server (on port 8484)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4277"/>
+        <location filename="../src/MainWindow.ui" line="4293"/>
         <source>Enable Daemon Web Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4374"/>
+        <location filename="../src/MainWindow.ui" line="4390"/>
         <source>Manage Your Password Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4394"/>
+        <location filename="../src/MainWindow.ui" line="4410"/>
         <source>Password Profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4479"/>
+        <location filename="../src/MainWindow.ui" line="4495"/>
         <source>Delayed Cancel Buttons to Prevent Mistakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4499"/>
+        <location filename="../src/MainWindow.ui" line="4515"/>
         <source>Enable Long Press Cancel Buttons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4624"/>
+        <location filename="../src/MainWindow.ui" line="4640"/>
         <source>Systray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4331"/>
+        <location filename="../src/MainWindow.ui" line="4347"/>
         <source>Subdomain selection: Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4405"/>
+        <location filename="../src/MainWindow.ui" line="4421"/>
         <source>Default Password Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4735"/>
+        <location filename="../src/MainWindow.ui" line="4751"/>
         <source>Now checking the integrity of your stored credentials. This may take a while. Please do not unplug your Mooltipass during the check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="4775"/>
+        <location filename="../src/MainWindow.ui" line="4791"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5007"/>
+        <location filename="../src/MainWindow.ui" line="5023"/>
         <source>SSH Key Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.ui" line="5029"/>
+        <location filename="../src/MainWindow.ui" line="5045"/>
         <source>ALWA&amp;YS visible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2322,22 +2327,22 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="379"/>
+        <location filename="../src/MainWindow.cpp" line="380"/>
         <source>Very Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="380"/>
+        <location filename="../src/MainWindow.cpp" line="381"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="381"/>
+        <location filename="../src/MainWindow.cpp" line="382"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="382"/>
+        <location filename="../src/MainWindow.cpp" line="383"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2357,79 +2362,79 @@ Hint: keep your mouse positioned over an option to get more details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="419"/>
+        <location filename="../src/MainWindow.cpp" line="420"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="420"/>
+        <location filename="../src/MainWindow.cpp" line="421"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="738"/>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
-        <location filename="../src/MainWindow.cpp" line="1982"/>
-        <location filename="../src/MainWindow.cpp" line="2515"/>
+        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <location filename="../src/MainWindow.cpp" line="1999"/>
+        <location filename="../src/MainWindow.cpp" line="2532"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="739"/>
+        <location filename="../src/MainWindow.cpp" line="740"/>
         <source>Password Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="740"/>
+        <location filename="../src/MainWindow.cpp" line="741"/>
         <source>Login + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="428"/>
+        <location filename="../src/MainWindow.cpp" line="429"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="429"/>
+        <location filename="../src/MainWindow.cpp" line="430"/>
         <source>_white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="574"/>
+        <location filename="../src/MainWindow.cpp" line="575"/>
         <source>Fetching UID from device. This may take a few seconds...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="590"/>
+        <location filename="../src/MainWindow.cpp" line="591"/>
         <source>Either the device have been tempered with or the input key is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="594"/>
+        <location filename="../src/MainWindow.cpp" line="595"/>
         <source>Your device&apos;s UID is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="790"/>
+        <location filename="../src/MainWindow.cpp" line="791"/>
         <source>Credentials have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="971"/>
+        <location filename="../src/MainWindow.cpp" line="972"/>
         <source>Remove the card from the device to change this setting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/MainWindow.cpp" line="34"/>
-        <location filename="../src/MainWindow.cpp" line="400"/>
+        <location filename="../src/MainWindow.cpp" line="401"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2479,488 +2484,493 @@ Think twice before resetting a card.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="387"/>
+        <location filename="../src/MainWindow.cpp" line="388"/>
         <source>No Inactivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="391"/>
+        <location filename="../src/MainWindow.cpp" line="392"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="994"/>
+        <location filename="../src/MainWindow.cpp" line="995"/>
         <source>%1Mb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1161"/>
-        <location filename="../src/MainWindow.cpp" line="1312"/>
+        <location filename="../src/MainWindow.cpp" line="1170"/>
+        <location filename="../src/MainWindow.cpp" line="1321"/>
         <source>&lt;html&gt;&lt;!--enter_credentials_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1174"/>
+        <location filename="../src/MainWindow.cpp" line="1183"/>
         <source>&lt;html&gt;&lt;!--save_credentials_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving Changes to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1196"/>
+        <location filename="../src/MainWindow.cpp" line="1205"/>
         <source>Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1194"/>
+        <location filename="../src/MainWindow.cpp" line="1203"/>
         <source>Couldn&apos;t save credentials, please contact the support team with moolticute&apos;s log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Low Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="311"/>
+        <location filename="../src/MainWindow.cpp" line="312"/>
         <source>Battery is below %1%, please charge your Mooltipass.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="388"/>
+        <location filename="../src/MainWindow.cpp" line="389"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="389"/>
+        <location filename="../src/MainWindow.cpp" line="390"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="390"/>
+        <location filename="../src/MainWindow.cpp" line="391"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="393"/>
+        <location filename="../src/MainWindow.cpp" line="394"/>
         <source>0.5 second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="394"/>
+        <location filename="../src/MainWindow.cpp" line="395"/>
         <source>1 second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="395"/>
+        <location filename="../src/MainWindow.cpp" line="396"/>
         <source>2 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="396"/>
+        <location filename="../src/MainWindow.cpp" line="397"/>
         <source>3 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="397"/>
+        <location filename="../src/MainWindow.cpp" line="398"/>
         <source>4 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="398"/>
+        <location filename="../src/MainWindow.cpp" line="399"/>
         <source>5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="401"/>
+        <location filename="../src/MainWindow.cpp" line="402"/>
         <source>Nyancat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="403"/>
+        <location filename="../src/MainWindow.cpp" line="404"/>
         <source>Let moolticute decide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="404"/>
+        <location filename="../src/MainWindow.cpp" line="405"/>
         <source>Force subdomain support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="405"/>
+        <location filename="../src/MainWindow.cpp" line="406"/>
         <source>Force subdomain ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="636"/>
+        <location filename="../src/MainWindow.cpp" line="637"/>
         <source>Security Challenge Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="741"/>
+        <location filename="../src/MainWindow.cpp" line="742"/>
         <source>[Enter] + Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="742"/>
+        <location filename="../src/MainWindow.cpp" line="743"/>
         <source>[Ctrl+Alt+Del] + Pass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="743"/>
+        <location filename="../src/MainWindow.cpp" line="744"/>
         <source>Password / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="744"/>
+        <location filename="../src/MainWindow.cpp" line="745"/>
         <source>Login + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="745"/>
+        <location filename="../src/MainWindow.cpp" line="746"/>
         <source>[Enter] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="746"/>
+        <location filename="../src/MainWindow.cpp" line="747"/>
         <source>[Ctrl+Alt+Del] + Pass / [Win+L]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="861"/>
+        <location filename="../src/MainWindow.cpp" line="862"/>
         <source>Device Bluetooth Name Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="862"/>
+        <location filename="../src/MainWindow.cpp" line="863"/>
         <source>Please disable and re-enable bluetooth for your changes to take effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1190"/>
+        <location filename="../src/MainWindow.cpp" line="1199"/>
         <source>Couldn&apos;t change all passwords, please approve prompts on the device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2540"/>
-        <location filename="../src/MainWindow.cpp" line="2554"/>
+        <location filename="../src/MainWindow.cpp" line="2557"/>
+        <location filename="../src/MainWindow.cpp" line="2571"/>
         <source>Incorrect Serial Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2541"/>
+        <location filename="../src/MainWindow.cpp" line="2558"/>
         <source>It looks like your device serial number doesn&apos;t match the one present on your device&apos;s case.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2542"/>
+        <location filename="../src/MainWindow.cpp" line="2559"/>
         <source>Please reach out to support@themooltipass.com for the right code to enter below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2555"/>
+        <location filename="../src/MainWindow.cpp" line="2572"/>
         <source>The entered serial number is incorrect!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2562"/>
+        <location filename="../src/MainWindow.cpp" line="2579"/>
         <source>Serial number change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2568"/>
+        <location filename="../src/MainWindow.cpp" line="2585"/>
         <source>Set serial number successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2573"/>
+        <location filename="../src/MainWindow.cpp" line="2590"/>
         <source>Serial number still does not match platform serial.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2578"/>
+        <location filename="../src/MainWindow.cpp" line="2595"/>
         <source>Set serial number failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1210"/>
+        <location filename="../src/MainWindow.cpp" line="1219"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1223"/>
+        <location filename="../src/MainWindow.cpp" line="1232"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Please Approve Request On Device&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1281"/>
+        <location filename="../src/MainWindow.cpp" line="1290"/>
         <source>&lt;html&gt;&lt;!--exit_file_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1302"/>
+        <location filename="../src/MainWindow.cpp" line="1311"/>
         <source>&lt;html&gt;&lt;!--exit_fido_mgm_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Saving changes to device&apos;s memory&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1342"/>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
         <source>&lt;html&gt;&lt;!--export_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Exporting Database from Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <location filename="../src/MainWindow.cpp" line="1354"/>
         <source>&lt;html&gt;&lt;!--import_db_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Importing and Merging File to Device&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1363"/>
+        <location filename="../src/MainWindow.cpp" line="1372"/>
         <source>Disable autostart at boot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <location filename="../src/MainWindow.cpp" line="1374"/>
         <source>Enable autostart at boot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
         <source>Start Moolticute with the computer: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1384"/>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
-        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1386"/>
-        <location filename="../src/MainWindow.cpp" line="1399"/>
-        <location filename="../src/MainWindow.cpp" line="1417"/>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1388"/>
-        <location filename="../src/MainWindow.cpp" line="1401"/>
-        <location filename="../src/MainWindow.cpp" line="1421"/>
+        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1410"/>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1397"/>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
         <source>Subdomain selection: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <location filename="../src/MainWindow.cpp" line="1421"/>
         <source>Integration with &lt;a href=&quot;%1&quot;&gt;Have I Been Pwned&lt;/a&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1518"/>
+        <location filename="../src/MainWindow.cpp" line="1527"/>
         <source>Select database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1551"/>
+        <location filename="../src/MainWindow.cpp" line="1560"/>
         <source>Save database export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1576"/>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
         <source>Successfully exported the database from your device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1663"/>
+        <location filename="../src/MainWindow.cpp" line="1672"/>
         <source>Memory integrity check done successfully!
 %1 of %2 credential slots used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1672"/>
+        <location filename="../src/MainWindow.cpp" line="1681"/>
         <source>To be sure that no one has tempered with your device, you can request a password which will allow you to fetch the UID of your device.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=UID Request Code&amp;body=My serial number is %1 and my order number is: FILL IN YOUR ORDER NO&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the password.&lt;/li&gt;&lt;li&gt;Enter the password you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1680"/>
+        <location filename="../src/MainWindow.cpp" line="1690"/>
         <source>To be sure that no one has tampered with your device, you can request a challenge string and enter it below.&lt;ol&gt;&lt;li&gt;Get the serial number from the back of your device.&lt;/li&gt;&lt;li&gt;&amp;shy;&lt;a href=&quot;mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&amp;body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME&quot;&gt;Send us an email&lt;/a&gt; with the serial number and your order number, requesting the challenge string.&lt;/li&gt;&lt;li&gt;Enter the string you received from us&lt;/li&gt;&lt;/ol&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1963"/>
+        <location filename="../src/MainWindow.cpp" line="1695"/>
+        <source>Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!&lt;ol&gt;&lt;li&gt;Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;&lt;/li&gt;&lt;li&gt;There&apos;s no way we can do a security challenge for your device, since we haven&apos;t made it and don&apos;t have the required data;&lt;/li&gt;&lt;li&gt;This menu is disabled to avoid any frustration and erroneous emails;&lt;/li&gt;&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1980"/>
         <source>Import Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1964"/>
+        <location filename="../src/MainWindow.cpp" line="1981"/>
         <source>Files were not imported from mini backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2035"/>
+        <location filename="../src/MainWindow.cpp" line="2052"/>
         <source>&lt;html&gt;&lt;!--nimh_recondition--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;NiMH Recondition is in progress.&lt;/span&gt;&lt;/p&gt;%1&lt;p&gt;Please wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2083"/>
+        <location filename="../src/MainWindow.cpp" line="2100"/>
         <source>Reset card failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2085"/>
+        <location filename="../src/MainWindow.cpp" line="2102"/>
         <source>Reset card done successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2092"/>
+        <location filename="../src/MainWindow.cpp" line="2109"/>
         <source>Select CSV file to import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
         <source>Nothing is read from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
         <source>Unable to import %1: Each row must contain exact 3 items. Some lines don&apos;t (lines number: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
         <source>Unable to import %1: Each row must contain exact 3 items (more than 10 lines don&apos;t)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Unable to import %1: Each row must contain exact 3 items using comma as a delimiter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2229"/>
+        <location filename="../src/MainWindow.cpp" line="2246"/>
         <source>Disable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2231"/>
+        <location filename="../src/MainWindow.cpp" line="2248"/>
         <source>Enable subdomain selection?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2251"/>
+        <location filename="../src/MainWindow.cpp" line="2268"/>
         <source>Disable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2255"/>
+        <location filename="../src/MainWindow.cpp" line="2272"/>
         <source>Enable Have I Been Pwned check?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2353"/>
+        <location filename="../src/MainWindow.cpp" line="2370"/>
         <source>This procedure will take around 5 hours, please confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2371"/>
+        <location filename="../src/MainWindow.cpp" line="2388"/>
         <source>This token is only used for debugging purposes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2373"/>
+        <location filename="../src/MainWindow.cpp" line="2390"/>
         <source>Waiting for Security Challenge result...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2390"/>
+        <location filename="../src/MainWindow.cpp" line="2407"/>
         <source>NiMH Recondition Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2391"/>
+        <location filename="../src/MainWindow.cpp" line="2408"/>
         <source>Recondition finished in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2400"/>
+        <location filename="../src/MainWindow.cpp" line="2417"/>
         <source>NiMH Recondition Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2401"/>
+        <location filename="../src/MainWindow.cpp" line="2418"/>
         <source>Recondition finished with error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2432"/>
+        <location filename="../src/MainWindow.cpp" line="2449"/>
         <source>Confirm Reset Settings to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2433"/>
+        <location filename="../src/MainWindow.cpp" line="2450"/>
         <source>Do you want to reset every settings value to device defaults?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="1548"/>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
-        <location filename="../src/MainWindow.cpp" line="1603"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
-        <location filename="../src/MainWindow.cpp" line="2121"/>
-        <location filename="../src/MainWindow.cpp" line="2154"/>
-        <location filename="../src/MainWindow.cpp" line="2158"/>
-        <location filename="../src/MainWindow.cpp" line="2166"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="1557"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
+        <location filename="../src/MainWindow.cpp" line="2138"/>
+        <location filename="../src/MainWindow.cpp" line="2171"/>
+        <location filename="../src/MainWindow.cpp" line="2175"/>
+        <location filename="../src/MainWindow.cpp" line="2183"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1527"/>
-        <location filename="../src/MainWindow.cpp" line="2101"/>
+        <location filename="../src/MainWindow.cpp" line="1536"/>
+        <location filename="../src/MainWindow.cpp" line="2118"/>
         <source>Unable to read file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <location filename="../src/MainWindow.cpp" line="1580"/>
         <source>Unable to write to file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1599"/>
+        <location filename="../src/MainWindow.cpp" line="1608"/>
         <source>Successfully imported and merged database into the device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1614"/>
+        <location filename="../src/MainWindow.cpp" line="1623"/>
         <source>Do you want to start the integrity check of your device?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1625"/>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
         <source>&lt;html&gt;&lt;!--check_integrity_job--&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot;font-size:12pt; font-weight:600;&quot;&gt;Waiting For Device Confirmation&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Confirm the request on your device.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1657"/>
+        <location filename="../src/MainWindow.cpp" line="1666"/>
         <source>Memory integrity check failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1779"/>
+        <location filename="../src/MainWindow.cpp" line="1796"/>
         <source>An error occured when trying to go into Memory Management mode.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="1792"/>
+        <location filename="../src/MainWindow.cpp" line="1809"/>
         <source>System default language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/MainWindow.cpp" line="2052"/>
+        <location filename="../src/MainWindow.cpp" line="2069"/>
         <source>Memory exports (*.bin)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -131,6 +131,7 @@ MainWindow::MainWindow(WSClient *client, DbMasterController *mc, QWidget *parent
     ui->labelAboutMainMCU->setText(tr("Main MCU version:"));
 
     ui->widgetNotFlashedWarning->hide();
+    ui->labelIsCommunityBuild->hide();
     ui->labelNotFlashedWarningIcon->setPixmap(AppGui::qtAwesome()->icon(fa::warning).pixmap(QSize(20, 20)));
     ui->labelSerialNumberIncorrect->setStyleSheet("QLabel {color: blue;}");
     connect(ui->labelSerialNumberIncorrect, &ClickableLabel::clicked, this, &MainWindow::onIncorrectSerialNumberClicked);
@@ -999,13 +1000,21 @@ void MainWindow::updateSerialInfos() {
         ui->label_UserManual->setText(MANUAL_STRING.arg(wsClient->isMPBLE() ? BLE_MANUAL_URL : MINI_MANUAL_URL));
         ui->label_UserManual->show();
         if (wsClient->isMPBLE() && wsClient->get_hwSerial() > STARTING_NOT_FLASHED_SERIAL &&
-                wsClient->get_hwSerial() == wsClient->get_platformSerial())
+                wsClient->get_hwSerial() == wsClient->get_platformSerial() &&
+                wsClient->get_hwSerial() < STARTING_COMMUNITY_SERIAL)
         {
             ui->widgetNotFlashedWarning->show();
         }
         else
         {
             ui->widgetNotFlashedWarning->hide();
+        }
+        if (wsClient->get_hwSerial() >= STARTING_COMMUNITY_SERIAL) {
+            ui->labelIsCommunityBuild->show();
+            ui->groupBoxSecurityChallenge->setEnabled(false);
+        } else {
+            ui->labelIsCommunityBuild->hide();
+            ui->groupBoxSecurityChallenge->setEnabled(true);
         }
     }
     else
@@ -1677,10 +1686,18 @@ void MainWindow::setUIDRequestInstructionsWithId(const QString & id)
 
 void MainWindow::setSecurityChallengeText(const QString &id, const QString &bundleVersion)
 {
-    ui->labelSecurityChallenge->setText(tr("To be sure that no one has tampered with your device, you can request a challenge string and enter it below.<ol>"
-                                    "<li>Get the serial number from the back of your device.</li>"
-                                    "<li>&shy;<a href=\"mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME\">Send us an email</a> with the serial number and your order number, requesting the challenge string.</li>"
-                                    "<li>Enter the string you received from us</li></ol>").arg(id).arg(bundleVersion));
+    if (id.toInt() < STARTING_COMMUNITY_SERIAL) {
+        ui->labelSecurityChallenge->setText(tr("To be sure that no one has tampered with your device, you can request a challenge string and enter it below.<ol>"
+                                        "<li>Get the serial number from the back of your device.</li>"
+                                        "<li>&shy;<a href=\"mailto:support@themooltipass.com?subject=Security Challenge Token and Response Request&body=My serial number is %1, my bundle number is %2 and my order number is: FILL ME\">Send us an email</a> with the serial number and your order number, requesting the challenge string.</li>"
+                                        "<li>Enter the string you received from us</li></ol>").arg(id).arg(bundleVersion));
+     } else {
+        ui->labelSecurityChallenge->setText(tr("Your device (serial number %1) is a community-made device in no way affiliated with the original mooltipass team!<ol>"
+                                        "<li>Mooltipass is open-source and open-hardware, so anyone with enough skill can make one;</li>"
+                                        "<li>There's no way we can do a security challenge for your device, since we haven't made it and don't have the required data;</li>"
+                                        "<li>This menu is disabled to avoid any frustration and erroneous emails;</li>"
+                                        "</ol>").arg(id));
+    }
 }
 
 void MainWindow::enableCredentialsManagement(bool enable)

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -345,6 +345,7 @@ private:
     static constexpr int MAC_DEFAULT_HEIGHT = 500;
 #endif
     static constexpr int STARTING_NOT_FLASHED_SERIAL = 2000;
+    static constexpr int STARTING_COMMUNITY_SERIAL = 100000;
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>1081</height>
+    <height>632</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>932</width>
-             <height>1832</height>
+             <width>770</width>
+             <height>882</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -3955,8 +3955,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>524</width>
-               <height>704</height>
+               <width>646</width>
+               <height>885</height>
               </rect>
              </property>
              <property name="autoFillBackground">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>946</width>
-    <height>632</height>
+    <height>1081</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -328,7 +328,7 @@ QWidget {background-color: #EFEFEF;}</string>
        <enum>Qt::LeftToRight</enum>
       </property>
       <property name="currentIndex">
-       <number>9</number>
+       <number>8</number>
       </property>
       <widget class="QWidget" name="pageNoDaemon">
        <layout class="QHBoxLayout" name="horizontalLayout_noDaemon1">
@@ -576,8 +576,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>770</width>
-             <height>882</height>
+             <width>932</width>
+             <height>1832</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -3372,6 +3372,22 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               </widget>
              </item>
              <item>
+              <widget class="QLabel" name="labelIsCommunityBuild">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="font">
+                <font>
+                 <bold>true</bold>
+                 <underline>true</underline>
+                </font>
+               </property>
+               <property name="text">
+                <string>Community Creation</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="horizontalSpacer_62">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -3939,8 +3955,8 @@ Hint: keep your mouse positioned over an option to get more details.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>646</width>
-               <height>885</height>
+               <width>524</width>
+               <height>704</height>
               </rect>
              </property>
              <property name="autoFillBackground">


### PR DESCRIPTION
I have made a few mini bles for me and friends based on the available specs. As @limpkin suggested I used serial numbers >= 100000 for them. To avoid any frustration (in case any of the devices end up on ebay), I suggest treating any devices with serial number >=100000 as 'community creations'. For them: 

- Security challenge is disabled to avoid any irrelevant spam to the (unexpecting) original team,
- A warning is printed that the device is not affiliated with the original team. 

The translation files are updated yet again, I've added relevant Russian translation for the new messages and (hopefully) not too ugly German one. (The latter one needs some checking by some native speaker though, my knowledge of German is pretty bad). 
