### PR TITLE
BleDev: Fix handling of incorrect bundle version during initial bundle upload

### DIFF
--- a/src/BleDev.cpp
+++ b/src/BleDev.cpp
@@ -157,7 +157,7 @@ bool BleDev::checkBundleFilePassword(const QFileInfo& fileInfo, QString &passwor
             return false;
         }
         const auto serial = fileParts[SERIAL_FILE_PART].toUInt();
-        if (!skipDeviceChecks && wsClient->get_hwSerial() != serial)
+        if (!skipDeviceChecks && (wsClient->get_hwSerial() !=0) && (wsClient->get_hwSerial() != serial))
         {
             QMessageBox::warning(this, INVALID_BUNDLE_TEXT,
                                  tr("The device serial number is not correct in bundle filename."));


### PR DESCRIPTION
When loading the very first bundle into a freshly assembled DIY device wsClient->get_hwSerial() returns 0. On subsequent uploads the returned hwSerial is correct.  

Therefore the filename should be renamed 
from update_123456_from_bundle_0_to_1_xxxxxxxx.img to update_0_from_bundle_0_to_1_xxxxxxxx.img before moolticute will allow upload. This patch tells moolticute to treat hwSerial()==0 specially and allow bundle upload regardless of what serial number is specified in the filename.  For any hwSerial()!=0 the checks stay the same