### PR TITLE
Fix undefined 32-bit shift that traps on arm64 (daemon crashes on card read)

### DIFF
--- a/src/FilesCache.cpp
+++ b/src/FilesCache.cpp
@@ -156,8 +156,12 @@ bool FilesCache::setCardCPZ(QByteArray cardCPZ)
     m_filePath = dataDir.absoluteFilePath(fileName);
 
     qint64 m_key = 0;
+    // The shift must stay 32-bit and wrap at 32 ((i*8) & 31) to derive the
+    // same key historical x86 builds produced: shifting a 32-bit value by
+    // >= 32 is undefined behaviour that x86 silently wrapped, while on
+    // arm64 the compiler turns it into a trap (crash on Apple Silicon).
     for (int i = 0;i < std::min(8, static_cast<int>(cardCPZ.size()));i++)
-        m_key += (static_cast<unsigned int>(cardCPZ[i]) & 0xFF) << (i * 8);
+        m_key += (static_cast<unsigned int>(cardCPZ[i]) & 0xFF) << ((i * 8) & 31);
 
     m_simpleCrypt.setKey(m_key);
     m_simpleCrypt.setIntegrityProtectionMode(SimpleCrypt::ProtectionHash);

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -5414,9 +5414,13 @@ quint64 MPDevice::getUInt64EncryptionKey()
 quint64 MPDevice::getUInt64EncryptionKeyOld()
 {
     qint64 key = 0;
+    // This legacy key derivation must reproduce what historical x86 builds
+    // computed: the 32-bit shift by >= 32 was undefined behaviour that x86
+    // silently wrapped ((i*8) & 31), while on arm64 the compiler turns the
+    // unmasked form into a trap (crash on Apple Silicon).
     for (int i = 0; i < std::min(8, static_cast<int>(m_cardCPZ.size())) ; i++)
     {
-        key += (static_cast<unsigned int>(m_cardCPZ[i]) & 0xFF) << (i*8);
+        key += (static_cast<unsigned int>(m_cardCPZ[i]) & 0xFF) << ((i*8) & 31);
     }
 
     return key;

--- a/src/MPDevice_mac.cpp
+++ b/src/MPDevice_mac.cpp
@@ -29,12 +29,22 @@ void _read_report_callback(void *context,
                            uint8_t *report,
                            CFIndex report_length)
 {
-    Q_UNUSED(result);
     Q_UNUSED(sender);
     Q_UNUSED(report_type);
     Q_UNUSED(report_id);
 
     MPDevice_mac *dev = reinterpret_cast<MPDevice_mac *>(context);
+
+    // IOKit invokes this callback with an error result (and meaningless
+    // buffer/length) when the device drops mid-read, e.g. while the BLE
+    // device re-enumerates its interfaces. Never feed that to the parser.
+    if (result != kIOReturnSuccess || !report || report_length <= 0)
+    {
+        qWarning() << "Ignoring errored HID input report, result:" << result
+                   << "length:" << static_cast<qint64>(report_length);
+        return;
+    }
+
     QByteArray data((const char *)report, report_length);
     if (dev->isBT())
     {


### PR DESCRIPTION
## What breaks

When Moolticute is compiled natively for Apple Silicon (arm64), `moolticuted` crashes every time a card CPZ is read — i.e. on every device connect/unlock, which makes the app unusable. Crash reports from a Mooltipass Mini BLE on macOS 26.5.2 (M-series Mac) are deterministic:

```
exception: EXC_BREAKPOINT (SIGTRAP)
0  moolticuted  FilesCache::setCardCPZ(QByteArray) + 1376
1  moolticuted  MPDevice::getCurrentCardCPZ()::$_36::operator()(QByteArray const&, bool&) + 644
2  moolticuted  MPCommandJob::start(QByteArray const&)::$_0::operator()(...) + 64
3  moolticuted  MPDevice::newDataRead(QByteArray const&) + 4160
4  moolticuted  MPDevice::platformDataRead(QByteArray const&) + 52
5  moolticuted  _read_report_callback(...) + 72
6  IOKit        __IOHIDDeviceInputReportApplier + 72
```

## Why

`FilesCache::setCardCPZ()` and `MPDevice::getUInt64EncryptionKeyOld()` derive the SimpleCrypt key from the 8-byte card CPZ like this:

```cpp
for (int i = 0; i < std::min(8, cardCPZ.size()); i++)
    key += (static_cast<unsigned int>(cardCPZ[i]) & 0xFF) << (i * 8);   // i*8 reaches 56
```

The shifted operand is 32-bit, so for `i >= 4` this shifts by 32..56 — **undefined behaviour**. x86 silently wraps the shift count modulo 32, which is what every historical Intel build actually computed. For arm64, clang proves those iterations are undefined and emits a trap instead: disassembling the built binary shows `brk #1` (`0xd4200020`) at exactly the crash offset inside `FilesCache::setCardCPZ`.

The unit tests don't catch it — none exercise the CPZ path, so the suite passes 63/63 on an arm64 CI runner while the app crashes against real hardware.

Note that `MPDevice::getUInt64EncryptionKey()` (the `SIMPLE_CRYPT_V2` path) already does this correctly in 64-bit; only the legacy path and the `FilesCache` copy were left with the undefined shift.

## The fix

Mask the shift count (`(i * 8) & 31`) so the historical x86 wrapping becomes explicit and well-defined. **Derived keys stay byte-identical to what existing Intel installs produce**, so cached data and SimpleCrypt-encrypted exports continue to decrypt — no migration and no data loss. The V2 path is untouched.

The second commit is related and was found alongside it: `_read_report_callback()` in `src/MPDevice_mac.cpp` ignored the `IOReturn result` argument. IOKit invokes that callback with an error result (and a meaningless buffer/length) when a device drops mid-read — for example while a BLE device re-enumerates its interfaces — and those bytes were parsed as if they were a real device message. Errored reports are now discarded.

## Verification

Built on a `macos-14` (arm64) runner and tested on hardware (Mooltipass Mini BLE, macOS 26.5.2):

- **Before:** the daemon crash-loops on 100% of unlock attempts; the GUI briefly shows unlocked, then resets to "daemon is not running".
- **After:** unlock works and holds, and device detection, credential read/write (persisting across replug), browser-extension login through the daemon WebSocket, `mc-cli`, notes read/write, device settings change/revert, and unplug/replug recovery all pass. A binary check confirms no `brk` remains in `FilesCache::setCardCPZ`.

Related to #1254 and #1255 (native Apple Silicon builds), but this fix is independent of any build-pipeline change — it is a latent correctness bug in the codebase that only manifests once the code is compiled for arm64.
