### PR TITLE
Main window size

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>946</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>


### PR DESCRIPTION
# Main window display

In french version of moolticute, some pane of the main window have widgets partially hide (see image below). So some action aren't accessible. To fix this issue, I've increase `MainWindow->maximumSize->width` value from `946` to `16777215` (the same than height).

After this, moolticute can be display with full screen and all widget are accessible.

![moolticute](https://github.com/user-attachments/assets/92231a88-dd47-4634-ba4e-6afcc3e1cee2)


